### PR TITLE
Handle some nil results better

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1618,9 +1618,9 @@ interface RenameParams {
   (lsp--cur-workspace-check)
   (unless (lsp--capability "renameProvider")
     (signal 'lsp-capability-not-supported (list "renameProvider")))
-  (let ((edits (lsp--send-request (lsp--make-request
-                                   "textDocument/rename"
-                                   (lsp--make-document-rename-params newname)))))
+  (when-let ((edits (lsp--send-request (lsp--make-request
+                                        "textDocument/rename"
+                                        (lsp--make-document-rename-params newname)))))
     (lsp--apply-workspace-edit edits)))
 
 (define-inline lsp--execute-command (command)

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1281,7 +1281,7 @@ export interface MarkupContent {
     (when (and hover
             (lsp--point-is-within-bounds-p start end)
             (eq (current-buffer) buffer) (eldoc-display-message-p))
-      (let ((contents (gethash "contents" hover)))
+      (when-let ((contents (gethash "contents" hover)))
         (eldoc-message
           ;; contents: MarkedString | MarkedString[] | MarkupContent
           (if (lsp--markup-content-p contents)


### PR DESCRIPTION
Fixes 2 places nils are being handled poorly:

 1. In the on-hover callback a nil result (representing an empty results list) triggers eldoc unnecessarily with an empty string. (Hard to say if this is actually user facing, but eldoc still seems to behave correctly with this fix so at the very least its cutting out a redundant function call)
 2. When using `lsp-rename`, errors aren't handled: They get sent back as nil values from `lsp--send-request` which then triggers an unrelated elisp error. Handling the nil allows the user a chance to see the actual error message.

Demonstrated on `emacs -Q` with current master:

Before:
![rename-bad](https://user-images.githubusercontent.com/1004194/35727057-c057e546-07bb-11e8-96e8-28322aca3329.gif)

After:
![rename-good](https://user-images.githubusercontent.com/1004194/35727056-c042e43e-07bb-11e8-8dd9-c749a31c8ff1.gif)

