### PR TITLE
Ensure current major-mode is supported by lsp-flycheck

### DIFF
--- a/lsp-flycheck.el
+++ b/lsp-flycheck.el
@@ -20,8 +20,7 @@
 ;; Put this in your config file:
 ;;
 ;; (with-eval-after-load 'lsp-mode
-;;   (require 'lsp-flycheck)
-;;   (lsp-flycheck-setup))
+;;   (require 'lsp-flycheck))
 
 ;;; Code:
 

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -448,7 +448,7 @@ disappearing, unset all the variables related to it."
   (when lsp-enable-eldoc
     (eldoc-mode 1))
 
-  (when (and lsp-enable-flycheck (featurep 'flycheck))
+  (when (and lsp-enable-flycheck (featurep 'lsp-flycheck))
     (setq-local flycheck-check-syntax-automatically nil)
     (setq-local flycheck-checker 'lsp)
     (lsp-flycheck-add-mode major-mode)

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -452,12 +452,10 @@ disappearing, unset all the variables related to it."
     (setq-local flycheck-check-syntax-automatically nil)
     (setq-local flycheck-checker 'lsp)
     (lsp-flycheck-add-mode major-mode)
-    (unless (memq 'lsp flycheck-checkers)
-      (add-to-list 'flycheck-checkers 'lsp))
-    (unless (memq 'flycheck-buffer lsp-after-diagnostics-hook)
-      (add-hook 'lsp-after-diagnostics-hook (lambda ()
-                                              (when flycheck-mode
-                                                (flycheck-buffer))))))
+    (add-to-list 'flycheck-checkers 'lsp)
+    (add-hook 'lsp-after-diagnostics-hook (lambda ()
+					    (when flycheck-mode
+					      (flycheck-buffer)))))
 
   (when (and lsp-enable-indentation
           (lsp--capability "documentRangeFormattingProvider"))

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -451,6 +451,7 @@ disappearing, unset all the variables related to it."
   (when (and lsp-enable-flycheck (featurep 'flycheck))
     (setq-local flycheck-check-syntax-automatically nil)
     (setq-local flycheck-checker 'lsp)
+    (lsp-flycheck-add-mode major-mode)
     (unless (memq 'lsp flycheck-checkers)
       (add-to-list 'flycheck-checkers 'lsp))
     (unless (memq 'flycheck-buffer lsp-after-diagnostics-hook)


### PR DESCRIPTION
Without this change *flycheck* signals error: 
```
Debugger entered--Lisp error: (error "Error parsing language server output: (error Flycheck cannot use lsp in this buffer, type M-x flycheck-verify-setup for more details)")
  signal(error ("Error parsing language server output: (error Flycheck cannot use lsp in this buffer, type M-x flycheck-verify-setup for more details)"))
  error("Error parsing language server output: %s" (error "Flycheck cannot use lsp in this buffer, type M-x flycheck-verify-setup for more details"))
  (progn (lsp--parser-reset p) (progn (progn nil (or (progn nil (and (vectorp p) (>= (length p) 15) (memq (aref p 0) cl-struct-lsp--parser-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--parser) p))) (let* ((v p)) (aset v 2 nil))) (progn nil (or (progn nil (and (vectorp p) (>= (length p) 15) (memq (aref p 0) cl-struct-lsp--parser-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--parser) p))) (let* ((v p)) (aset v 1 nil)))) (error "Error parsing language server output: %s" err))
  (condition-case err (lsp--parser-read p output) (error (progn (lsp--parser-reset p) (progn (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... p))) (let* ((v p)) (aset v 2 nil))) (progn nil (or (progn nil (and ... ... ... t)) (signal (quote wrong-type-argument) (list ... p))) (let* ((v p)) (aset v 1 nil)))) (error "Error parsing language server output: %s" err))))
  (progn (condition-case err (lsp--parser-read p output) (error (progn (lsp--parser-reset p) (progn (progn nil (or (progn nil ...) (signal ... ...)) (let* (...) (aset v 2 nil))) (progn nil (or (progn nil ...) (signal ... ...)) (let* (...) (aset v 1 nil)))) (error "Error parsing language server output: %s" err)))))
  (if (let* ((--cl-var-- ignore-regexps) (r nil) (--cl-var-- t) --cl-var--) (while (and (consp --cl-var--) (progn (setq r (car --cl-var--)) (if (string-match r output) (setq --cl-var-- nil --cl-var-- nil) t))) (setq --cl-var-- (cdr --cl-var--))) (if --cl-var-- (progn t) --cl-var--)) (progn (condition-case err (lsp--parser-read p output) (error (progn (lsp--parser-reset p) (progn (progn nil (or ... ...) (let* ... ...)) (progn nil (or ... ...) (let* ... ...))) (error "Error parsing language server output: %s" err))))))
  (closure ((ignore-regexps "^SLF4J: " "^Listening for transport dt_socket at address: ") (p . [cl-struct-lsp--parser nil nil nil "" nil nil nil nil nil nil nil [cl-struct-lsp--workspace #3 "java" 1 #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ("/home/juergen/java/pushover4j/src/main/java/net/pushover/client/Status.java" 0 ...)) #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ("textDocumentSync" 2 "hoverProvider" t "completionProvider" #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ("resolveProvider" t "triggerCharacters" ("." "@" "#") ...)) "definitionProvider" t "referencesProvider" t "documentHighlightProvider" t "documentSymbolProvider" t "workspaceSymbolProvider" t "codeActionProvider" t "codeLensProvider" #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ("resolveProvider" t ...)) "documentFormattingProvider" t "documentRangeFormattingProvider" t ...)) "/home/juergen/java/pushover4j/" [cl-struct-lsp--client "java" lsp--stdio-send-sync lsp--stdio-send-async stdio (closure (... ... t) (filter sentinel) (let ... ... ...)) lsp-java--get-root ("^SLF4J: " "^Listening for transport dt_socket at address: ") #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ( ...))] nil #<process Java Language Server> #<process Java Language Server> (#<buffer Status.java\client\pushover\net\java\main\src\pushover4j\java\juergen\home\>) nil] #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ( ...)) #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ("workspace/applyEdit" lsp--workspace-apply-edit-handler ...))]) cl-struct-lsp--parser-tags t) (proc output) (setq lsp--no-response nil) (if (let* ((--cl-var-- ignore-regexps) (r nil) (--cl-var-- t) --cl-var--) (while (and (consp --cl-var--) (progn (setq r (car --cl-var--)) (if (string-match r output) (setq --cl-var-- nil --cl-var-- nil) t))) (setq --cl-var-- (cdr --cl-var--))) (if --cl-var-- (progn t) --cl-var--)) (progn (condition-case err (lsp--parser-read p output) (error (progn (lsp--parser-reset p) (progn (progn nil ... ...) (progn nil ... ...)) (error "Error parsing language server output: %s" err)))))) (if (progn nil (or (progn nil (and (vectorp p) (>= (length p) 15) (memq (aref p 0) cl-struct-lsp--parser-tags) t)) (signal (quote wrong-type-argument) (list (quote lsp--parser) p))) (aref p 1)) (progn (condition-case nil (let ((inhibit-quit nil)) (accept-process-output proc)) (quit (setq quit-flag t) (eval (quote (ignore nil))))))))(#<process Java Language Server> "{\"jsonrpc\":\"2.0\",\"method\":\"window/logMessage\",\"params\":{\"type\":3,\"message\":\"09.05.2017 17:53:18 begin problem for Status.java\"}}Content-Length: 128
\n
\n{\"jsonrpc\":\"2.0\",\"method\":\"window/logMessage\",\"params\":{\"type\":3,\"message\":\"09.05.2017 17:53:18 end reporting for Status.java\"}}Content-Length: 179
\n
\n{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\",\"params\":{\"uri\":\"file:///home/juergen/java/pushover4j/src/main/java/net/pushover/client/Status.java\",\"diagnostics\":[]}}")
```
```
The following checker is explicitly selected for this buffer:

  lsp
    - major mode: `java-mode' not supported
    - may enable: yes
    - predicate:  t

```
