### PR TITLE
Whitelist features

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -346,12 +346,18 @@ disappearing, unset all the variables related to it."
                      exit-str)
             (lsp--uninitialize-workspace)))))))
 
+(defvar lsp--project-whitelist-temp nil
+  "If a project is started manually and not added to the
+  whitelist, the root is stored here so other files belonging to
+  it will also be added to the session.")
+
 (defun lsp--should-start-p (root)
   "Consult `lsp-project-blacklist' and `lsp-project-whitelist' to
   determine if a server should be started for the given ROOT
   directory"
   (if lsp-project-whitelist
-      (member root lsp-project-whitelist)
+      (or (member root lsp-project-whitelist)
+          (member root lsp--project-whitelist-temp))
     (not (member root lsp-project-blacklist))))
 
 (defun lsp--start (client)


### PR DESCRIPTION
Split the lsp-XXXX-enable into non-interactive and interactive

The non-interactive one gets called in the mode hook, and is quiet

The interactive one will ask to add a project to the whitelist if invoked to
start LSP for it and it would not otherwise start.

For some reason I can't get both macros to be defined at once, so currently you
need to call something like

    (lsp-define-stdio-client-noninteractive
                     lsp-haskell "haskell"
                     #'lsp-haskell--get-root
                     '("hie" "--lsp" "-d" "-l" "/tmp/hie.log") )
    (lsp-define-interactive-client lsp-haskell)

Supersedes https://github.com/emacs-lsp/lsp-mode/pull/141

