### PR TITLE
Fix lsp-xx-whitelist-remove

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -109,7 +109,7 @@ GET-ROOT is the language-specific function to determine the project root for the
          (,enable-interactive)
          ))))
 
-(cl-defmacro lsp-define-whitelist-remove(name get-root
+(cl-defmacro lsp-define-whitelist-remove (name get-root
                                             &key docstring)
   "Define a function to remove the project root for the current buffer from the whitleist.
 NAME is the base name for the command.
@@ -168,7 +168,7 @@ Optional arguments:
   (let ((enable-name (intern (format "%s-enable" name))))
     `(progn
        (lsp-define-whitelist-add ,name ,get-root)
-       (lsp-define-whitelist-remove,name ,get-root)
+       (lsp-define-whitelist-remove ,name ,get-root)
        (defun ,enable-name ()
          ,docstring
          (interactive)
@@ -264,7 +264,7 @@ Optional arguments:
   (let ((enable-name (intern (format "%s-enable" name))))
     `(progn
        (lsp-define-whitelist-add ,name ,get-root)
-       (lsp-define-whitelist-remove,name ,get-root)
+       (lsp-define-whitelist-remove ,name ,get-root)
        (defun ,enable-name ()
          ,docstring
          (interactive)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -105,7 +105,7 @@ GET-ROOT is the language-specific function to determine the project root for the
        (interactive)
        (let ((root (funcall ,get-root)))
          (customize-save-variable 'lsp-project-whitelist
-           (add-to-list 'lsp-project-whitelist (concat "^" (regexp-quote root) "$")))
+           (add-to-list 'lsp-project-whitelist (lsp--as-regex root)))
          (,enable-interactive)
          ))))
 
@@ -120,7 +120,11 @@ GET-ROOT is the language-specific function to determine the project root for the
        (interactive)
        (let ((root (funcall ,get-root)))
          (customize-save-variable 'lsp-project-whitelist
-           (remove (concat "^" (regexp-quote root) "$") 'lsp-project-whitelist))))))
+           (remove (lsp--as-regex root) lsp-project-whitelist))))))
+
+(defun lsp--as-regex (root)
+  "Convert the directory path in ROOT to an equivalent regex."
+  (concat "^" (regexp-quote root) "$"))
 
 (cl-defmacro lsp-define-stdio-client (name language-id get-root command
                                        &key docstring

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -93,7 +93,7 @@
                 "lsp-define-client: :ignore-regexps element %s is not a string"
                 e))))
 
-(cl-defmacro lsp-define-whitelist-enable (name get-root
+(cl-defmacro lsp-define-whitelist-add (name get-root
                                                &key docstring)
   "Define a function to add the project root for the current buffer to the whitleist.
 NAME is the base name for the command.
@@ -109,7 +109,7 @@ GET-ROOT is the language-specific function to determine the project root for the
          (,enable-interactive)
          ))))
 
-(cl-defmacro lsp-define-whitelist-disable (name get-root
+(cl-defmacro lsp-define-whitelist-remove(name get-root
                                             &key docstring)
   "Define a function to remove the project root for the current buffer from the whitleist.
 NAME is the base name for the command.
@@ -167,8 +167,8 @@ Optional arguments:
   (cl-check-type name symbol)
   (let ((enable-name (intern (format "%s-enable" name))))
     `(progn
-       (lsp-define-whitelist-enable ,name ,get-root)
-       (lsp-define-whitelist-disable ,name ,get-root)
+       (lsp-define-whitelist-add ,name ,get-root)
+       (lsp-define-whitelist-remove,name ,get-root)
        (defun ,enable-name ()
          ,docstring
          (interactive)
@@ -263,8 +263,8 @@ Optional arguments:
   (cl-check-type name symbol)
   (let ((enable-name (intern (format "%s-enable" name))))
     `(progn
-       (lsp-define-whitelist-enable ,name ,get-root)
-       (lsp-define-whitelist-disable ,name ,get-root)
+       (lsp-define-whitelist-add ,name ,get-root)
+       (lsp-define-whitelist-remove,name ,get-root)
        (defun ,enable-name ()
          ,docstring
          (interactive)

--- a/test/lsp-mode-test.el
+++ b/test/lsp-mode-test.el
@@ -43,4 +43,25 @@
   (with-temp-buffer
     (test-tcp-client-enable)))
 
+(ert-deftest lsp-define-whitelist ()
+  (lsp-define-stdio-client test-stdio-client "test language"
+                           (lambda () "/tmp/baz/")
+                           '("/bin/false"))
+  (should (fboundp 'test-stdio-client-whitelist-add))
+  (should (fboundp 'test-stdio-client-whitelist-remove))
+  (should (not lsp-project-whitelist))
+  (with-temp-buffer
+    (test-stdio-client-whitelist-add)
+    (should (equal lsp-project-whitelist '("^/tmp/baz/$") ))
+    ;; Should not add a duplicate
+    (test-stdio-client-whitelist-add)
+    (should (equal lsp-project-whitelist '("^/tmp/baz/$") ))
+    ;; testing remove
+    (customize-save-variable 'lsp-project-whitelist
+           (add-to-list 'lsp-project-whitelist (concat "^" (regexp-quote "/tmp/foo") "$")))
+    (should (equal lsp-project-whitelist '("^/tmp/foo$" "^/tmp/baz/$") ))
+    (test-stdio-client-whitelist-remove)
+    (should (equal lsp-project-whitelist '("^/tmp/foo$") ))
+    ))
+
 ;;; lsp-mode-test.el ends here

--- a/test/lsp-mode-test.el
+++ b/test/lsp-mode-test.el
@@ -58,7 +58,7 @@
     (should (equal lsp-project-whitelist '("^/tmp/baz/$") ))
     ;; testing remove
     (customize-save-variable 'lsp-project-whitelist
-           (add-to-list 'lsp-project-whitelist (concat "^" (regexp-quote "/tmp/foo") "$")))
+           (add-to-list 'lsp-project-whitelist (lsp--as-regex "/tmp/foo")))
     (should (equal lsp-project-whitelist '("^/tmp/foo$" "^/tmp/baz/$") ))
     (test-stdio-client-whitelist-remove)
     (should (equal lsp-project-whitelist '("^/tmp/foo$") ))

--- a/test/lsp-mode-test.el
+++ b/test/lsp-mode-test.el
@@ -62,6 +62,9 @@
     (should (equal lsp-project-whitelist '("^/tmp/foo$" "^/tmp/baz/$") ))
     (test-stdio-client-whitelist-remove)
     (should (equal lsp-project-whitelist '("^/tmp/foo$") ))
+    ;; Should be idempotent
+    (test-stdio-client-whitelist-remove)
+    (should (equal lsp-project-whitelist '("^/tmp/foo$") ))
     ))
 
 ;;; lsp-mode-test.el ends here


### PR DESCRIPTION
Previously it used the quoted form `'lsp-project-whitelist` instead of `lsp-project-whitelist` so did not update the actual value.