### PR TITLE
Fix 'end of buffer' error

### DIFF
--- a/lsp-common.el
+++ b/lsp-common.el
@@ -40,14 +40,18 @@
 
 (defvar lsp--no-response)
 
-;; from http://emacs.stackexchange.com/questions/8082/how-to-get-buffer-position-given-line-number-and-column-number
 (defun lsp--position-to-point (params)
   "Convert Position object in PARAMS to a point."
   (save-excursion
-    (goto-char (point-min))
-    (forward-line (gethash "line" params))
-    (forward-char (gethash "character" params))
-    (point)))
+    (save-restriction
+      (widen)
+      (goto-char 1)
+      ;; The next line calculs the point from the LSP position.
+      ;; We use `goto-char' to ensure that we return a point inside the buffer
+      ;; to avoid out of range error
+      (goto-char (+ (line-beginning-position (1+ (gethash "line" params)))
+                    (gethash "character" params)))
+      (point))))
 
 (defun lsp-make-traverser (name)
   "Return a closure that walks up the current directory until NAME is found.


### PR DESCRIPTION
When forward-char reaches the end of buffer it raises an error.
This commit silent the errors.