### PR TITLE
Fixes bug with default value of `language-fn-id`

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -79,7 +79,7 @@
 
 (cl-defmacro lsp-define-stdio-client (name language-id get-root command
                                        &key docstring
-                                       (language-id-fn #'(lambda (_b) language-id))
+                                       language-id-fn
                                        command-fn
                                        ignore-regexps
                                        initialize)
@@ -105,7 +105,7 @@ Optional arguments:
        ,docstring
        (interactive)
        (let ((client (make-lsp--client
-                       :language-id ,language-id-fn
+                       :language-id (if ,language-id-fn ,language-id-fn #'(lambda (_) ,language-id))
                        :send-sync #'lsp--stdio-send-sync
                        :send-async #'lsp--stdio-send-async
                        :new-connection (lsp--make-stdio-connection
@@ -126,7 +126,7 @@ Optional arguments:
 
 (cl-defmacro lsp-define-tcp-client (name language-id get-root command host port
                                      &key docstring
-                                     (language-id-fn #'(lambda (_b) language-id))
+                                     language-id-fn
                                      command-fn
                                      ignore-regexps
                                      initialize)
@@ -153,7 +153,7 @@ Optional arguments:
        ,docstring
        (interactive)
        (let ((client (make-lsp--client
-                       :language-id ,language-id-fn
+                       :language-id (if ,language-id-fn ,language-id-fn #'(lambda (_) ,language-id))
                        :send-sync #'lsp--stdio-send-sync
                        :send-async #'lsp--stdio-send-async
                        :new-connection (lsp--make-tcp-connection


### PR DESCRIPTION
cl-defmacro automatically evaluates default values. To prevent evaluation, the
default value needs to be escaped, but when escaped `language-id` is not
replaced by the macro system. To circumvent these problems, the value of
`language-fn-id` is checked at execution and if the value is `nil` a lambda
returning the `language-id` is used.