### PR TITLE
whitelist features

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -481,12 +481,18 @@ registered client capabilities by calling
                      exit-str)
             (lsp--uninitialize-workspace)))))))
 
+(defvar lsp--project-whitelist-temp nil
+  "If a project is started manually and not added to the
+  whitelist, the root is stored here so other files belonging to
+  it will also be added to the session.")
+
 (defun lsp--should-start-p (root)
   "Consult `lsp-project-blacklist' and `lsp-project-whitelist' to
 determine if a server should be started for the given ROOT
 directory."
   (if lsp-project-whitelist
-      (member root lsp-project-whitelist)
+      (or (member root lsp-project-whitelist)
+          (member root lsp--project-whitelist-temp))
     (not (member root lsp-project-blacklist))))
 
 (defun lsp--start (client)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -77,7 +77,17 @@
                 "lsp-define-client: :ignore-regexps element %s is not a string"
                 e))))
 
-(cl-defmacro lsp-define-stdio-client (name language-id get-root command
+;; --------------------------------------------------------
+
+(defmacro lsp-define-interactive-client (name)
+  (let ((enable-noninteractive (intern (format "%s-enable-hook" name)))
+        (enable-interactive    (intern (format "%s-enable" name)))
+        )
+    `(defun ,enable-interactive (&optional ask)
+       (interactive)
+       (,enable-noninteractive t))))
+
+(cl-defmacro lsp-define-stdio-client-noninteractive (name language-id get-root command
                                        &key docstring
                                        (language-id-fn #'(lambda (_b) language-id))
                                        command-fn
@@ -100,8 +110,8 @@ Optional arguments:
 
 `:initialize' is a function called when the client is intiailized. It takes a
   single argument, the newly created client."
-  (let ((enable (intern (format "%s-enable" name))))
-    `(defun ,enable ()
+  (let ((enable (intern (format "%s-enable-hook" name))))
+    `(defun ,enable (&optional ask)
        ,docstring
        (interactive)
        (let ((client (make-lsp--client
@@ -119,10 +129,20 @@ Optional arguments:
               `(funcall ,initialize client))
            (let ((root (funcall (lsp--client-get-root client))))
              (if (lsp--should-start-p root)
-               (progn
-                 (lsp-mode 1)
-                 (lsp--start client))
-               (message "Not initializing project %s" root))))))))
+                 (progn
+                   (lsp-mode 1)
+                   (lsp--start client))
+               (if ask
+                   (let ((question (format-message "Add %s to lsp-project-whitelist? " root)))
+                     (if (y-or-n-p question) ;; cannot use when , side effects problem
+                         (progn (message "About to customize lsp-project-whitelist")
+                                (customize-save-variable 'lsp-project-whitelist (add-to-list 'lsp-project-whitelist root)))
+                       (setq lsp--project-whitelist-temp (add-to-list 'lsp--project-whitelist-temp root)))
+                     ;; start regardless, this is called interactively
+                     (lsp-mode 1)
+                     (lsp--start client))
+                 (message "Not initializing project %s" root))))))))
+  )
 
 (cl-defmacro lsp-define-tcp-client (name language-id get-root command host port
                                      &key docstring


### PR DESCRIPTION
If a whitelist exists, and the current project is not on it, lsp-mode cannot be started for it, without this patch.

An alternative would be some simple way to add the current project root to the whitelist, which would require calling the relevant function to determine the root.

Supersedes https://github.com/emacs-lsp/lsp-mode/pull/156