### PR TITLE
Specify the connection type explicitly when creating a TCP connection.

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -57,6 +57,7 @@
         (error (format "Couldn't find executable %s" (nth 0 final-command))))
       (setq proc (make-process
                   :name name
+                  :connection-type 'pipe
                   :coding 'no-conversion
                   :command final-command
                   :sentinel sentinel


### PR DESCRIPTION
‘pipe’ is implied by ‘:stderr’, but it’s cleaner (and consistent with the stdio
equivalent) to specify it explicitly.