### PR TITLE
Make symbol highlighting looks good on dark themes.

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -327,19 +327,22 @@ before saving a document."
 
 ;;;###autoload
 (defface lsp-face-highlight-textual
-  '((t :background "yellow"))
+  '((((background dark))  :background "saddle brown")
+    (((background light)) :background "yellow"))
   "Face used for textual occurances of symbols."
   :group 'lsp-faces)
 
 ;;;###autoload
 (defface lsp-face-highlight-read
-  '((t :background "red"))
+  '((((background dark))  :background "firebrick")
+    (((background light)) :background "red"))
   "Face used for highlighting symbols being read."
   :group 'lsp-faces)
 
 ;;;###autoload
 (defface lsp-face-highlight-write
-  '((t :background "green"))
+  '((((background dark))  :background "sea green")
+     (((background light)) :background "green"))
   "Face used for highlighting symbols being written to."
   :group 'lsp-faces)
 


### PR DESCRIPTION
The highlighting faces' background is decided by the theme's background, thus makes it looks good on both light and dark themes.

![lsp-face-dark](https://user-images.githubusercontent.com/28714352/37239305-1cfd3a2e-2474-11e8-829d-42751ff755d7.png)

![lsp-face-light](https://user-images.githubusercontent.com/28714352/37239309-244d2460-2474-11e8-97af-b372e3911715.png)
