### PR TITLE
Make tests work with ert-runner.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - cask install
 script:
   - cask build
-  - emacs -batch -l ert -L . -l test/lsp-mode-tests.el -l test/lsp-io-tests.el -l test/lsp-common-tests.el -f ert-run-tests-batch-and-exit
+  - emacs -batch -l ert -L . -l test/lsp-mode-test.el -l test/lsp-io-test.el -l test/lsp-common-test.el -f ert-run-tests-batch-and-exit
 
 notifications:
   webhooks:

--- a/Cask
+++ b/Cask
@@ -3,3 +3,7 @@
 (depends-on "flycheck")
 (package-file "lsp-mode.el")
 (files "*.el")
+
+(development
+ (depends-on "ert-runner")
+ (depends-on "f"))

--- a/test/lsp-common-test.el
+++ b/test/lsp-common-test.el
@@ -1,4 +1,4 @@
-;;; lsp-common-tests.el --- unit tests for lsp-io.el -*- lexical-binding: t -*-
+;;; lsp-common-test.el --- unit tests for lsp-io.el -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2017  Lukas Fuermetz <fuermetz@mailbox.org>.
 
@@ -32,5 +32,4 @@
   (let ((lsp--uri-file-prefix "file://"))
     (should (equal (lsp--uri-to-path "/root/%5E/%60") "/root/^/`"))))
 
-(provide 'lsp-common-tests)
-;;; lsp-common-tests.el ends here
+;;; lsp-common-test.el ends here

--- a/test/lsp-io-test.el
+++ b/test/lsp-io-test.el
@@ -1,4 +1,4 @@
-;;; lsp-io-tests.el --- unit tests for lsp-io.el -*- lexical-binding: t -*-
+;;; lsp-io-test.el --- unit tests for lsp-io.el -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2016-2017  Vibhav Pant <vibhavp@gmail.com>.
 
@@ -68,5 +68,4 @@
     (lsp--on-notification p (lsp--read-json "{\"jsonrpc\":\"2.0\",\"method\":\"window/logMessage\",\"params\":{\"type\":2,\"message\":\"Important message\"}}"))
     (should (equal log '("Important message")))))
 
-(provide 'lsp-io-tests)
-;;; lsp-io-tests.el ends here
+;;; lsp-io-test.el ends here

--- a/test/lsp-mode-test.el
+++ b/test/lsp-mode-test.el
@@ -1,0 +1,36 @@
+;;; lsp-mode-test.el --- unit tests for lsp-mode.el  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2017  Google Inc.
+
+;; Author: Philipp Stephani <phst@google.com>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Unit tests for lsp-mode.el.
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(require 'ert)
+
+(ert-deftest lsp-define-stdio-client ()
+  (lsp-define-stdio-client test-client "test language"
+                           (lambda () default-directory)
+                           '("/bin/false"))
+  (should (fboundp 'test-client-enable)))
+
+;;; lsp-mode-test.el ends here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,10 +1,8 @@
-;;; lsp-mode-tests.el --- unit tests for lsp-mode.el  -*- lexical-binding: t; -*-
+;;; test-helper.el --- Helpers for lsp-mode-test.el  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2017  Google Inc.
+;; Copyright (C) 2018  Google LLC <phst@google.com>
 
-;; Author: Philipp Stephani <phst@google.com>
-
-;; This program is free software; you can redistribute it and/or modify
+;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
@@ -19,18 +17,13 @@
 
 ;;; Commentary:
 
-;; Unit tests for lsp-mode.el.
+;; Initializes test support for ‘lsp-mode’.
 
 ;;; Code:
 
-(require 'lsp-mode)
+(require 'f)
 
-(require 'ert)
+(add-to-list 'load-path
+             (file-name-as-directory (f-parent (f-parent (f-this-file)))))
 
-(ert-deftest lsp-define-stdio-client ()
-  (lsp-define-stdio-client test-client "test language"
-                           (lambda () default-directory)
-                           '("/bin/false"))
-  (should (fboundp 'test-client-enable)))
-
-;;; lsp-mode-tests.el ends here
+;;; test-helper.el ends here


### PR DESCRIPTION
- Add necessary dependencies to Cask file.
- Rename test files to match the pattern expected by ert-runner.
- Add source directory to test helper.