### PR TITLE
Add :ignore-messages client option

### DIFF
--- a/lsp-io.el
+++ b/lsp-io.el
@@ -102,12 +102,15 @@
       'notification
       (signal 'lsp-unknown-message-type (list json-data)))))
 
+(defun lsp--default-message-handler (workspace params)
+  (lsp--window-show-message params workspace))
+
 (defconst lsp--default-notification-handlers
   #s(hash-table
      test equal
      data
-     ("window/showMessage" (lambda (_w params) (lsp--window-show-message params))
-      "window/logMessage" (lambda (_w params) (lsp--window-show-message params))
+     ("window/showMessage" lsp--default-message-handler
+      "window/logMessage" lsp--default-message-handler
       "textDocument/publishDiagnostics" (lambda (w p) (lsp--on-diagnostics p w))
       "textDocument/diagnosticsEnd" ignore
       "textDocument/diagnosticsBegin" ignore)))

--- a/lsp-io.el
+++ b/lsp-io.el
@@ -216,12 +216,15 @@
    (lsp--parser-body p) nil
    (lsp--parser-reading-body p) nil))
 
+(defun lsp--read-json (str)
+  (let* ((json-array-type 'list)
+         (json-object-type 'hash-table)
+         (json-false nil))
+    (json-read-from-string str)))
+
 (defun lsp--parser-on-message (p msg)
   "Called when the parser reads a complete message from the server."
-  (let* ((json-array-type 'list)
-          (json-object-type 'hash-table)
-          (json-false nil)
-          (json-data (json-read-from-string msg))
+  (let* ((json-data (lsp--read-json msg))
           (id (gethash "id" json-data nil))
           (client (lsp--workspace-client (lsp--parser-workspace p)))
           callback)

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -38,6 +38,7 @@
   (stderr nil :read-only t)
   (get-root nil :read-only t)
   (ignore-regexps nil :read-only t)
+  (ignore-messages nil :read-only t)
 
   (notification-handlers (make-hash-table :test 'equal) :read-only t)
   (request-handlers (make-hash-table :test 'equal) :read-only t)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -121,6 +121,7 @@ GET-ROOT is the language-specific function to determine the project root for the
                                        language-id-fn
                                        command-fn
                                        ignore-regexps
+                                       ignore-messages
                                        extra-init-params
                                        initialize)
   "Define a LSP client using stdio.
@@ -132,8 +133,14 @@ Optional arguments:
 `:docstring' is an optional docstring used for the entrypoint function created by
 `lsp-define-stdio-client'.
 
-`:ignore-regexps' is a list of regexps which when matched will be ignored by the
- output parser.
+`:ignore-regexps' is a list of regexps.  When a data packet from the LSP server
+ matches any of these regexps, it will be ignored.  This is intended for dealing
+ with LSP servers that output non-protocol data.
+
+`:ignore-messages' is a list of regexps.  When a message from the LSP server
+ matches any of these regexps, it will be ignored.  This is useful for filtering
+ out unwanted messages; such as servers that send nonstandard message types, or
+ extraneous `logMessage's.
 
 `:command-fn' is a function that returns the command string/list to be used to
  launch the language server. If non-nil, COMMAND is ignored.
@@ -168,7 +175,8 @@ Optional arguments:
                                             stderr)
                            :stderr stderr
                            :get-root ,get-root
-                           :ignore-regexps ,ignore-regexps)))
+                           :ignore-regexps ,ignore-regexps
+                           :ignore-messages ,ignore-messages)))
              ,(when initialize
                 `(funcall ,initialize client))
              (let ((root (funcall (lsp--client-get-root client))))
@@ -183,6 +191,7 @@ Optional arguments:
                                      language-id-fn
                                      command-fn
                                      ignore-regexps
+                                     ignore-messages
                                      extra-init-params
                                      initialize)
   "Define a LSP client using TCP.
@@ -192,8 +201,14 @@ the Language Server.  COMMAND is the command to run.  HOST is the
 host address.  PORT is the port number.
 
 Optional arguments:
-`:ignore-regexps' is a list of regexps which when matched will be ignored by the
- output parser.
+`:ignore-regexps' is a list of regexps.  When a data packet from the LSP server
+ matches any of these regexps, it will be ignored.  This is intended for dealing
+ with LSP servers that output non-protocol data.
+
+`:ignore-messages' is a list of regexps.  When a message from the LSP server
+ matches any of these regexps, it will be ignored.  This is useful for filtering
+ out unwanted messages; such as servers that send nonstandard message types, or
+ extraneous `logMessage's.
 
 `:command-fn' is a function that returns the command string/list to be used to
  launch the language server. If non-nil, COMMAND is ignored.
@@ -230,7 +245,8 @@ Optional arguments:
                                             stderr)
                            :stderr stderr
                            :get-root ,get-root
-                           :ignore-regexps ,ignore-regexps)))
+                           :ignore-regexps ,ignore-regexps
+                           :ignore-messages ,ignore-messages)))
              ,(when initialize
                 `(funcall ,initialize client))
              (let ((root (funcall (lsp--client-get-root client))))

--- a/lsp-notifications.el
+++ b/lsp-notifications.el
@@ -24,11 +24,16 @@
   :type 'boolean
   :group 'lsp-mode)
 
-(defun lsp--window-show-message (params)
-  "Send the server's messages to message, inhibit if `lsp-inhibit-message' is set."
-  (let* ((inhibit-message (or inhibit-message lsp-inhibit-message)))
-    (message "%s" (lsp--propertize (gethash "message" params)
-                    (gethash "type" params)))))
+(defun lsp--window-show-message (params &optional workspace)
+  "Send the server's messages to message, inhibit if `lsp-inhibit-message' is set,
+or the message matches one of this client's :ignore-messages"
+  (let* ((inhibit-message (or inhibit-message lsp-inhibit-message))
+         (message (gethash "message" params))
+         (client (lsp--workspace-client workspace)))
+    (when (or (not client)
+              (cl-notany (lambda (r) (string-match-p r message))
+                         (lsp--client-ignore-messages client)))
+      (message "%s" (lsp--propertize message (gethash "type" params))))))
 
 (defcustom lsp-after-diagnostics-hook nil
   "Hooks to run after diagnostics are received from the language


### PR DESCRIPTION
Adds an :ignore-messages option (akin to :ignore-regexps, but applied specifically to the text of messages to be shown to the user) as discussed in https://github.com/emacs-lsp/lsp-mode/pull/251