### PR TITLE
Don't reset parser in lsp--parser-on-message

### DIFF
--- a/lsp-receive.el
+++ b/lsp-receive.el
@@ -167,8 +167,7 @@ Else it is queued (unless DONT-QUEUE is non-nil)"
         (setf (lsp--parser-response-result p) nil
           (lsp--parser-waiting-for-response p) nil))
       ('notification (lsp--on-notification p json-data))
-      ('request      (lsp--on-request p json-data))))
-  (lsp--parser-reset p))
+      ('request      (lsp--on-request p json-data)))))
 
 (defun lsp--parser-read (p chunk)
   (cl-assert (lsp--parser-workspace p) nil "Parser workspace cannot be nil.")


### PR DESCRIPTION
We don't need to reset the parser in lsp--parser-on-message, because the parser
is already reset when a full message was read. Resetting the parser in the
lsp--parser-on-message function leads to errors when the parser is currently
parsing a message, but the chunk did not contain all the required data.

Fixes: https://github.com/emacs-lsp/lsp-mode/issues/132