### PR TITLE
Bring in some LSP 3.0 features

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -720,10 +720,10 @@ Returns xref-item(s)."
     contents))
 
 (defun lsp-eldoc ()
-  (let ((throwaway (when (and (gethash "codeActionProvider" (lsp--server-capabilities))
-                              lsp-enable-codeaction)
-                     (lsp--text-document-code-action))))
-        nil)
+  (when (and (gethash "codeActionProvider" (lsp--server-capabilities))
+             lsp-enable-codeaction)
+    (lsp--text-document-code-action))
+  (message "lsp-eldoc:after codeAction")
   (lsp--text-document-hover-string))
 
 (defun lsp--text-document-hover-string ()
@@ -755,15 +755,13 @@ type MarkedString = string | { language: string; value: string };"
 the diagnostics"
   (unless lsp--cur-workspace
     (user-error "No language server is associated with this buffer"))
-  ;; (message "lsp--text-document-code-action")
   (let* ((actions (lsp--send-request (lsp--make-request
                                     "textDocument/codeAction"
                                     (lsp--text-document-code-action-params))
-                                     ))
-         ;; (contents (gethash "contents" (or actions (make-hash-table))))
-         nil)
-    )
-  nil)
+                                     )))
+    (when lsp-print-io
+      (message "lsp--text-document-code-action:actions= %s" actions))
+    nil))
 
 (defun lsp--make-document-formatting-options ()
   (let ((json-false :json-false))

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -958,9 +958,8 @@ interface RenameParams {
                              "textDocument/executeCommand"
                              (lsp--make-execute-command-params
                               "hare:demote"
-                              (vector `(:textDocument ,(lsp--text-document-identifier))
-                                       `(:position    ,(lsp--point-to-position (point)))
-                                       `(:range-pos   ,(lsp--current-region-or-pos))  ))))))
+                              (vector `(:file (:textDocument ,(lsp--text-document-identifier)))
+                                      `(:start_pos (:position     ,(lsp--point-to-position (point))))))))))
     (lsp--apply-workspace-edits edits)))
 
 (defun lsp--make-execute-command-params (cmd &optional args)

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -625,7 +625,7 @@ to a text document."
                   ))
 
 (defun lsp--code-action-context ()
-  ;; TODO: find any diagnostics intersecting the current region
+  "Return any diagnostics tha apply to the current line"
   (let* ((diags (gethash buffer-file-name lsp--diagnostics nil ) )
          (range (lsp--current-region-or-pos))
          (start-line (1+ (lsp--range-start-line range)))

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -181,9 +181,7 @@ for a new workspace."
 
 (defun lsp--send-request (body &optional no-wait)
   "Send BODY as a request to the language server, get the response.
-If no-wait is non-nil, don't synchronously wait for a response.
-If no-flush-changes is non-nil, don't flush document changes before sending
-the request."
+If no-wait is non-nil, don't synchronously wait for a response."
   ;; lsp-send-sync should loop until lsp--from-server returns nil
   ;; in the case of Rust Language Server, this can be done with
   ;; 'accept-process-output`.'

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -953,10 +953,14 @@ interface RenameParams {
   (unless lsp--cur-workspace
     (user-error "No language server is associated with this buffer"))
   (lsp--send-changes lsp--cur-workspace)
-  (let ((edits
+  (let* ((edits
          (lsp--send-request (lsp--make-request
                              "textDocument/executeCommand"
-                             (lsp--make-execute-command-params "hare:demote" (lsp--point-to-position (point)))))))
+                             (lsp--make-execute-command-params
+                              "hare:demote"
+                              (vector `(:textDocument ,(lsp--text-document-identifier))
+                                       `(:position    ,(lsp--point-to-position (point)))
+                                       `(:range-pos   ,(lsp--current-region-or-pos))  ))))))
     (lsp--apply-workspace-edits edits)))
 
 (defun lsp--make-execute-command-params (cmd &optional args)

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -960,35 +960,25 @@ interface RenameParams {
                                     (lsp--make-document-rename-params newname)))))
     (lsp--apply-workspace-edits edits)))
 
-;;----------------------------------------------------------------------
-;; AZ:Temporary while experimenting with solutions
-(defun lsp-demote ()
-  "Demote a function to the level it is used"
-  (interactive)
+(defun lsp--send-execute-command (command &optional args)
+  "Create and send a 'textDocument/executeCommand' message having
+command COMMAND and optionsl ARGS"
   (lsp--cur-workspace-check)
   (lsp--send-changes lsp--cur-workspace)
   (lsp--send-request
    (lsp--make-request
     "textDocument/executeCommand"
-    (lsp--make-execute-command-params
-     "hare:demote"
-     (vector `(:file (:textDocument ,(lsp--text-document-identifier)))
-             `(:start_pos (:position     ,(lsp--point-to-position (point)))))))))
+    (lsp--make-execute-command-params command args))))
 
 (defun lsp--make-execute-command-params (cmd &optional args)
   (if args
       (list :command cmd :arguments args)
     (list :command cmd)))
 
-(defun lsp-lift-to-top ()
-  "Lift a function to the top level"
-  (interactive)
-  (lsp--cur-workspace-check)
-  (user-error "Not implemented")
-  )
 
-;;----------------------------------------------------------------------
-
+(defalias 'lsp-point-to-position #'lsp--point-to-position)
+(defalias 'lsp-text-document-identifier #'lsp--text-document-identifier)
+(defalias 'lsp-send-execute-command #'lsp--send-execute-command)
 (defalias 'lsp-on-open #'lsp--text-document-did-open)
 (defalias 'lsp-on-save #'lsp--text-document-did-save)
 ;; (defalias 'lsp-on-change #'lsp--text-document-did-change)

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -961,13 +961,13 @@ interface RenameParams {
     (lsp--apply-workspace-edits edits)))
 
 (defun lsp--send-execute-command (command &optional args)
-  "Create and send a 'textDocument/executeCommand' message having
+  "Create and send a 'workspace/executeCommand' message having
 command COMMAND and optionsl ARGS"
   (lsp--cur-workspace-check)
   (lsp--send-changes lsp--cur-workspace)
   (lsp--send-request
    (lsp--make-request
-    "textDocument/executeCommand"
+    "workspace/executeCommand"
     (lsp--make-execute-command-params command args))))
 
 (defun lsp--make-execute-command-params (cmd &optional args)

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -950,8 +950,7 @@ interface RenameParams {
 (defun lsp-demote ()
   "Demote a function to the level it is used"
   (interactive)
-  (unless lsp--cur-workspace
-    (user-error "No language server is associated with this buffer"))
+  (lsp--cur-workspace-check)
   (lsp--send-changes lsp--cur-workspace)
   (let* ((edits
          (lsp--send-request (lsp--make-request
@@ -970,8 +969,7 @@ interface RenameParams {
 (defun lsp-lift-to-top ()
   "Lift a function to the top level"
   (interactive)
-  (unless lsp--cur-workspace
-    (user-error "No language server is associated with this buffer"))
+  (lsp--cur-workspace-check)
   (user-error "Not implemented")
   )
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -109,7 +109,7 @@ Optional arguments:
      ("codeActionProvider" . ("The server provides code actions" . boolean))
      ("codeLensProvider" . ("The server provides code lens" . boolean))
      ("documentFormattingProvider" . ("The server provides file formatting" . boolean))
-     (("documentRangeFormattingProvider" . ("The server provides region formatting" . boolean)))    
+     (("documentRangeFormattingProvider" . ("The server provides region formatting" . boolean)))
      (("renameProvider" . ("The server provides rename support" . boolean)))))
 
 (defun lsp--cap-str (cap)

--- a/lsp-notifications.el
+++ b/lsp-notifications.el
@@ -39,6 +39,9 @@ server and put in `lsp--diagnostics'."
   (code nil :read-only t) ;; the diagnostic's code
   (source nil :read-only t) ;;
   (message nil :read-only t) ;; diagnostic's message
+  (original nil :read-only t) ;; original diagnostic from LSP, kept for when it
+                              ;; needs to be sent back in e.g. codeAction
+                              ;; context.
   )
 
 (defun lsp--make-diag (diag)
@@ -55,7 +58,8 @@ server and put in `lsp--diagnostics'."
       :severity (gethash "severity" diag)
       :code (gethash "code" diag)
       :source (gethash "source" diag)
-      :message (if source (format "%s: %s" source message) message))))
+      :message (if source (format "%s: %s" source message) message)
+      :original diag)))
 
 (defun lsp--equal-files (f1 f2)
   (string-equal (expand-file-name f1) (expand-file-name f2)))

--- a/lsp-receive.el
+++ b/lsp-receive.el
@@ -35,7 +35,8 @@
   (queued-requests nil)
 
   (workspace nil) ;; the workspace
-  (method-handlers nil :read-only t))
+  (method-handlers nil :read-only t)
+  (request-handlers nil))
 
 
 ;;  id  method
@@ -87,7 +88,6 @@ Else it is queued (unless DONT-QUEUE is non-nil)"
 (defun lsp--on-request (p request &optional dont-queue)
   "If response queue is empty, call the appropriate handler for REQUEST.
 Else it is queued (unless DONT-QUEUE is non-nil)"
-  (message "lsp--on-request entered")
   (let ((params (gethash "params" request))
          handler)
     ;; (if (and (not dont-queue) (lsp--parser-response-result p))
@@ -95,14 +95,10 @@ Else it is queued (unless DONT-QUEUE is non-nil)"
       (push (lsp--parser-queued-requests p) request)
       ;; else, call the appropriate handler
       (pcase (gethash "method" request)
-        ("client/registerCapability"   (error "client/registerCapability not implemented"))
-        ("client/unregisterCapability" (error "client/unregisterCapability not implemented"))
-        ("workspace/applyEdit" (error "workspace/applyEdit not implemented"))
-                                ;; need to call lsp--apply-workspace-edits
         (other
-          (setq handler (gethash other (lsp--parser-method-handlers p) nil))
+          (setq handler (gethash other (lsp--parser-request-handlers p) nil))
           (if (not handler)
-            (message "Unkown method: %s" other)
+            (message "Unkown request method: %s" other)
             (funcall handler (lsp--parser-workspace p) params)))))))
 
 (defconst lsp--errors

--- a/lsp-receive.el
+++ b/lsp-receive.el
@@ -32,21 +32,30 @@
   (prev-char nil)
 
   (queued-notifications nil)
+  (queued-requests nil)
 
   (workspace nil) ;; the workspace
   (method-handlers nil :read-only t))
 
-(defun lsp--get-message-type (params)
-  "Get the message type from PARAMS."
-  (when (not (string= (gethash "jsonrpc" params "") "2.0"))
+
+;;  id  method
+;;   x    x     request
+;;   x    .     response
+;;   .    x     notification
+
+(defun lsp--get-message-type (json-data)
+  "Get the message type from JSON-DATA."
+  (when (not (string= (gethash "jsonrpc" json-data "") "2.0"))
     (error "JSON-RPC version is not 2.0"))
-  (if (gethash "id" params nil)
-    (if (gethash "error" params nil)
+  (if (gethash "id" json-data nil)
+    (if (gethash "error" json-data nil)
       'response-error
-      'response)
-    (if (gethash "method" params nil)
+      (if (gethash "method" json-data nil)
+          'request
+        'response))
+    (if (gethash "method" json-data nil)
       'notification
-      (error "Couldn't guess message type from params"))))
+      (error "Couldn't guess message type from json-data"))))
 
 (defun lsp--flush-notifications (p)
   "Flush any notifications that were queued while processing the last response."
@@ -69,6 +78,27 @@ Else it is queued (unless DONT-QUEUE is non-nil)"
                                              (lsp--parser-workspace p)))
         ("textDocument/diagnosticsEnd")
         ("textDocument/diagnosticsBegin")
+        (other
+          (setq handler (gethash other (lsp--parser-method-handlers p) nil))
+          (if (not handler)
+            (message "Unkown method: %s" other)
+            (funcall handler (lsp--parser-workspace p) params)))))))
+
+(defun lsp--on-request (p request &optional dont-queue)
+  "If response queue is empty, call the appropriate handler for REQUEST.
+Else it is queued (unless DONT-QUEUE is non-nil)"
+  (message "lsp--on-request entered")
+  (let ((params (gethash "params" request))
+         handler)
+    ;; (if (and (not dont-queue) (lsp--parser-response-result p))
+    (if nil
+      (push (lsp--parser-queued-requests p) request)
+      ;; else, call the appropriate handler
+      (pcase (gethash "method" request)
+        ("client/registerCapability"   (error "client/registerCapability not implemented"))
+        ("client/unregisterCapability" (error "client/unregisterCapability not implemented"))
+        ("workspace/applyEdit" (error "workspace/applyEdit not implemented"))
+                                ;; need to call lsp--apply-workspace-edits
         (other
           (setq handler (gethash other (lsp--parser-method-handlers p) nil))
           (if (not handler)
@@ -143,7 +173,8 @@ Else it is queued (unless DONT-QUEUE is non-nil)"
           (message (lsp--error-string (gethash "error" json-data nil))))
         (setf (lsp--parser-response-result p) nil
           (lsp--parser-waiting-for-response p) nil))
-      ('notification (lsp--on-notification p json-data))))
+      ('notification (lsp--on-notification p json-data))
+      ('request      (lsp--on-request p json-data))))
   (lsp--parser-reset p))
 
 (defun lsp--parser-read (p output)


### PR DESCRIPTION
- Send a `codeAction` request based on current point
- Start on UI elements to choose which code actions to apply, based on the intero code
- Send expanded client capabilities with `initialize`
- Introduce `executeCommand` and expose it for language specific use
- manage request messages from the server, starting with `workspace/applyEdit` 