### PR TITLE
Use buffer-undo-history to recover range for change events

### DIFF
--- a/lsp-common.el
+++ b/lsp-common.el
@@ -69,5 +69,14 @@ If no such directory could be found, log a warning and return `default-directory
               "Couldn't find project root, using the current directory as the root.")
             default-directory)))))
 
+(defconst DEBUG 0)
+(defconst INFO 1)
+
+(defvar lsp--log-level INFO)
+
+(defmacro lsp--log (lvl fmt &rest args)
+  `(when (>= ,lvl lsp--log-level)
+     (message ,(format "[%s]: %s" lvl fmt) ,@args)))
+
 (provide 'lsp-common)
 ;;; lsp-common.el ends here

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -600,10 +600,9 @@ interface Range {
   (gethash cap (or capabilities (lsp--server-capabilities))))
 
 (defun lsp--get-text-deleted-in-most-recent-change ()
-  "If the most recent change in buffer-undo-list includes a text
-deletion, return the text corresponding to the first
-deletion. Returns nil if the latest change in buffer-undo-list
-does not contain a deletion."
+  "Search until the first undo boundary and return the text
+corresponding to the first deletion in buffer-undo-list, if
+present. Else return nil. "
   (if undo-tree-mode
       (user-error "lsp-mode is not compatible with undo-tree mode!")
     (let ((l buffer-undo-list)
@@ -614,57 +613,32 @@ does not contain a deletion."
           (setq l (cdr l))))
       result)))
 
-
-(defun lsp--substitution-change (start end length)
-  (if-let ((last-deletion-change (lsp--get-text-deleted-in-most-recent-change)))
-      (let* ((d (split-string last-deletion-change "\n"))
-             (start-p (lsp-point-to-position start))
-             (end-p '(:line 0 :character 0)))
-        (plist-put end-p :line (+ (plist-get start-p :line) (length d) -1))
-        (plist-put end-p :character (if (> (length d) 1)
-                                        (length (car (last d)))
-                                      (+ (length (car (last d))) (plist-get start-p :character))))
-        `(:range (:start ,start-p :end ,end-p)
-                 :rangeLength ,length
-                 :text ,(buffer-substring-no-properties start end)))
-    (log DEBUG "Ignoring text change, because it seems like nothing actually changed: [start=%s; end=%s; length=%s]" start end length)))
-
-(defun lsp--delete-change (start end length)
-  (if-let* ((last-deletion-change (lsp--get-text-deleted-in-most-recent-change))
-            (d (split-string  last-deletion-change "\n"))
-            (start-p (lsp-point-to-position start))
-            (end-p '(:line 0 :character 0)))
-      (progn
-        (plist-put end-p :line (+ (plist-get start-p :line) (length d) -1))
-        (plist-put end-p :character (if (> (length d) 1)
-                                        (length (car (last d)))
-                                      (+ (length (car (last d))) (plist-get start-p :character))))
-        `(:range (:start ,start-p
-                         :end ,end-p)
-                 :rangeLength ,length
-                 :text ""))
-    (error "Can't send a change event to the server because we couldn't recover the deleted text. This is likely a bug in lsp-mode")))
-
 (defun lsp--substitution-or-deletion-change (start end length)
+  "Return a change corresponding to a text substitution or
+deletion by recovering the affected text from the undo
+history. This logic doesn't play well with the redo functionality
+provided by undo-tree mode."
   (if-let* ((last-deletion-change (lsp--get-text-deleted-in-most-recent-change))
-            (d (split-string  last-deletion-change "\n"))
+            (deleted-lines (split-string last-deletion-change "\n"))
             (start-p (lsp-point-to-position start))
             (end-p '(:line 0 :character 0)))
       (progn
-        (plist-put end-p :line (+ (plist-get start-p :line) (length d) -1))
-        (plist-put end-p :character (if (> (length d) 1)
-                                        (length (car (last d)))
-                                      (+ (length (car (last d))) (plist-get start-p :character))))
+        (plist-put end-p :line (+ (plist-get start-p :line) (length deleted-lines) -1))
+        (plist-put end-p :character (if (> (length deleted-lines) 1)
+                                        (length (car (last deleted-lines)))
+                                      (+ (length (car (last deleted-lines))) (plist-get start-p :character))))
         `(:range (:start ,start-p :end ,end-p)
                  :rangeLength ,length
                  :text ,(buffer-substring-no-properties start end)))
+    ;; else, we couldn't find a deletion in the undo history
     (if (eq start end)
       ;; deletion
       (error "Can't send a change event to the server because we couldn't recover the deleted text. This is likely a bug in lsp-mode")
-      ;; substitution
-      (log DEBUG "Ignoring text change, because it seems like nothing actually changed: [start=%s; end=%s; length=%s]" start end length))))
-
-
+      ;; substitution - I've observed the undo of a substitution
+      ;; trigger 3 changes, the first of which seems to overwrite part
+      ;; of the affected region with the same text that's already
+      ;; present
+      (lsp--log DEBUG "Ignoring text change, because it seems like nothing actually changed: [start=%s; end=%s; length=%s]" start end length))))
 
 (defun lsp--text-document-content-change-event (start end length)
   "Make a TextDocumentContentChangeEvent body for START to END, of length LENGTH."
@@ -681,17 +655,24 @@ does not contain a deletion."
   ;;            ,"end"  :{"line":7,"character":0}}
   ;;            ,"rangeLength":7
   ;;            ,"text":""}
-  (message "In change hook: start=%s; end=%s; length=%s\nBuffer contents:\n%s\nbuffer-undo-list: %s" start end length
-           (buffer-substring-no-properties (point-min) (point-max))
-           (prin1-to-string buffer-undo-list))
+  (lsp--log DEBUG
+            "In change hook: [start=%s; end=%s; length=%s]
+Buffer contents:
+---------------------------------
+%s
+---------------------------------
+buffer-undo-list: %s"
+            start end length
+            (buffer-substring-no-properties (point-min) (point-max))
+            (prin1-to-string buffer-undo-list))
   (if (eq length 0)
       ;; Adding something, work from start only
       `(:range ,(lsp--range (lsp--point-to-position start)
                             (lsp--point-to-position start))
                :rangeLength 0
                :text ,(buffer-substring-no-properties start end))
-      ;; Deleting or substituting something
-      (lsp--substitution-or-deletion-change start end length)))
+    ;; Deleting or substituting something
+    (lsp--substitution-or-deletion-change start end length)))
 
 ;; Observed from vscode for applying a diff replacing one line with
 ;; another. Emacs on-change shows this as a delete followed by an
@@ -722,15 +703,6 @@ does not contain a deletion."
 (defvar-local lsp--changes [])
 (defvar-local lsp--has-changes []
   "non-nil if the current buffer has any changes yet to be sent.")
-
-(defconst DEBUG 0)
-(defconst INFO 1)
-
-(defvar-local lsp--log-level DEBUG)
-
-(defmacro log (lvl fmt &rest args)
-  `(when (>= ,lvl lsp--log-level)
-     (message ,(format "[%s]: %s" lvl fmt) ,@args)))
 
 (defun lsp--rem-idle-timer ()
   (when lsp--change-idle-timer

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -133,6 +133,19 @@ Optional arguments:
   :group 'lsp-mode
   (lsp--start))
 
+(defun lsp--warn-if-undo-tree-mode-enabled ()
+  (warn "LSP is incompatible with undo-tree-mode. Please disable undo-tree-mode or your changes will not be synced correctly."))
+
+(add-hook 'lsp-mode-hook (lambda ()
+                           (when (and lsp-mode
+                                      (boundp 'undo-tree-mode)
+                                      undo-tree-mode)
+                             (lsp--warn-if-undo-tree-mode-enabled))))
+
+(add-hook 'undo-tree-mode-hook (lambda ()
+                                 (when (and undo-tree-mode lsp-mode)
+                                   (lsp--warn-if-undo-tree-mode-enabled))))
+
 (defconst lsp--sync-type
   `((0 . "None")
      (1 . "Full Document")

--- a/test/lsp-document-tests.el
+++ b/test/lsp-document-tests.el
@@ -1,0 +1,127 @@
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+;; TODO: remove this
+(add-to-list 'load-path "/home/astahlman/workplace/lsp/lsp-mode")
+
+;;(setq ert-debug-on-error t)
+
+(require 'ert)
+(require 'lsp-methods)
+
+(defmacro with-buffer-contents (s &rest forms)
+    "Create a temporary buffer with contents S and execute FORMS."
+    `(save-excursion
+       (with-temp-buffer
+         (progn
+           (buffer-enable-undo)
+           (goto-char 0)
+           (insert ,s)
+           (goto-char 0)
+           ,@forms))))
+
+(defun capture-changes (change-event)
+  (add-hook 'after-change-functions
+            (lambda (start end length)
+              (setq change-event (lsp--text-document-content-change-event start end length)))
+            nil
+            t))
+
+(ert-deftest lsp--content-change-event-delete-line1 ()
+  (let ((change-event nil))
+    (with-buffer-contents
+     "1234
+5678"
+     (capture-changes change-event)
+     (goto-char (point-min))
+     (kill-line 1)
+    (should (equal '(:range (:start (:line 0 :character 0)
+                             :end (:line 1 :character 0))
+                     :rangeLength 5
+                     :text "")
+                   change-event))))
+
+(ert-deftest lsp--content-change-event-join-lines ()
+  (let ((change-event))
+    (with-buffer-contents
+     "1234
+5678"
+     (capture-changes change-event)
+     (goto-char 5)
+     (kill-line))
+    (should (equal '(:range (:start (:line 0 :character 4)
+                             :end (:line 1 :character 0))
+                     :rangeLength 1
+                     :text "")
+                   change-event))))
+
+(ert-deftest lsp--content-change-event-delete-last-line ()
+  (let ((change-event))
+    (with-buffer-contents
+     "1234
+5678"
+     (capture-changes change-event)
+    (progn
+       (goto-char 5)
+       (let ((beg (point)))
+         (goto-char (point-max))
+         (delete-region beg (point))))) ;; Buffer contents now a single-line: "1234"
+    (should (equal '(:range (:start (:line 0 :character 4)
+                             :end (:line 1 :character 4))
+                     :rangeLength 5
+                     :text "")
+                   change-event)))))
+
+(ert-deftest lsp--content-change-event-insert-at-beginning-of-line ()
+  (let ((change-event nil))
+    (with-buffer-contents
+     "1234
+5678"
+     (capture-changes change-event)
+     (progn
+       (goto-char 0)
+       (insert "0")))
+    (should (equal '(:range (:start (:line 0 :character 0)
+                             :end (:line 0 :character 0))
+                            :rangeLength 0
+                            :text "0")
+                   change-event))))
+
+(ert-deftest lsp--content-change-event-insert-at-end-of-line ()
+  (let ((change-event))
+    (with-buffer-contents
+     "1234
+5678"
+     (capture-changes change-event)
+     (progn
+       (goto-char 5)
+       (insert "5 1/2")))
+    (should (equal '(:range (:start (:line 0 :character 4)
+                             :end (:line 0 :character 4))
+                            :rangeLength 0
+                            :text "5 1/2")
+                   change-event))))
+
+(ert-deftest lsp--content-change-event-substitute-range-of-different-length ()
+  (let ((change-event))
+    (with-buffer-contents
+     "1234
+5678"
+     (capture-changes change-event)
+     (progn
+       (goto-char 1)
+       (search-forward "23")
+       (replace-match "abc")))
+    (should (equal '(:range (:start (:line 0 :character 1)
+                             :end (:line 0 :character 3))
+                            :rangeLength 2
+                            :text "abc")
+                   change-event))))

--- a/test/lsp-document-tests.el
+++ b/test/lsp-document-tests.el
@@ -1,3 +1,9 @@
+;; Copyright (C) 2016  Vibhav Pant <vibhavp@gmail.com> -*- lexical-binding: t -*-
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
 
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -8,9 +14,6 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Code:
-
-;; TODO: remove this
-(add-to-list 'load-path "/home/astahlman/workplace/lsp/lsp-mode")
 
 ;;(setq ert-debug-on-error t)
 


### PR DESCRIPTION
This is a proof-of-concept of an idea suggested by @kongds in https://github.com/emacs-lsp/lsp-mode/issues/114. In order to correctly calculate the end position of the `Range` for a change event corresponding to the deletion or substitution of text, we examine the most recent change in the buffer's undo history to recover the affected region. 

I've tested this approach manually and haven't found any issues. I've also added unit tests, which may be useful regardless of whether this approach is ultimately adopted.

The downside of this approach is that it breaks if the user has `undo-tree-mode` enabled in the same buffer as `lsp-mode`. I think it would be possible to tailor this logic to work with `undo-tree-mode` by advising the `undo` and `redo` functions to track the current position in the undo tree. For now, I've just added a warning that LSP is incompatible with undo-tree.