### PR TITLE
Remove major-mode<->client association

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -275,8 +275,7 @@ interface TextDocumentItem {
   "When a workspace is shut down, by request or from just
 disappearing, unset all the variables related to it."
   (remhash (lsp--workspace-root lsp--cur-workspace) lsp--workspaces)
-  (let ((old-root (lsp--workspace-root lsp--cur-workspace))
-         proc)
+  (let (proc)
     (with-current-buffer (current-buffer)
       (setq proc (lsp--workspace-proc lsp--cur-workspace))
       (unless (eq (process-status proc) 'exit)
@@ -312,7 +311,7 @@ disappearing, unset all the variables related to it."
     (setq lsp--server-sync-method (or lsp-document-sync-method
                                       method))))
 
-(defun lsp--workspace-apply-edit-handler (workspace params)
+(defun lsp--workspace-apply-edit-handler (_workspace params)
   (lsp--apply-workspace-edits (gethash "edit" params))
   ;; TODO: send reply
   )
@@ -616,14 +615,14 @@ interface Range {
         (lsp--change-for-mismatch start end length)))))
 
 
-(defun lsp--change-for-mismatch (start end length)
+(defun lsp--change-for-mismatch (_start _end _length)
   "If the current change is not fully bracketed, report it and
 return the full contents of the buffer as the change."
   (lsp--full-change-event))
 
 
 ;; TODO: Add tests for this function.
-(defun lsp--bracketed-change-p (start end length)
+(defun lsp--bracketed-change-p (start _end length)
   "If the before and after positions are the same, and the length
 is the size of the start range, we are probably good."
   (and (eq start (plist-get lsp--before-change-vals :start) )

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -786,21 +786,6 @@ to a text document."
       (lsp--send-changes lsp--cur-workspace)
       (lsp--set-idle-timer lsp--cur-workspace))))
 
-;; (defun lsp--text-document-did-change (start end length)
-;;   "Executed when a file is changed.
-;; Added to `after-change-functions'"
-;;   (when lsp--cur-workspace
-;;     (unless (or (eq lsp--server-sync-method 'none)
-;; 		(eq lsp--server-sync-method nil))
-;;       (lsp--cur-file-version t)
-;;       (lsp--send-notification
-;;        (lsp--make-notification
-;; 	"textDocument/didChange"
-;; 	`(:textDocument
-;; 	  ,(lsp--versioned-text-document-identifier)
-;; 	  :contentChanges
-;; 	  [,(lsp--text-document-content-change-event start end length)]))))))
-
 (defun lsp--shut-down-p ()
   (y-or-n-p "Close the language server for this workspace? "))
 

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -419,7 +419,7 @@ disappearing, unset all the variables related to it."
 
   (when (and lsp-enable-completion-at-point (lsp--capability "completionProvider"))
     (setq-local completion-at-point-functions nil)
-    (add-hook 'completion-at-point-functions #'lsp-completion-at-point))
+    (add-hook 'completion-at-point-functions #'lsp-completion-at-point nil t))
 
   ;; Make sure the hook is local (last param) otherwise we see all changes for all buffers
   (add-hook 'before-change-functions #'lsp-before-change nil t)
@@ -1251,9 +1251,9 @@ command COMMAND and optionsl ARGS"
   (when lsp-enable-xref
     (setq-local xref-backend-functions nil))
   (when lsp-enable-completion-at-point
-    (remove-hook 'completion-at-point-functions #'lsp-completion-at-point))
-  (remove-hook 'after-change-functions #'lsp-on-change))
-
+    (remove-hook 'completion-at-point-functions #'lsp-completion-at-point t))
+  (remove-hook 'after-change-functions #'lsp-on-change t)
+  (remove-hook 'before-change-functions #'lsp-before-change t))
 
 (defun lsp--error-explainer (fc-error)
     "Proof of concept to use this flycheck function to apply a
@@ -1262,10 +1262,11 @@ command COMMAND and optionsl ARGS"
     https://github.com/flycheck/flycheck/issues/530#issuecomment-235224763"
   (message "lsp--error-explainer: got %s" fc-error))
 
-
 (defun lsp--set-configuration (settings)
   "Set the configuration for the lsp server."
-  (lsp--send-notification (lsp--make-notification "workspace/didChangeConfiguration" `(:settings , settings))))
+  (lsp--send-notification (lsp--make-notification
+                            "workspace/didChangeConfiguration"
+                            `(:settings , settings))))
 
 (provide 'lsp-methods)
 ;;; lsp-methods.el ends here

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -34,7 +34,8 @@
   (new-connection nil :read-only t)
   (get-root nil :read-only t)
   (ignore-regexps nil :read-only t)
-  (method-handlers (make-hash-table :test 'equal) :read-only t))
+  (notification-handlers (make-hash-table :test 'equal) :read-only t)
+  (request-handlers (make-hash-table :test 'equal) :read-only t))
 
 (cl-defstruct lsp--workspace
   (parser nil :read-only t)
@@ -172,7 +173,7 @@ initialized. When set this turns off use of
   (cl-check-type client lsp--client)
   (cl-check-type method string)
   (cl-check-type callback function)
-  (puthash method callback (lsp--client-method-handlers client)))
+  (puthash method callback (lsp--client-notification-handlers client)))
 
 (defun lsp-client-on-request (client method callback)
   (cl-check-type client lsp--client)
@@ -350,8 +351,7 @@ disappearing, unset all the variables related to it."
         (setq lsp--cur-workspace workspace)
 
         (setf
-          parser (make-lsp--parser
-                   :method-handlers (lsp--client-method-handlers client))
+          parser (make-lsp--parser)
           lsp--cur-workspace (make-lsp--workspace
                                :parser parser
                                :language-id (lsp--client-language-id client)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -101,10 +101,13 @@ Optional arguments:
          (unless lsp-mode
            ,(when (plist-get args :initialize)
               `(funcall ,(plist-get args :initialize) client))
-           (lsp-mode 1)
-           (lsp--start client))))))
+           (if (lsp--should-start-p (funcall (lsp--client-get-root client)))
+             (progn
+               (lsp-mode 1)
+               (lsp--start client))
+             (message "Not initializing project %s" root)))))))
 
-(defun lsp-define-tcp-client (mode language-id get-root command host port &rest args)
+(defmacro lsp-define-tcp-client (mode language-id get-root command host port &rest args)
   "Define a LSP client using TCP.
 NAME is the symbol to use for the name of the client.
 MODE is the major mode for which this client will be invoked.
@@ -131,8 +134,11 @@ Optional arguments:
          (unless lsp-mode
            ,(when (plist-get args :initialize)
               `(funcall ,(plist-get args :initialize) client))
-           (lsp-mode 1)
-           (lsp--start client))))))
+           (if (lsp--should-start-p (funcall (lsp--client-get-root client)))
+             (progn
+               (lsp-mode 1)
+               (lsp--start client))
+             (message "Not initializing project %s" root)))))))
 
 ;;;###autoload
 (define-minor-mode lsp-mode ""

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -32,8 +32,8 @@
 
 (defun lsp--make-stdio-connection (name command command-fn)
   (lambda (filter sentinel)
-    (let ((command (if command-fn (funcall command-fn) command)))
-      (let ((final-command (if (consp command) command (list command))))
+    (let* ((command (if command-fn (funcall command-fn) command))
+            (final-command (if (consp command) command (list command))))
       (unless (executable-find (nth 0 final-command))
         (error (format "Couldn't find executable %s" (nth 0 final-command))))
       (make-process
@@ -43,13 +43,13 @@
         :command final-command
         :filter filter
         :sentinel sentinel
-        :stderr (generate-new-buffer-name (concat "*" name " stderr")))))))
+        :stderr (generate-new-buffer-name (concat "*" name " stderr*"))))))
 
 (defun lsp--make-tcp-connection (name command command-fn host port)
   (lambda (filter sentinel)
-    (let ((command (if command-fn (funcall command-fn) command)))
-    (let ((final-command (if (consp command) command (list command)))
-           proc tcp-proc)
+    (let* ((command (if command-fn (funcall command-fn) command))
+            (final-command (if (consp command) command (list command)))
+            proc tcp-proc)
       (unless (executable-find (nth 0 final-command))
         (error (format "Couldn't find executable %s" (nth 0 final-command))))
       (setq proc (make-process
@@ -62,7 +62,7 @@
                    nil host port
                    :type 'plain))
       (set-process-filter tcp-proc filter)
-      (cons proc tcp-proc)))))
+      (cons proc tcp-proc))))
 
 (defun lsp--verify-regexp-list (l)
   (cl-assert (cl-typep l 'list) nil
@@ -74,64 +74,71 @@
         "lsp-define-client: :ignore-regexps element %s is not a string"
         e))))
 
-(defun lsp-define-stdio-client (mode language-id type get-root name command &rest args)
-  "Define a LSP client using stdio.
+(defmacro lsp-define-stdio-client (name language-id get-root command &rest args)
+   "Define a LSP client using stdio.
+NAME is the symbol to use for the name of the client.
 MODE is the major mode for which this client will be invoked.
 LANGUAGE-ID is the language id to be used when communication with the Language Server.
-NAME is the process name for the language server.
 COMMAND is the command to run.
 Optional arguments:
 `:ignore-regexps' is a list of regexps which when matched will be ignored by the output parser.
-`:command-fn' will be called when the client is created and `command' will be ignored."
-  (lsp--assert-type mode #'symbolp)
-  (let* ((command-fn-arg (plist-get args :command-fn)) (command-fn (if command-fn-arg (lsp--assert-type command-fn-arg #'functionp) nil)))
-    (let* (client)
-      (setq client
-        (make-lsp--client
-          :language-id (lsp--assert-type language-id #'stringp)
-          :send-sync 'lsp--stdio-send-sync
-          :send-async 'lsp--stdio-send-async
-          :type (lsp--assert-type type #'symbolp)
-          :new-connection (lsp--make-stdio-connection name command command-fn)
-          :get-root (lsp--assert-type get-root #'functionp)
-          :ignore-regexps (lsp--verify-regexp-list (plist-get
-                                                     args
-                                                     :ignore-regexps))))
-      (puthash mode client lsp--defined-clients))))
+`:command-fn' is a function that returns the command string/list to be used to launch the language server. If non-nil, COMMAND is ignored.
+`:initialize' is a function called when the client is intiailized. It takes a single argument, the newly created client.
+"
+  (let ((enable (intern (format "%s-enable" name)))
+         (disable (intern (format "%s-disable" name))))
+    `(defun ,enable ()
+       ,(plist-get args :docstring)
+       (interactive)
+       (let ((client (make-lsp--client
+                       :language-id ,(lsp--assert-type language-id #'stringp)
+                       :send-sync #'lsp--stdio-send-sync
+                       :send-async #'lsp--stdio-send-async
+                       :new-connection (lsp--make-stdio-connection ,(symbol-name name) ,command
+                                         ,(plist-get args :command-fn))
+                       :get-root ,get-root
+                       :ignore-regexps ,(plist-get args :ignore-regexps))))
+         (unless lsp-mode
+           ,(when (plist-get args :initialize)
+              `(funcall ,(plist-get args :initialize) client))
+           (lsp-mode 1)
+           (lsp--start client))))))
 
-(defun lsp-define-tcp-client (mode language-id type get-root name command host port &rest args)
+(defun lsp-define-tcp-client (mode language-id get-root command host port &rest args)
   "Define a LSP client using TCP.
+NAME is the symbol to use for the name of the client.
 MODE is the major mode for which this client will be invoked.
 LANGUAGE-ID is the language id to be used when communication with the Language Server.
-NAME is the process name for the language server.
 COMMAND is the command to run.
 HOST is the host address.
 PORT is the port number.
 Optional arguments:
 `:ignore-regexps' is a list of regexps which when matched will be ignored by the output parser.
-`:command-fn' will be called when the client is created and `command' will be ignored."
-  (lsp--assert-type mode #'symbolp)
-  (let* ((command-fn-arg (plist-get args :command-fn)) (command-fn (if command-fn-arg (lsp--assert-type command-fn-arg #'functionp) nil)))
-    (let* (client)
-      (setq client
-        (make-lsp--client
-          :language-id (lsp--assert-type language-id #'stringp)
-          :send-sync 'lsp--stdio-send-sync
-          :send-async 'lsp--stdio-send-async
-          :type (lsp--assert-type type #'symbolp)
-          :new-connection (lsp--make-tcp-connection name command command-fn host port)
-          :get-root (lsp--assert-type get-root #'functionp)
-          :ignore-regexps (lsp--verify-regexp-list (plist-get
-                                                     args
-                                                     :ignore-regexps))))
-      (puthash mode client lsp--defined-clients))))
+`:command-fn' is a function that returns the command string/list to be used to launch the language server. If non-nil, COMMAND is ignored.
+`:initialize' is a function called when the client is intiailized. It takes a single argument, the newly created client."
+  (let ((enable (intern (format "%s-enable" name)))
+         (disable (intern (format "%s-disable" name))))
+    `(defun ,enable ()
+       ,(plist-get args :docstring)
+       (interactive)
+       (let ((client (make-lsp--client
+                       :language-id ,(lsp--assert-type language-id #'stringp)
+                       :send-sync #'lsp--stdio-send-sync
+                       :send-async #'lsp--stdio-send-async
+                       :new-connection (lsp--make-tcp-connection ,(symbol-name name) ,command ,(plist-get args :command-fn) ,host ,port)
+                       :get-root ,get-root
+                       :ignore-regexps ,(plist-get args :ignore-regexps))))
+         (unless lsp-mode
+           ,(when (plist-get args :initialize)
+              `(funcall ,(plist-get args :initialize) client))
+           (lsp-mode 1)
+           (lsp--start client))))))
 
 ;;;###autoload
 (define-minor-mode lsp-mode ""
   nil nil nil
   :lighter " LSP"
-  :group 'lsp-mode
-  (lsp--start))
+  :group 'lsp-mode)
 
 (defconst lsp--sync-type
   `((0 . "None")

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -18,7 +18,7 @@
 ;; Author: Vibhav Pant <vibhavp@gmail.com>
 ;; URL: https://github.com/emacs-lsp/lsp-mode
 ;; Package-Requires: ((emacs "25.1") (flycheck "30"))
-;; Version: 2.0
+;; Version: 3.0
 
 ;;; Commentary:
 

--- a/lsp-receive.el
+++ b/lsp-receive.el
@@ -35,9 +35,7 @@
   (queued-requests nil)
 
   (workspace nil) ;; the workspace
-  (method-handlers nil :read-only t)
-  (request-handlers nil))
-
+  )
 
 ;;  id  method
 ;;   x    x     request
@@ -68,6 +66,7 @@
   "If response queue is empty, call the appropriate handler for NOTIFICATION.
 Else it is queued (unless DONT-QUEUE is non-nil)"
   (let ((params (gethash "params" notification))
+         (client (lsp--workspace-client (lsp--parser-workspace p)))
          handler)
     ;; If we've been explicitly told to queue
     (if (and (not dont-queue) (lsp--parser-response-result p))
@@ -81,7 +80,7 @@ Else it is queued (unless DONT-QUEUE is non-nil)"
         ("textDocument/diagnosticsEnd")
         ("textDocument/diagnosticsBegin")
         (other
-          (setq handler (gethash other (lsp--parser-method-handlers p) nil))
+          (setq handler (gethash other (lsp--client-notification-handlers client) nil))
           (if (not handler)
             (message "Unknown method: %s" other)
             (funcall handler (lsp--parser-workspace p) params)))))))
@@ -89,6 +88,7 @@ Else it is queued (unless DONT-QUEUE is non-nil)"
 (defun lsp--on-request (p request)
   "Call the appropriate handler for REQUEST."
   (let ((params (gethash "params" request))
+         (client (lsp--workspace-client (lsp--parser-workspace p)))
          handler)
     (pcase (gethash "method" request)
       ("client/registerCapability")
@@ -96,7 +96,7 @@ Else it is queued (unless DONT-QUEUE is non-nil)"
       ("workspace/applyEdit" (lsp--workspace-apply-edit-handler
                                (lsp--parser-workspace p) params))
       (other
-        (setq handler (gethash other (lsp--parser-request-handlers p) nil))
+        (setq handler (gethash other (lsp--client-request-handlers client) nil))
         (if (not handler)
           (message "Unknown request method: %s" other)
           (funcall handler (lsp--parser-workspace p) params))))))


### PR DESCRIPTION
This PR turns all `lsp-define-{tcp,stdio}-client` functions into macros, which create a new function `<name>-enable`. Defining a client no longer needs an associated major mode symbol, as clients are now enabled by their respective functions instead, which removes the dependency on the major mode's package for an LSP client. For instance, here's how a client for python would be defined:
```lisp
(lsp-define-stdio-client lsp-python "python"
			 (lsp-make-traverser #'(lambda (dir)
						 (directory-files
						  dir
						  nil
						  "\\(__init__\\|setup\\)\\.py")))
			 '("pyls"))
```

This defines the function `lsp-python-enable`, which is hooked to `python-mode` with `(add-hook 'python-mode #'lsp-python-enable)`. Also, the package's version has been bumped to `3.0` to accommodate for the
 API change. 

TODO:
- [ ] Document changes to API in `API.org`.