### PR TITLE
Fix sync method for backward compatibility

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -338,12 +338,11 @@ disappearing, unset all the variables related to it."
 
 (defun lsp--set-sync-method ()
   (let* ((sync (gethash "textDocumentSync" (lsp--server-capabilities)))
-         (kind (gethash "change" sync))
+         (kind (if (hash-table-p sync) (gethash "change" sync) sync))
          (method (alist-get kind lsp--sync-methods))
          )
     (setq lsp--server-sync-method (or lsp-document-sync-method
-                                      method
-                                      (alist-get sync lsp--sync-methods)))))
+                                      method))))
 
 (defun lsp--client-request-handlers ()
   "Handlers for requests originating from the server"


### PR DESCRIPTION
The [LanguageServer.jl](https://github.com/JuliaEditorSupport/LanguageServer.jl) package does not yet use the new [`TextDocumentSyncOptions` struct](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md):
```
interface ServerCapabilities {
	/**
	 * Defines how text documents are synced. Is either a detailed structure defining each notification or
	 * for backwards compatibility the TextDocumentSyncKind number.
	 */
	textDocumentSync?: TextDocumentSyncOptions | number;
...
```

This PR should allow the lsp-mode package to communicate with language servers, which do not yet use `TextDocumentSyncOptions `.