### PR TITLE
Fix textDocument/references parameters

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1400,7 +1400,7 @@ A reference is highlighted only if it is visible in a window."
          (params (plist-get properties 'ref-params))
          (ref (lsp--send-request (lsp--make-request
                                   "textDocument/references"
-                                  params))))
+                                  (or params (lsp--make-reference-params))))))
     (if (consp ref)
         (mapcar 'lsp--location-to-xref ref)
       (and ref `(,(lsp--location-to-xref ref))))))


### PR DESCRIPTION
In case text properties aren't set, be sure to provide a position to
the server and send a valid request.
The Rust LS doesn't like receiving a empty param and it makes it exit
unexpectedly.

It reproduces the behavior of `xref-backend-definitions` on the PR #101 