### PR TITLE
Update link to spec in lsp--gethash's docstring

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1048,7 +1048,7 @@ DFLT defaults to nil.
 Needed for completion request fallback behavior for the fields
 'sortText', 'filterText', and 'insertText' as described here:
 
-https://microsoft.github.io/language-server-protocol/specification#completion-request-leftwards_arrow_with_hook"
+https://microsoft.github.io/language-server-protocol/specification#textDocument_completion"
 
   (let ((result (gethash key table dflt)))
     (when (member result '(nil "" 0 :json-false))

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1048,7 +1048,7 @@ DFLT defaults to nil.
 Needed for completion request fallback behavior for the fields
 'sortText', 'filterText', and 'insertText' as described here:
 
-https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#completion-request"
+https://microsoft.github.io/language-server-protocol/specification#completion-request-leftwards_arrow_with_hook"
 
   (let ((result (gethash key table dflt)))
     (when (member result '(nil "" 0 :json-false))


### PR DESCRIPTION
The current link now points to a shut down GitHub repo, so I've updated it to
 point to the site the old repo recommended.