### PR TITLE
Add global hook to shutdown the language servers on exit

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -157,3 +157,18 @@ Optional arguments:
     (switch-to-buffer "lsp-capabilities")))
 
 (provide 'lsp-mode)
+
+;; Clean up the entire state of lsp mode when Emacs is killed, to get rid of any
+;; pending language servers.
+(add-hook 'kill-emacs-hook #'lsp--global-teardown)
+
+(defun lsp--global-teardown ()
+  (maphash (lambda (key value) (lsp--teardown-client value)) lsp--workspaces)
+  )
+
+(defun lsp--teardown-client (client)
+  (setq lsp--cur-workspace client)
+  ;; TODO: This should send a "shutdown" request and wait for a response first
+  (lsp--send-notification
+   (lsp--make-notification "exit"))
+  )


### PR DESCRIPTION
This is incomplete, it should first send a shutdown message and wait for the
response before sending the exit notification.

Partly completes #14 