### PR TITLE
Handle bytes better

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -39,6 +39,7 @@
       (make-process
         :name name
         :connection-type 'pipe
+        :coding 'no-conversion
         :command final-command
         :filter filter
         :sentinel sentinel
@@ -53,6 +54,7 @@
         (error (format "Couldn't find executable %s" (nth 0 final-command))))
       (setq proc (make-process
                    :name name
+                   :coding 'no-conversion
                    :command final-command
                    :sentinel sentinel
                    :stderr (generate-new-buffer-name (concat "*" name " stderr*")))

--- a/lsp-receive.el
+++ b/lsp-receive.el
@@ -196,14 +196,14 @@ Else it is queued (unless DONT-QUEUE is non-nil)"
       ;; Read body
       (let* ((total-body-length (lsp--parser-body-length p))
              (received-body-length (lsp--parser-body-received p))
-             (chunk-length (length chunk))
+             (chunk-length (string-bytes chunk))
              (left-to-receive (- total-body-length received-body-length))
              (this-body (substring chunk 0 (min left-to-receive chunk-length)))
-             (leftovers (substring chunk (length this-body))))
+             (leftovers (substring chunk (string-bytes this-body))))
 
         (store-substring (lsp--parser-body p) received-body-length this-body)
         (setf (lsp--parser-body-received p) (+ (lsp--parser-body-received p)
-                                               (length this-body)))
+                                               (string-bytes this-body)))
 
         (when (>= chunk-length left-to-receive)
           (when lsp-print-io

--- a/lsp-receive.el
+++ b/lsp-receive.el
@@ -212,6 +212,9 @@ Else it is queued (unless DONT-QUEUE is non-nil)"
           (setf (lsp--parser-body-received p) (+ (lsp--parser-body-received p)
 																								 (string-bytes this-body)))
           (when (>= chunk-length left-to-receive)
+						;; TODO: keep track of the Content-Type header, if
+						;; present, and use its value instead of just defaulting
+						;; to utf-8
             (push (decode-coding-string (lsp--parser-body p) 'utf-8) messages)
             (lsp--parser-reset p))
 

--- a/lsp-receive.el
+++ b/lsp-receive.el
@@ -145,12 +145,12 @@ Else it is queued (unless DONT-QUEUE is non-nil)"
    (lsp--parser-body p) nil
    (lsp--parser-reading-body p) nil))
 
-(defun lsp--parser-on-message (p)
+(defun lsp--parser-on-message (p msg)
   "Called when the parser reads a complete message from the server."
   (let* ((json-array-type 'list)
           (json-object-type 'hash-table)
           (json-false nil)
-          (json-data (json-read-from-string (lsp--parser-body p))))
+          (json-data (json-read-from-string msg)))
     (pcase (lsp--get-message-type json-data)
       ('response (setf (lsp--parser-response-result p)
                    (and json-data (gethash "result" json-data nil))
@@ -167,66 +167,73 @@ Else it is queued (unless DONT-QUEUE is non-nil)"
 (defun lsp--parser-read (p chunk)
   (cl-assert (lsp--parser-workspace p) nil "Parser workspace cannot be nil.")
 
-  (while (not (string-empty-p chunk))
-    (if (not (lsp--parser-reading-body p))
-      (let* ((full-chunk (concat (lsp--parser-leftovers p) chunk))
-             (body-sep-pos (string-match-p "\r\n\r\n" chunk)))
-        (if body-sep-pos
-          ;; We've got all the headers, handle them all at once:
-          (let* ((header-raw (substring chunk 0 body-sep-pos))
-                 (content (substring chunk (+ body-sep-pos 4)))
-                 (headers
-                   (mapcar 'lsp--parse-header
-                     (split-string header-raw "\r\n")))
-                  (body-length (lsp--get-body-length headers)))
-            (setf
-              (lsp--parser-headers p) headers
-              (lsp--parser-reading-body p) t
-              (lsp--parser-body-length p) body-length
-              (lsp--parser-body-received p) 0
-              (lsp--parser-body p) (make-string body-length ?\0)
-              (lsp--parser-leftovers p) nil)
-            (setq chunk content))
+  (let ((messages '()))
+    (while (not (string-empty-p chunk))
+      (if (not (lsp--parser-reading-body p))
+					(let* ((full-chunk (concat (lsp--parser-leftovers p) chunk))
+								 (body-sep-pos (string-match-p "\r\n\r\n" chunk)))
+						(if body-sep-pos
+								;; We've got all the headers, handle them all at once:
+								(let* ((header-raw (substring chunk 0 body-sep-pos))
+											 (content (substring chunk (+ body-sep-pos 4)))
+											 (headers
+												(mapcar 'lsp--parse-header
+																(split-string header-raw "\r\n")))
+											 (body-length (lsp--get-body-length headers)))
+									(setf
+									 (lsp--parser-headers p) headers
+									 (lsp--parser-reading-body p) t
+									 (lsp--parser-body-length p) body-length
+									 (lsp--parser-body-received p) 0
+									 (lsp--parser-body p) (make-string body-length ?\0)
+									 (lsp--parser-leftovers p) nil)
+									(setq chunk content))
 
-          ;; Haven't found the end of the headers yet, save everything
-          ;; for when the next chunk arrives:
-          (setf (lsp--parser-leftovers p) full-chunk)
-          (setq chunk "")))
+							;; Haven't found the end of the headers yet, save everything
+							;; for when the next chunk arrives:
+							(setf (lsp--parser-leftovers p) full-chunk)
+							(setq chunk "")))
 
-      ;; Read body
-      (let* ((total-body-length (lsp--parser-body-length p))
-             (received-body-length (lsp--parser-body-received p))
-             (chunk-length (string-bytes chunk))
-             (left-to-receive (- total-body-length received-body-length))
-             (this-body (substring chunk 0 (min left-to-receive chunk-length)))
-             (leftovers (substring chunk (string-bytes this-body))))
+        ;; Read body
+        (let* ((total-body-length (lsp--parser-body-length p))
+							 (received-body-length (lsp--parser-body-received p))
+							 (chunk-length (string-bytes chunk))
+							 (left-to-receive (- total-body-length received-body-length))
+							 (this-body
+								(substring chunk 0 (min left-to-receive chunk-length)))
+							 (leftovers (substring chunk (string-bytes this-body))))
+          (store-substring (lsp--parser-body p) received-body-length this-body)
+          (setf (lsp--parser-body-received p) (+ (lsp--parser-body-received p)
+																								 (string-bytes this-body)))
+          (when (>= chunk-length left-to-receive)
+            (push (decode-coding-string (lsp--parser-body p) 'utf-8) messages)
+            (lsp--parser-reset p))
 
-        (store-substring (lsp--parser-body p) received-body-length this-body)
-        (setf (lsp--parser-body-received p) (+ (lsp--parser-body-received p)
-                                               (string-bytes this-body)))
+          (setq chunk leftovers))))
 
-        (when (>= chunk-length left-to-receive)
-          (when lsp-print-io
-            (message "Output from language server: %s" (lsp--parser-body p)))
-          (lsp--parser-on-message p))
-
-        (setq chunk leftovers)))))
+    (reverse messages)))
 
 (defun lsp--parser-make-filter (p ignore-regexps)
   #'(lambda (proc output)
       (setq lsp--no-response nil)
       (when (cl-loop for r in ignore-regexps
-              ;; check if the output is to be ignored or not
-              ;; TODO: Would this ever result in false positives?
-              when (string-match r output) return nil
-              finally return t)
-        (condition-case err
-          (lsp--parser-read p output)
-          (error
-            (progn (lsp--parser-reset p)
-              (setf (lsp--parser-response-result p) nil
-                (lsp--parser-waiting-for-response p) nil)
-              (error "Error parsing language server output: %s" err)))))
+										 ;; check if the output is to be ignored or not
+										 ;; TODO: Would this ever result in false positives?
+										 when (string-match r output) return nil
+										 finally return t)
+        (let ((messages
+							 (condition-case err
+									 (lsp--parser-read p output)
+								 (error
+									(progn
+										(lsp--parser-reset p)
+										(setf (lsp--parser-response-result p) nil
+													(lsp--parser-waiting-for-response p) nil)
+										(error "Error parsing language server output: %s" err))))))
+
+          (dolist (m messages)
+            (when lsp-print-io (message "Output from language server: %s" m))
+            (lsp--parser-on-message p m))))
       (when (lsp--parser-waiting-for-response p)
         (with-local-quit (accept-process-output proc)))))
 

--- a/lsp-receive.el
+++ b/lsp-receive.el
@@ -119,7 +119,13 @@ Else it is queued (unless DONT-QUEUE is non-nil)"
 	    (or (car (alist-get code lsp--errors)) "Unknown error"))))
 
 (defun lsp--get-body-length (headers)
-  (string-to-number (cdr (assoc "Content-Length" headers))))
+	(let ((content-length (cdr (assoc "Content-Length" headers))))
+		(if content-length
+				(string-to-number content-length)
+
+			;; This usually means either the server our our parser is
+			;; screwed up with a previous Content-Length
+			(error "No Content-Length header"))))
 
 (defun lsp--parse-header (s)
   "Parse string S as a LSP (KEY . VAL) header."

--- a/test/lsp-receive-tests.el
+++ b/test/lsp-receive-tests.el
@@ -1,0 +1,59 @@
+;; Copyright (C) 2016  Vibhav Pant <vibhavp@gmail.com> -*- lexical-binding: t -*-
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+(require 'lsp-methods)
+(require 'lsp-receive)
+
+(setq lsp--test-workspace
+  (make-lsp--workspace))
+
+(ert-deftest lsp--parser-read--multiple-messages ()
+  (let* ((p (make-lsp--parser :workspace lsp--test-workspace))
+         (messages-in '("Content-Length: 2\r\n\r\n{}"
+                        "Content-Length: 2\r\n\r\n{}"
+                        "Content-Length: 2\r\n\r\n{}"
+                        "Content-Length: 2\r\n\r\n{}"
+                        "Content-Length: 2\r\n\r\n{}"))
+         (messages (lsp--parser-read p (string-join messages-in))))
+    (should (equal messages '("{}" "{}" "{}" "{}" "{}")))))
+
+(ert-deftest lsp--parser-read--multibyte ()
+  (let* ((p (make-lsp--parser :workspace lsp--test-workspace))
+				 (message-in "Content-Length: 3\r\n\r\n\xe2\x80\x99")
+         (messages (lsp--parser-read p message-in)))
+    (should (equal messages '("’")))))
+
+(ert-deftest lsp--parser-read--multiple-chunks ()
+  (let* ((p (make-lsp--parser :workspace lsp--test-workspace)))
+		(should (equal (lsp--parser-read p "Content-Length: 14\r\n\r\n{") nil))
+		(should (equal (lsp--parser-read p "\"somedata\":1") nil))
+		(should (equal (lsp--parser-read p "}Content-Length: 14\r\n\r\n{")
+									 '("{\"somedata\":1}")))
+		(should (equal (lsp--parser-read p "\"somedata\":2}")
+									 '("{\"somedata\":2}")))))
+
+(ert-deftest lsp--parser-read--multiple-multibyte-chunks ()
+  (let* ((p (make-lsp--parser :workspace lsp--test-workspace)))
+		(should (equal (lsp--parser-read p "Content-Length: 18\r\n\r\n{") nil))
+		(should (equal (lsp--parser-read p "\"somedata\":\"\xe2\x80") nil))
+		(should (equal (lsp--parser-read p "\x99\"}Content-Length: 14\r\n\r\n{")
+									 '("{\"somedata\":\"’\"}")))
+		(should (equal (lsp--parser-read p "\"somedata\":2}")
+									 '("{\"somedata\":2}")))))
+
+(provide 'lsp-receive-tests)


### PR DESCRIPTION
Okay, hopefully the last touches needed on the parser for a while.

1. Fix a freeze and/or error happening due to multibyte characters in responses. This is done by changing the `:coding` of the server processes to be `no-conversion`, which basically causes the strings to act like byte buffers. We then decode the message as utf-8 only once we have the whole thing.
2. Change `lsp--parser-read` to return a list of parsed messages (there can be multiple in a single chunk), instead of calling straight into `lsp--parser-on-message`. This change makes testing easier since we can just check the return value instead of having to mock `lsp--parser-on-message`. 
3. Add `ert` test cases. Run with `emacs -batch -l ert -L . -l test/lsp-receive-tests.el -f ert-run-tests-batch-and-exit`