### PR TITLE
Send changes immediately instead of queueing them

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -733,7 +733,14 @@ to a text document."
     (setq lsp--has-changes t)
     (lsp--rem-idle-timer)
     (when (eq lsp--server-sync-method 'incremental)
-      (lsp--push-change (lsp--text-document-content-change-event start end length)))
+      ;; (lsp--push-change (lsp--text-document-content-change-event start end length)))
+
+      ;; Each change needs to be wrt to the current doc, so send immediately.
+      ;; Otherwise we need to adjust the coordinates of the new change according
+      ;; to the cumulative changes already queued.
+      (progn
+        (lsp--push-change (lsp--text-document-content-change-event start end length))
+        (lsp--send-changes lsp--cur-workspace)))
     (if (lsp--workspace-change-timer-disabled lsp--cur-workspace)
       (lsp--send-changes lsp--cur-workspace)
       (lsp--set-idle-timer lsp--cur-workspace))))


### PR DESCRIPTION
For incremental change mode, all the changes in a `textDocument/didChange`
message are interpreted as applying to the same version of a particular
document.

But each emacs change corresponds to the state of the document when the change
happens. So harmonise the expectations by sending each change in its own
message.

closes #112