### PR TITLE
[hover] Display the last MarkedString when there are multiple.

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1284,7 +1284,7 @@ export interface MarkupContent {
                                  (funcall renderer (gethash "value" e)))
                                (gethash "value" e))
                              e)))
-              (if (listp contents) contents (list contents)) "\n")))))))
+              (if (listp contents) (last contents) (list contents)) "\n")))))))
 
 (defun lsp-provide-marked-string-renderer (client language renderer)
   (cl-check-type language string)


### PR DESCRIPTION
        ;; We may receive multiple MarkedString's in the Hover response,
        ;; render the last one because others are likely comments which will
        ;; make the eldoc message span multiple lines.

For comments, @sebastiencs 's lsp-ui-doc.el should be preferred.

See https://github.com/emacs-lsp/lsp-ui/issues/19 for some demos.