### PR TITLE
Fix format-buffer #253

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1422,16 +1422,22 @@ If title is nil, return the name for the command handler."
   (interactive)
   (let ((edits (lsp--send-request (lsp--make-request
                                    "textDocument/formatting"
-                                   (lsp--make-document-formatting-params))))
-        (content (buffer-string))
-        (buffer (get-buffer-create " *lsp-formatting*")))
-    (replace-buffer-contents
-     (with-current-buffer buffer
-       (erase-buffer)
-       (insert content)
-       (lsp--apply-text-edits edits)
-       (current-buffer)))
-    (kill-buffer buffer)))
+                                   (lsp--make-document-formatting-params)))))
+    (if (fboundp 'replace-buffer-contents)
+        (let ((content (buffer-string))
+              (buffer (get-buffer-create " *lsp-formatting*")))
+          (unwind-protect
+              (replace-buffer-contents
+               (with-current-buffer buffer
+                 (erase-buffer)
+                 (insert content)
+                 (lsp--apply-text-edits edits)
+                 (current-buffer)))
+            (kill-buffer buffer)))
+      (let ((point (point)))
+        (lsp--apply-text-edits edits)
+        (goto-char point)
+        (goto-char (line-beginning-position))))))
 
 (defun lsp--make-document-range-formatting-params (start end)
   "Make DocumentRangeFormattingParams for selected region.

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1421,9 +1421,17 @@ If title is nil, return the name for the command handler."
   "Ask the server to format this document."
   (interactive)
   (let ((edits (lsp--send-request (lsp--make-request
-                                    "textDocument/formatting"
-                                    (lsp--make-document-formatting-params)))))
-    (save-excursion (lsp--apply-text-edits edits))))
+                                   "textDocument/formatting"
+                                   (lsp--make-document-formatting-params))))
+        (content (buffer-string))
+        (buffer (get-buffer-create " *lsp-formatting*")))
+    (replace-buffer-contents
+     (with-current-buffer buffer
+       (erase-buffer)
+       (insert content)
+       (lsp--apply-text-edits edits)
+       (current-buffer)))
+    (kill-buffer buffer)))
 
 (defun lsp--make-document-range-formatting-params (start end)
   "Make DocumentRangeFormattingParams for selected region.

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1434,10 +1434,12 @@ If title is nil, return the name for the command handler."
                  (lsp--apply-text-edits edits)
                  (current-buffer)))
             (kill-buffer buffer)))
-      (let ((point (point)))
+      (let ((point (point))
+            (w-start (window-start)))
         (lsp--apply-text-edits edits)
         (goto-char point)
-        (goto-char (line-beginning-position))))))
+        (goto-char (line-beginning-position))
+        (set-window-start (selected-window) w-start)))))
 
 (defun lsp--make-document-range-formatting-params (start end)
   "Make DocumentRangeFormattingParams for selected region.

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1424,13 +1424,13 @@ If title is nil, return the name for the command handler."
                                    "textDocument/formatting"
                                    (lsp--make-document-formatting-params)))))
     (if (fboundp 'replace-buffer-contents)
-        (let ((content (buffer-string))
-              (buffer (get-buffer-create " *lsp-formatting*")))
+        (let ((current-buffer (current-buffer))
+              (buffer (generate-new-buffer " *lsp-formatting*")))
           (unwind-protect
               (replace-buffer-contents
                (with-current-buffer buffer
                  (erase-buffer)
-                 (insert content)
+                 (insert-buffer-substring-no-properties current-buffer)
                  (lsp--apply-text-edits edits)
                  (current-buffer)))
             (kill-buffer buffer)))


### PR DESCRIPTION
While applying text changes to the buffer, the cursor position can
be lost with delete-region. See:
https://emacs.stackexchange.com/a/7577/15635

So we apply the changes in a temporary buffer and replace the content
of the current buffer with it using the function `replace-buffer-contents` which handle very well the modifications (cursor position, undo, ...).