### PR TITLE
Change project whitelist/blacklist checking logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,11 @@ to your init file to enable imenu integration.
 In order to more finely control the `lsp-mode` startup, there are a number of
 customizable variables.
 
-`lsp-project-whitelist` : Defaults to `nil`. If set, `lsp-mode` will only be
-started if the given project root appears in the whitelist.
+`lsp-project-whitelist` : Defaults to `nil`.
+`lsp-project-blacklist` : Defaults to `nil`.
 
-`lsp-project-blacklist` : Defaults to `nil`. If set, all projects will be
-started except those in this list. It is ignored if `lsp-project-whitelist` is
-set.
+`lsp-mode` will only be started if the given project root matches one pattern
+in the whitelist, or does not match any pattern in the blacklist.
 
 There are also the functions `lsp-MAJOR-MODE-whitelist-add` and
 `lsp-MAJOR-MODE-whitelist-remove` to adjust the current buffer project root

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -91,7 +91,7 @@
                                                &key docstring)
   "Define a function to add the project root for the current buffer to the whitleist.
 NAME is the base name for the command.
-GET-ROOT is the language-specific function to determint the project root for the current buffer."
+GET-ROOT is the language-specific function to determine the project root for the current buffer."
   (let ((whitelist-add      (intern (format "%s-whitelist-add" name)))
         (enable-interactive (intern (format "%s-enable" name))))
     `(defun ,whitelist-add ()
@@ -99,22 +99,22 @@ GET-ROOT is the language-specific function to determint the project root for the
        (interactive)
        (let ((root (funcall ,get-root)))
          (customize-save-variable 'lsp-project-whitelist
-                                  (add-to-list 'lsp-project-whitelist root))
+           (add-to-list 'lsp-project-whitelist (concat "^" (regexp-quote root) "$")))
          (,enable-interactive)
          ))))
 
 (cl-defmacro lsp-define-whitelist-disable (name get-root
-                                               &key docstring)
+                                            &key docstring)
   "Define a function to remove the project root for the current buffer from the whitleist.
 NAME is the base name for the command.
-GET-ROOT is the language-specific function to determint the project root for the current buffer."
+GET-ROOT is the language-specific function to determine the project root for the current buffer."
   (let ((whitelist-remove (intern (format "%s-whitelist-remove" name))))
     `(defun ,whitelist-remove ()
        ,docstring
        (interactive)
        (let ((root (funcall ,get-root)))
          (customize-save-variable 'lsp-project-whitelist
-                                  (remove root 'lsp-project-whitelist ))))))
+           (remove (concat "^" (regexp-quote root) "$") 'lsp-project-whitelist))))))
 
 (cl-defmacro lsp-define-stdio-client (name language-id get-root command
                                        &key docstring


### PR DESCRIPTION
`lsp-mode` will only be started if the given project root matches one pattern
in the whitelist, or does not match any pattern in the blacklist.

This is more flexible than the original "either whitelist or blacklist".

With this, people can have blanket `^/tmp/.*$` blacklist with a few exemptions 
