### PR TITLE
Implement window/showMessageRequest

### DIFF
--- a/lsp-io.el
+++ b/lsp-io.el
@@ -140,6 +140,11 @@
           (dolist (reg (gethash "registrations" params))
             (lsp--server-register-capability reg))
           empty-response)
+        ("window/showMessageRequest"
+         (let ((choice (lsp--window-show-message-request params)))
+           (lsp--make-response (gethash "id" request)
+                               `(:title ,choice)
+                               nil)))
         ("client/unregisterCapability"
           (dolist (unreg (gethash "unregisterations" params))
             (lsp--server-unregister-capability unreg))

--- a/lsp-notifications.el
+++ b/lsp-notifications.el
@@ -35,6 +35,17 @@ or the message matches one of this client's :ignore-messages"
                          (lsp--client-ignore-messages client)))
       (message "%s" (lsp--propertize message (gethash "type" params))))))
 
+(defun lsp--window-show-message-request (params)
+  "Display a message request to the user and send the user's
+selection back to the server."
+  (let* ((type (gethash "type" params))
+         (message (lsp--propertize (gethash "message" params) type))
+         (choices (mapcar (lambda (choice) (gethash "title" choice))
+                          (gethash "actions" params))))
+    (if choices
+        (completing-read (concat message " ") choices nil t)
+      (message message))))
+
 (defcustom lsp-after-diagnostics-hook nil
   "Hooks to run after diagnostics are received from the language
 server and put in `lsp--diagnostics'."


### PR DESCRIPTION
Implements this [window/showMessageRequest](https://microsoft.github.io/language-server-protocol/specification#window_showMessageRequest) message type.

Currently I've only seen it actually used by [flow-language-server](https://github.com/flowtype/flow-language-server) (and even then, they seem to be abusing it by sending back 0 options)

Demo: (using a [dummy script](https://github.com/gpittarelli/emacs-lsp-acceptance-testing/blob/master/servers/dummy/showMessage.sh) as the server)

![showmessagerequest](https://user-images.githubusercontent.com/1004194/35791252-cd7ff23a-09fb-11e8-9fe2-4987271611b7.gif)
