### PR TITLE
Provide option different modes to plugin uri<->path conversion

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -468,7 +468,7 @@ interface TextDocumentItem {
 }"
   (inline-quote
     (let ((language-id-fn (lsp--client-language-id (lsp--workspace-client lsp--cur-workspace))))
-      (list :uri (lsp--path-to-uri buffer-file-name)
+      (list :uri (lsp--buffer-uri)
 	      :languageId (funcall language-id-fn (current-buffer))
 	      :version (lsp--cur-file-version)
 	      :text (buffer-substring-no-properties (point-min) (point-max))))))
@@ -840,7 +840,7 @@ directory."
 interface TextDocumentIdentifier {
     uri: string;
 }"
-  (inline-quote (list :uri (lsp--path-to-uri buffer-file-name))))
+  (inline-quote (list :uri (lsp--buffer-uri))))
 
 (define-inline lsp--versioned-text-document-identifier ()
   "Make VersionedTextDocumentIdentifier.

--- a/test/lsp-common-test.el
+++ b/test/lsp-common-test.el
@@ -33,4 +33,8 @@
   (let ((lsp--uri-file-prefix "file://"))
     (should (equal (lsp--uri-to-path "/root/%5E/%60") "/root/^/`"))))
 
+(ert-deftest lsp-common--path-to-uri-custom-schemes ()
+  (lsp-register-uri-handler "custom" (lambda (_) "file-path"))
+  (should (equal (lsp--uri-to-path "custom://file-path") "file-path")))
+
 ;;; lsp-common-test.el ends here


### PR DESCRIPTION
https://github.com/emacs-lsp/lsp-java/issues/18

When the user looks for Definition/implementation/reference that is not part of the
current project source code the JDT server returns URI prefixed with jdt: and
then it has a separate call which retrieves the source. After this change, different modes will be able to register a URI resolver.