### PR TITLE
Use symbol to get completion prefix bounds.

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -833,7 +833,7 @@ to a text document."
 
 (defun lsp--get-completions ()
   (lsp--send-changes lsp--cur-workspace)
-  (let ((bounds (bounds-of-thing-at-point 'word)))
+  (let ((bounds (bounds-of-thing-at-point 'symbol)))
     (list
       (if bounds (car bounds) (point))
       (if bounds (cdr bounds) (point))


### PR DESCRIPTION
word fails to get the completion prefix with underscores. For example, if
try to complete at

    FOO_B
         ^

The prefix optained from the bound is B, not FOO_B. Using symbol fixes this
issue.