### PR TITLE
lsp--make-hover-callback: Allow `hover` being null

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1191,7 +1191,8 @@ type MarkedString = string | { language: string; value: string };"
 (defun lsp--make-hover-callback (renderers start end buffer)
   (lambda (hover)
     (setq lsp--cur-hover-request-id nil)
-    (when (and (lsp--point-is-within-bounds-p start end)
+    (when (and hover
+            (lsp--point-is-within-bounds-p start end)
             (eq (current-buffer) buffer) (eldoc-display-message-p))
       (let ((contents (gethash "contents" hover)))
         (eldoc-message


### PR DESCRIPTION
null is allowed as a response of textDocument/hover, and cquery may emit messages like {"jsonrpc":"2.0","id":93,"result":null}