### PR TITLE
lsp-mode complains about "(wrong-number-of-arguments (1 . 2) 0)"

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -523,14 +523,13 @@ directory."
       (puthash root lsp--cur-workspace lsp--workspaces)
       (run-hooks 'lsp-before-initialize-hook)
       (setq init-params
-            (lsp--merge-plists
-             `(:processId ,(emacs-pid)
-                :rootPath ,root
-                :rootUri ,(concat "file://" root)
-                :capabilities ,(lsp--client-capabilities)
-                :initializationOptions ,(if (functionp extra-init-params)
-                                            (funcall extra-init-params lsp--cur-workspace)
-                                          extra-init-params))))
+            `(:processId ,(emacs-pid)
+                         :rootPath ,root
+                         :rootUri ,(concat "file://" root)
+                         :capabilities ,(lsp--client-capabilities)
+                         :initializationOptions ,(if (functionp extra-init-params)
+                                                     (funcall extra-init-params lsp--cur-workspace)
+                                                   extra-init-params)))
       (setf response (lsp--send-request
                       (lsp--make-request "initialize" init-params)))
       (unless response

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -196,8 +196,7 @@ Optional arguments:
 (define-minor-mode lsp-mode ""
   nil nil nil
   :lighter (:eval (lsp-mode-line))
-  :group 'lsp-mode
-  (lsp--start))
+  :group 'lsp-mode)
 
 (defconst lsp--sync-type
   `((0 . "None")


### PR DESCRIPTION
A recent commit attached a call to `(lsp--start)` to the lsp-mode's define-minor-mode call. Causes the following error while toggling the minor mode:

```
Debugger entered--Lisp error: (wrong-number-of-arguments (1 . 2) 0)
  lsp--start()
  lsp-mode(toggle)
  funcall-interactively(lsp-mode toggle)
  call-interactively(lsp-mode record nil)
  command-execute(lsp-mode record)
  execute-extended-command(nil "lsp-mode" "lsp-mode")
  funcall-interactively(execute-extended-command nil "lsp-mode" "lsp-mode")
  call-interactively(execute-extended-command nil nil)
  command-execute(execute-extended-command)
```

Also drops an unneeded call to `(lsp--merge-plists)` that I introduced with #181. It's not related, but it's really been bugging me (but doesn't seem worth an entire PR on its own)