### PR TITLE
Inhibit the window-show-message echo if lsp-inhibit-message is non-nil

### DIFF
--- a/lsp-notifications.el
+++ b/lsp-notifications.el
@@ -27,13 +27,9 @@
 (defun lsp--window-show-message (params)
   "Send the server's messages to message, inhibit if `lsp-inhibit-message'
 is set."
-  (let* ((prev-inhibit-message inhibit-message))
-    (when lsp-inhibit-message
-      (setq inhibit-message t))
+  (let* ((inhibit-message (or inhibit-message lsp-inhibit-message)))
     (message "%s" (lsp--propertize (gethash "message" params)
-                    (gethash "type" params)))
-    (when lsp-inhibit-message
-      (setq inhibit-message prev-inhibit-message))))
+                    (gethash "type" params)))))
 
 (defcustom lsp-after-diagnostics-hook nil
   "Hooks to run after diagnostics are received from the language

--- a/lsp-notifications.el
+++ b/lsp-notifications.el
@@ -19,9 +19,21 @@
 (require 'cl-lib)
 (require 'subr-x)
 
+(defcustom lsp-inhibit-message nil
+  "If non-nil, inhibit the message echo via `inhibit-message'."
+  :type 'boolean
+  :group 'lsp-mode)
+
 (defun lsp--window-show-message (params)
-  (message "%s" (lsp--propertize (gethash "message" params)
-                                 (gethash "type" params))))
+  "Send the server's messages to message, inhibit if `lsp-inhibit-message'
+is set."
+  (let* ((prev-inhibit-message inhibit-message))
+    (when lsp-inhibit-message
+      (setq inhibit-message t))
+    (message "%s" (lsp--propertize (gethash "message" params)
+                    (gethash "type" params)))
+    (when lsp-inhibit-message
+      (setq inhibit-message prev-inhibit-message))))
 
 (defcustom lsp-after-diagnostics-hook nil
   "Hooks to run after diagnostics are received from the language


### PR DESCRIPTION
I'm adding lsp-inhibit-message to inhibit LSP messages from getting echo'd if lsp-inhibit-message is non-nil.

Some language servers, like PHP, are really chatty with messages. The PHP language server sends a message every time a file is parsed. This can really add up on a big project that takes minutes to parse. With this flag, the messages are still sent to the *Messages* buffer, but they aren't echoed to the mode line, which is more sane.