### PR TITLE
README.md: replace hook name (prog-mode-hook)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Clone this repository to a suitable path, and add
 (with-eval-after-load 'lsp-mode
     (require 'lsp-flycheck))
 (require 'lsp-mode)
-(add-hook 'prog-major-mode #'lsp-mode)
+(add-hook 'prog-mode-hook #'lsp-mode)
 ```
 to your .emacs, where `prog-major-mode` is the hook variable for a supported
 programming language major mode.


### PR DESCRIPTION
The `prog-major-mode` didnt work for me and a quick google left me questioning its existence, so I assume `prog-mode-hook` was meant instead.