### PR TITLE
Allow the mode-line to change dynamically

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -18,7 +18,7 @@
 ;; Author: Vibhav Pant <vibhavp@gmail.com>
 ;; URL: https://github.com/emacs-lsp/lsp-mode
 ;; Package-Requires: ((emacs "25.1") (flycheck "30"))
-;; Version: 3.3
+;; Version: 3.4
 
 ;;; Commentary:
 
@@ -185,11 +185,19 @@ Optional arguments:
                  (lsp--start client ,extra-init-params))
                (message "Not initializing project %s" root))))))))
 
+(defvar-local lsp-status nil
+  "The current status of the LSP server.")
+
+(defun lsp-mode-line ()
+  "Construct the mode line text."
+  (concat " LSP" lsp-status))
+
 ;;;###autoload
 (define-minor-mode lsp-mode ""
   nil nil nil
-  :lighter " LSP"
-  :group 'lsp-mode)
+  :lighter (:eval (lsp-mode-line))
+  :group 'lsp-mode
+  (lsp--start))
 
 (defconst lsp--sync-type
   `((0 . "None")


### PR DESCRIPTION
This allows us to give some feedback to the user when the language server is
busy.

E.g., the RLS sends a `rustDocument/beginBuild` message when it starts building
the workspace, which can take quite some time on larger projects.