### PR TITLE
Deal a bit better with dead processes

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -499,7 +499,7 @@ disappearing, unset all the variables related to it."
         (root (lsp--workspace-root lsp--cur-workspace)))
     (with-current-buffer (current-buffer)
       (setq proc (lsp--workspace-proc lsp--cur-workspace))
-      (unless (eq (process-status proc) 'exit)
+      (if (process-live-p proc)
         (kill-process (lsp--workspace-proc lsp--cur-workspace)))
       (setq lsp--cur-workspace nil)
       (lsp--unset-variables)
@@ -1175,10 +1175,11 @@ Added to `after-change-functions'."
                 (delq (current-buffer) old-buffers))
 
           (remhash buffer-file-name file-versions)
-          (lsp--send-notification
-           (lsp--make-notification
-            "textDocument/didClose"
-            `(:textDocument ,(lsp--versioned-text-document-identifier))))
+          (with-demoted-errors "Error sending didClose notification in ‘lsp--text-document-did-close’: %S"
+            (lsp--send-notification
+             (lsp--make-notification
+              "textDocument/didClose"
+              `(:textDocument ,(lsp--versioned-text-document-identifier)))))
           (when (= 0 (hash-table-count file-versions))
             (lsp--shutdown-cur-workspace)))))))
 


### PR DESCRIPTION
This should make lsp-restart-workspace work when the server process is already dead, e.g. because it has crashed or because the user has killed it. Previously an error was thrown while trying to shut down the dead server; now at least one can recover from this situation by restarting the server.