### PR TITLE
The example from README.md is broken

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -155,7 +155,7 @@ Optional arguments:
 `:initialize' is a function called when the client is intiailized. It takes a
  single argument, the newly created client."
   (cl-check-type name symbol)
-  (macroexp-let2 nil get-root get-root
+  (macroexp-let2 (lambda (_) t) get-root get-root
     `(progn
        (lsp-define-whitelist-enable ,name ,get-root)
        (lsp-define-whitelist-disable ,name ,get-root)


### PR DESCRIPTION
Recently I got interested in [smarter/emacs-lsp-dotty](https://github.com/smarter/emacs-lsp-dotty) project so I've installed `lsp-mode` and tried setting up everything. But it wasn't working as expected. After some time I've figured out that even [example from your README.md](https://github.com/emacs-lsp/lsp-mode#installation) was not working properly.

I was getting `File mode specification error: (void-variable get-root)` in `*Messages*` buffer and language server was not started (the command to start the server was not executed)

This PR fixes the problem (not an ideal fix but works for me) - language server is started and works with flycheck.

I was not able to define a proper test for this because `*Messages*` buffer is always empty in test mode.

P. S. if I replace `(lambda (_) t)` with `functionp` it works for example from README.md but doesn't work when I am using `lsp-make-traverser` to make a function 