### PR TITLE
Split the lsp-XXXX-enable into non-interactive and interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Clone this repository to a suitable path, and add
 ;;
 ;; This function will turn lsp-mode on and call the command given to
 ;; start the LSP server.
-(add-hook 'prog-major-mode #'lsp-prog-major-mode-enable)
+(add-hook 'prog-major-mode #'lsp-prog-major-mode-enable-hook)
 ```
 to your .emacs, where `prog-major-mode` is the hook variable for a supported
 programming language major mode.
@@ -92,3 +92,20 @@ to find the references to the symbol under point.
 
 ### Flycheck
 ![flycheck](./examples/flycheck.gif)
+
+## Finer Control of Starting lsp-mode
+
+In order to more finely control the `lsp-mode` startup, there are a number of
+customizable variables.
+
+`lsp-project-whitelist` : Defaults to `nil`. If set, `lsp-mode` will only be
+started if the given project root appears in the whitelist.
+
+`lsp-project-blacklist` : Defaults to `nil`. If set, all projects will be
+started except those in this list. It is ignored if `lsp-project-whitelist` is
+set.
+
+There are also the functions `lsp-MAJOR-MODE-whitelist-add` and
+`lsp-MAJOR-MODE-whitelist-remove` to adjust the current buffer project root
+entry on the whitelist.
+

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -482,12 +482,19 @@ registered client capabilities by calling
                      exit-str)
             (lsp--uninitialize-workspace)))))))
 
+(defvar lsp--project-whitelist-temp nil
+  "If a project is started manually and not added to the
+  whitelist, the root is stored here so other files belonging to
+  it will also be added to the session. This variable is not
+  saved, so only exists for the duration of the session.")
+
 (defun lsp--should-start-p (root)
   "Consult `lsp-project-blacklist' and `lsp-project-whitelist' to
 determine if a server should be started for the given ROOT
 directory."
   (if lsp-project-whitelist
-      (member root lsp-project-whitelist)
+      (or (member root lsp-project-whitelist)
+          (member root lsp--project-whitelist-temp))
     (not (member root lsp-project-blacklist))))
 
 (defun lsp--start (client &optional extra-init-params)


### PR DESCRIPTION
The non-interactive one gets called in the mode hook, and is quiet

The interactive one will ask to add a project to the whitelist if invoked to
start LSP for it and it would not otherwise start, if `lsp-enable-whitelist-ask'
is set.

Also add
  lsp-XXXX-whitelist-add
  lsp-XXXX-whitelist-remove