### PR TITLE
Bring in lsp-project-whitelist

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -389,7 +389,6 @@ disappearing, unset all the variables related to it."
   (let* ((client (lsp--get-client t))
           (root (funcall (lsp--client-get-root client)))
           (workspace (gethash root lsp--workspaces))
-          ;; (should-not-init (member root lsp-project-blacklist))
           (should-not-init (not (lsp--should-start-p root)))
           conn response init-params)
     (if should-not-init


### PR DESCRIPTION
As an alternative to 'lsp-project-whitelist', this allows listing the projects
for which to use LSP mode.

The current logic is that if the whitelist is not nil, then the blacklist is
ignored.  This can be changed if a different policy makes sense, the decision
process is broken out into 'lsp--should-start-p'

cc #77 