### PR TITLE
Use forward-chars instead of move-to-column in lsp--position-to-point

### DIFF
--- a/lsp-common.el
+++ b/lsp-common.el
@@ -46,7 +46,7 @@
   (save-excursion
     (goto-char (point-min))
     (forward-line (gethash "line" params))
-    (move-to-column (gethash "character" params))
+    (forward-char (gethash "character" params))
     (point)))
 
 (defun lsp-make-traverser (name)


### PR DESCRIPTION
On Emacs 26.0.90, I was getting weird highlights on files with `indent-tabs-mode` set. Root cause seemed to be in `lsp--position-to-point`.

Before:
<img width="639" alt="screen shot 2017-11-19 at 20 37 38" src="https://user-images.githubusercontent.com/103758/33002708-b381c8e0-cd6a-11e7-92c7-1d9e6424fa91.png">

After:
<img width="614" alt="screen shot 2017-11-19 at 20 39 59" src="https://user-images.githubusercontent.com/103758/33002714-bc09f816-cd6a-11e7-9614-edd8a9b2e6a4.png">
