### PR TITLE
Document the Version of the LSP Supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ emacs-lsp
 [![MELPA](http://melpa.org/packages/lsp-mode-badge.svg)](http://melpa.org/#/lsp-mode)
 
 A Emacs Lisp library for implementing clients for servers using Microsoft's
-[Language Server Protocol](https://github.com/Microsoft/language-server-protocol/).
+[Language Server Protocol](https://github.com/Microsoft/language-server-protocol/) (v3.0).
 
 The library is designed to integrate with existing Emacs IDE frameworks
 (completion-at-point, xref (beginning with Emacs 25.1), flycheck, etc).

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -30,6 +30,9 @@
 (require 'cl-lib)
 (require 'network-stream)
 
+(defvar lsp-version-support "3.0"
+  "This is the version of the Language Server Protocol currently supported by lsp-mode")
+
 (defun lsp--make-stdio-connection (name command command-fn)
   (lambda (filter sentinel)
     (let* ((command (if command-fn (funcall command-fn) command))


### PR DESCRIPTION
This adds two pieces of documentation:

1. A programatic value for code to match against
2. A small update to the README for humans

fixes #144