### PR TITLE
Fix bindings in lsp--start

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -391,7 +391,8 @@ disappearing, unset all the variables related to it."
           (root (funcall (lsp--client-get-root client)))
           (workspace (gethash root lsp--workspaces))
           (should-not-init (not (lsp--should-start-p root)))
-          conn response init-params)
+          new-conn response init-params
+          parser proc cmd-proc)
     (if should-not-init
       (message "Not initializing project %s" root)
       (if workspace


### PR DESCRIPTION
When `lsp--start` is called, `setf` creates global variables `conn`, `proc` and `parser`.  This commit will fix it.