### PR TITLE
truncate response id

### DIFF
--- a/lsp-io.el
+++ b/lsp-io.el
@@ -211,6 +211,7 @@ Else it is queued (unless DONT-QUEUE is non-nil)"
     (pcase (lsp--get-message-type json-data)
       ('response
         (cl-assert id)
+        (setq id (truncate id))
         (setq callback (gethash id (lsp--client-response-handlers client) nil))
         (if callback
           (progn (funcall callback (gethash "result" json-data nil))


### PR DESCRIPTION
The [ResponseMessage](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md#response-message) `id` is either a `number`, a `string` or `null`, but since lsp-mode only sends `numbers`, we can assume it's a number. However, some servers ([cquery](https://github.com/jacobdufault/cquery)) respond with a floating point, even when they got an int on the request. I think this is conforming behaviour, as `number` can be a float, and `10.0 == 10`, but of course emacs hashing doesn't agree.

TL;DR: truncate ids recieved in `ResponseMessage`s before using them as indicies in the hashmap