### PR TITLE
Fix wrong type argument in lsp--text-document-hover-string

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1001,7 +1001,8 @@ type MarkedString = string | { language: string; value: string };"
     (let* ((hover (lsp--send-request (lsp--make-request
                                        "textDocument/hover"
                                        (lsp--text-document-position-params))))
-            (contents (gethash "contents" (or hover (make-hash-table)))))
+           (contents (gethash "contents" (or (if (consp hover) (car hover) hover)
+					     (make-hash-table)))))
       (lsp--marked-string-to-string (if (consp contents)
                                       (car contents)
                                       contents)))


### PR DESCRIPTION
In some cases the variable hover can be a list