### PR TITLE
Make xref-backend-definitions more robust

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1092,11 +1092,17 @@ interface DocumentRangeFormattingParams {
 ;;   nil)
 
 (cl-defmethod xref-backend-definitions ((_backend (eql xref-lsp)) identifier)
-  (let* ((properties (text-properties-at 0 identifier))
-          (params (plist-get properties 'def-params))
-          (def (lsp--send-request (lsp--make-request
-                                    "textDocument/definition"
-                                    params))))
+  (let* ((maybeparams (get-text-property 0 'def-params identifier))
+         ;; In some modes (such as haskell-mode), xref-find-definitions gets
+         ;; called directly without applying the properties expected here. So we
+         ;; must test if the properties are present, and if not use the current
+         ;; point location.
+         (params (if (symbolp maybeparams) ;; if it is a symbol it is not an assoc
+                     (lsp--text-document-position-params)
+                   maybeparams))
+         (def (lsp--send-request (lsp--make-request
+                                  "textDocument/definition"
+                                  params))))
     (if (consp def)
       (mapcar 'lsp--location-to-xref def)
       (and def `(,(lsp--location-to-xref def))))))

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1097,7 +1097,7 @@ interface DocumentRangeFormattingParams {
          ;; called directly without applying the properties expected here. So we
          ;; must test if the properties are present, and if not use the current
          ;; point location.
-         (params (if (symbolp maybeparams) ;; if it is a symbol it is not an assoc
+         (params (if (null maybeparams)
                      (lsp--text-document-position-params)
                    maybeparams))
          (def (lsp--send-request (lsp--make-request


### PR DESCRIPTION
In some modes, such as haskell-mode, xref-find-definitions gets called without
setting the expected property values.

Check for this, and use the current point location instead if necessary.

This is take 2 on https://github.com/emacs-lsp/lsp-mode/pull/100