### PR TITLE
Set projectile-project-root

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -529,6 +529,7 @@ directory."
          (workspace (gethash root lsp--workspaces))
          new-conn response init-params
          parser proc cmd-proc)
+    (setq-local projectile-project-root root)
     (if workspace
         (setq lsp--cur-workspace workspace)
 


### PR DESCRIPTION
This is useful for projects extracted from an archive or others that do not have .git .hg .svn project root indicators.