### PR TITLE
Show reference'line with xref-find-references

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1149,7 +1149,6 @@ The function returns a list of `xref-item'."
          (fn (lambda (loc) (lsp--xref-make-item filename loc))))
     (if visiting
         (with-current-buffer visiting
-          (font-lock-ensure)
           (mapcar fn (cdr file)))
       (when (file-readable-p filename)
         (with-temp-buffer


### PR DESCRIPTION
Extract the line from the buffer visiting its file and show it in the
list of references with xref-find-references.

![xref](https://user-images.githubusercontent.com/5273820/33229545-0e22f8fe-d1d1-11e7-9659-cc2a89da55f5.jpg)

Old behavior:
![xref_old](https://user-images.githubusercontent.com/5273820/33229546-17294f98-d1d1-11e7-800d-0849e0fbeb7a.jpg)

