### PR TITLE
Add macros to add and remove a project root from the whitelist

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -133,10 +133,15 @@ Optional arguments:
 
 `:initialize' is a function called when the client is intiailized. It takes a
  single argument, the newly created client."
-  (let ((enable (intern (format "%s-enable" name))))
-    `(defun ,enable ()
+   (let ((enable (intern (format "%s-enable" name))))
+    `(progn
+    (lsp-define-whitelist-enable ,name ,get-root)
+    (lsp-define-whitelist-disable ,name ,get-root)
+
+    (defun ,enable ()
        ,docstring
        (interactive)
+       (lsp-define-whitelist-disable ,name ,get-root)
        (let ((client (make-lsp--client
                        :language-id (if ,language-id-fn ,language-id-fn #'(lambda (_) ,language-id))
                        :send-sync #'lsp--stdio-send-sync
@@ -155,7 +160,7 @@ Optional arguments:
                (progn
                  (lsp-mode 1)
                  (lsp--start client ,extra-init-params))
-               (message "Not initializing project %s" root))))))))
+               (message "Not initializing project %s" root)))))))))
 
 (cl-defmacro lsp-define-tcp-client (name language-id get-root command host port
                                      &key docstring

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -79,6 +79,32 @@
                 "lsp-define-client: :ignore-regexps element %s is not a string"
                 e))))
 
+(cl-defmacro lsp-define-whitelist-enable (name get-root
+                                               &key docstring)
+  "Define a function to add the project root for the current buffer to the whitleist.
+NAME is the base name for the command.
+GET-ROOT is the language-specific function to determint the project root for the current buffer."
+  (let ((enable (intern (format "%s-whitelist-add" name))))
+    `(defun ,enable ()
+       ,docstring
+       (interactive)
+       (let ((root (funcall ,get-root)))
+         (customize-save-variable 'lsp-project-whitelist
+                                    (add-to-list 'lsp-project-whitelist root))))))
+
+(cl-defmacro lsp-define-whitelist-disable (name get-root
+                                               &key docstring)
+  "Define a function to remove the project root for the current buffer from the whitleist.
+NAME is the base name for the command.
+GET-ROOT is the language-specific function to determint the project root for the current buffer."
+  (let ((enable (intern (format "%s-whitelist-remove" name))))
+    `(defun ,enable ()
+       ,docstring
+       (interactive)
+       (let ((root (funcall ,get-root)))
+         (customize-save-variable 'lsp-project-whitelist
+                                  (remove root 'lsp-project-whitelist ))))))
+
 (cl-defmacro lsp-define-stdio-client (name language-id get-root command
                                        &key docstring
                                        language-id-fn


### PR DESCRIPTION
As an alternative to putting this in the enable function, as to my previous (ignored) PRs