### PR TITLE
File notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - cask install
 script:
   - cask build
-  - cask exec ert-runner
+  - cask exec ert-runner -t "!no-win"
 
 notifications:
   webhooks:

--- a/lsp-common.el
+++ b/lsp-common.el
@@ -19,6 +19,8 @@
 (require 'url-util)
 (require 'url-parse)
 (require 'subr-x)
+(require 'filenotify)
+(require 'cl)
 
 (defconst lsp--message-type-face
   `((1 . ,compilation-error-face)
@@ -118,6 +120,62 @@ If no such directory could be found, log a warning and return `default-directory
   (inline-quote
     (concat lsp--uri-file-prefix
       (url-hexify-string (file-truename ,path) url-path-allowed-chars))))
+
+(defun lsp--string-match-any (regex-list str)
+  "Given a list of REGEX-LIST and STR return the first matching regex if any."
+  (find-if (lambda (regex) (string-match regex str)) regex-list))
+
+(defun lsp-create-watch (dir file-regexp-list callback &optional watches root-dir)
+  "Create recursive file notificaton watch in DIR monitoring FILE-REGEXP-LIST.
+CALLBACK is the will be called when there are changes in any of
+the monitored files. WATCHES is a hash table directory->file
+notification handle which contains all of the watches that
+already have been created. "
+  (let ((all-dirs (thread-last
+                    (directory-files-recursively dir ".*" t)
+                    (seq-filter (lambda (f) (file-directory-p f)))
+                    (list* dir)))
+         (watches (or watches (make-hash-table :test 'equal)))
+         (root-dir (or root-dir dir)))
+    (seq-do
+      (lambda (dir-to-watch)
+        (puthash
+          dir-to-watch
+          (file-notify-add-watch
+            dir-to-watch
+            '(change)
+            (lambda (event)
+              (let ((file-name (caddr event))
+                    (event-type (cadr event)))
+                (cond
+                 ((and (file-directory-p file-name)
+                    (equal 'created event-type))
+
+                   (lsp-create-watch file-name file-regexp-list callback watches root-dir)
+
+                   ;; process the files that are already present in
+                   ;; the directory.
+                   (thread-last
+                     (directory-files-recursively file-name ".*" t)
+                     (seq-do (lambda (f)
+                               (when (and (lsp--string-match-any file-regexp-list
+                                            (file-relative-name f root-dir))
+                                       (not (file-directory-p f)))
+                                 (funcall callback (list nil 'created f)))))))
+                 ((and (not (file-directory-p file-name))
+                    (lsp--string-match-any file-regexp-list
+                      (file-relative-name file-name root-dir)))
+                   (funcall callback event))))))
+          watches))
+      all-dirs)
+    watches))
+
+(defun lsp-kill-watch (watches)
+  "Delete WATCHES."
+  (maphash
+    (lambda (_dir watch)
+      (file-notify-rm-watch watch))
+    watches))
 
 (provide 'lsp-common)
 ;;; lsp-common.el ends here

--- a/lsp-common.el
+++ b/lsp-common.el
@@ -158,13 +158,15 @@ already have been created. "
                    (thread-last
                      (directory-files-recursively file-name ".*" t)
                      (seq-do (lambda (f)
-                               (when (and (lsp--string-match-any file-regexp-list
-                                            (file-relative-name f root-dir))
+                               (when (and (lsp--string-match-any
+                                           file-regexp-list
+                                           (concat "/" (file-relative-name f root-dir)))
                                        (not (file-directory-p f)))
                                  (funcall callback (list nil 'created f)))))))
                  ((and (not (file-directory-p file-name))
-                    (lsp--string-match-any file-regexp-list
-                      (file-relative-name file-name root-dir)))
+                       (lsp--string-match-any
+                        file-regexp-list
+                        (concat "/" (file-relative-name file-name root-dir))))
                    (funcall callback event))))))
           watches))
       all-dirs)

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -22,8 +22,12 @@
 (require 'lsp-common)
 (require 'pcase)
 (require 'inline)
+(require 'em-glob)
 
-;;; Code:
+(defconst lsp--file-change-type
+  `((created . 1)
+     (changed . 2)
+     (deleted . 3)))
 
 ;; A ‘lsp--client’ object describes the client-side behavior of a language
 ;; server.  It is used to start individual server processes, each of which is
@@ -209,9 +213,14 @@
   (extra-client-capabilities nil)
 
   ;; Workspace status
-  (status nil))
+  (status nil)
+
+  ;; contains all the file notification watches that have been created for the
+  ;; current workspace in format filePath->file notification handle.
+  (watches (make-hash-table :test 'equal)))
 
 (defvar-local lsp--cur-workspace nil)
+
 (defvar lsp--workspaces (make-hash-table :test #'equal)
   "Table of known workspaces, indexed by the project root directory.")
 
@@ -519,6 +528,8 @@ interface TextDocumentItem {
 (defun lsp--uninitialize-workspace ()
   "When a workspace is shut down, by request or from just
 disappearing, unset all the variables related to it."
+  (lsp-kill-watch (lsp--workspace-watches lsp--cur-workspace))
+
   (let (proc
         (root (lsp--workspace-root lsp--cur-workspace)))
     (with-current-buffer (current-buffer)
@@ -2021,6 +2032,31 @@ command COMMAND and optionsl ARGS"
   (lsp--send-notification (lsp--make-notification
                            "workspace/didChangeConfiguration"
                            `(:settings , settings))))
+
+(defun lsp-workspace-register-watch (to-watch &optional workspace)
+  "Monitor for file change and trigger workspace/didChangeConfiguration.
+
+TO-WATCH is a list of the directories and regexp in the following format:
+'((root-dir1 (glob-pattern1 glob-pattern2))
+  (root-dir2 (glob-pattern3 glob-pattern4)))
+
+If WORKSPACE is not specified the `lsp--cur-workspace' will be used."
+  (setq workspace (or workspace lsp--cur-workspace))
+  (let ((watches (lsp--workspace-watches workspace)))
+    (cl-loop for (dir glob-patterns) in to-watch do
+      (lsp-create-watch
+        dir
+        (mapcar 'eshell-glob-regexp glob-patterns)
+        (lambda (event)
+          (let ((lsp--cur-workspace workspace))
+            (lsp-send-notification
+              (lsp-make-notification
+                "workspace/didChangeWatchedFiles"
+                (list :changes
+                  (list
+                    :type (alist-get (cadr event) lsp--file-change-type)
+                    :uri (lsp--path-to-uri (caddr event))))))))
+        watches))))
 
 (declare-function lsp-mode "lsp-mode" (&optional arg))
 

--- a/test/lsp-file-watch-test.el
+++ b/test/lsp-file-watch-test.el
@@ -147,7 +147,7 @@
 
 (ert-deftest lsp-file-watch--relative-path-glob-patterns ()
   (let* ((temp-directory (file-name-as-directory
-                          (concat (temporary-file-directory) "common-test-dir")))
+                           (concat temporary-file-directory "common-test-dir")))
           (matching-file (concat temp-directory "file.ext"))
           (nested-dir (file-name-as-directory
                         (concat temp-directory "nested")))

--- a/test/lsp-file-watch-test.el
+++ b/test/lsp-file-watch-test.el
@@ -1,0 +1,153 @@
+;;; lsp-file-watch.el --- File notifications tests   -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2018  Ivan Yonchovski
+
+;; Author: Ivan <kyoncho@myoncho>
+;; Keywords:
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; Tests for file notifications functions.
+
+;;; Code:
+(require 'lsp-mode)
+(require 'filenotify)
+(require 'lsp-common)
+(require 'em-glob)
+
+(ert-deftest lsp-file-watch--notifications ()
+  :tags '(no-win)
+  (let* ((temp-directory (file-name-as-directory
+                           (concat temporary-file-directory "common-test-dir")))
+          (matching-file (concat temp-directory "file.ext"))
+          (nested-dir (file-name-as-directory
+                        (concat temp-directory "nested")))
+          (nested-matching-file (concat nested-dir "file.ext"))
+          (create-lockfiles nil)
+         events watch expected-events)
+
+    (when (file-exists-p temp-directory)
+      (delete-directory temp-directory t))
+    (mkdir temp-directory)
+    (mkdir nested-dir)
+
+    (setq watch (lsp-create-watch
+                  temp-directory
+                  (list (eshell-glob-regexp "*.ext"))
+                  (lambda (event)
+                    (message "received: %s" event)
+                    (add-to-list 'events (cdr event)))))
+
+    (write-region "bla" nil matching-file)
+
+    (sit-for 0.2)
+    ;; created/changed events
+    (setq expected-events `((changed ,matching-file)
+                             (created ,matching-file)))
+    (should (equal events expected-events))
+
+    ;; create file that doesn't match the regexp
+    (write-region "bla" nil (concat temp-directory "file.ex"))
+    (should (equal expected-events events))
+
+    ;; not interested in directories
+    (mkdir (concat temp-directory "dirname.ext"))
+    (sit-for 0.1)
+
+    ;; not changed
+    (should (equal expected-events events))
+
+    (write-region "bla" nil nested-matching-file)
+    (sit-for 0.1)
+
+    (add-to-list 'expected-events (list 'created nested-matching-file))
+    (add-to-list 'expected-events (list 'changed nested-matching-file))
+
+    (should (equal expected-events events))
+    (let* ((nested-dir2 (file-name-as-directory
+                          (concat temp-directory "nested2")))
+           (nested-matching-file2 (concat nested-dir2 "newNestedFile.ext")))
+
+      (mkdir nested-dir2)
+      (write-region "bla" nil nested-matching-file2)
+      (write-region "bla1" nil (concat nested-matching-file2 "not-matching"))
+
+      (sit-for 0.1)
+
+      (add-to-list 'expected-events (list 'created nested-matching-file2))
+
+      (should (equal expected-events events))
+      (write-region "bla2" nil nested-matching-file2)
+
+      (add-to-list 'expected-events (list 'changed nested-matching-file2))
+
+      (sit-for 0.1)
+      (should (equal expected-events events)))
+
+    (should (equal expected-events events))
+
+    ;; delete directory
+    (delete-directory nested-dir t)
+
+    (sit-for 0.1)
+    (add-to-list 'expected-events (list 'deleted nested-matching-file))
+    (should (equal expected-events events))
+
+    (lsp-kill-watch watch)
+
+    ;; create directory and then create a file
+    ;; no updates after change
+    (write-region "bla1" nil matching-file)
+    (sit-for 0.1)
+
+    (should (equal expected-events events))))
+
+(ert-deftest lsp-file-watch--relative-path ()
+  :tags '(no-win)
+  (let* ((temp-directory (file-name-as-directory
+                           (concat temporary-file-directory "common-test-dir")))
+          (matching-file (concat temp-directory "file.ext"))
+          (nested-dir (file-name-as-directory
+                        (concat temp-directory "nested")))
+          (nested-matching-file (concat nested-dir "file.ext"))
+         events watch expected-events)
+
+    (when (file-exists-p temp-directory)
+      (delete-directory temp-directory t))
+    (mkdir temp-directory)
+    (mkdir nested-dir)
+
+    (setq watch (lsp-create-watch
+                  temp-directory
+                  (list (eshell-glob-regexp "file.ext"))
+                  (lambda (event)
+                    (message "received: %s" event)
+                    (add-to-list 'events (cdr event)))))
+
+    (write-region "bla" nil matching-file)
+    (sit-for 0.1)
+
+    (add-to-list 'expected-events (list 'created matching-file))
+    (add-to-list 'expected-events (list 'changed matching-file))
+
+    (should (equal expected-events events))))
+
+(ert-deftest lsp-file-watch--glob-pattern ()
+  (should (string-match (eshell-glob-regexp "pom.xml") "pom.xml"))
+  (should (string-match (eshell-glob-regexp "**/*.xml") "data/pom.xml"))
+  (should (not (string-match (eshell-glob-regexp "**/*.xml") "pom.xml"))))
+
+(provide 'lsp-file-watch-test)
+;;; lsp-file-watch-test.el ends here

--- a/test/lsp-file-watch-test.el
+++ b/test/lsp-file-watch-test.el
@@ -146,6 +146,7 @@
     (lsp-kill-watch watch)))
 
 (ert-deftest lsp-file-watch--relative-path-glob-patterns ()
+  :tags '(no-win)
   (let* ((temp-directory (file-name-as-directory
                            (concat temporary-file-directory "common-test-dir")))
           (matching-file (concat temp-directory "file.ext"))


### PR DESCRIPTION
Fixes #331

- implemented facilities for handling file notifications

Example ussage:

(lsp-workspace-register-watch
 '(("/full/path/to/project/"
    ("**/*.java"
     "**/pom.xml"
     "**/*.gradle"
     "**/.project"
     "**/.classpath"
     "**/settings/*.prefs"))))

- I had a problems with running the tests with ert and on travis since the file
  notification are handled only when emacs is running in interactive
  mode (accept-process-output didn't work at all) and ert does not support
  running tests in that mode(the output is lost). Unfortunatelly the emacs
  instances that are running on travis are not compiled with file notification
  library and the tests cannot run on travis.
  The summary is that the tests for file notifications functions are disabled in
  travis but can be run locally if you have emacs compiled with file
  notification library with the following command:

  cast exect ert-runner -t no-win --no-win

- I haven't implemented the handling DidChangeWatchedFilesRegistrationOptions
  since the LSP server that I am using for testing (jdt) is not sending these
  notifications but instead the vscode-java plugin have predefined set of
  files (similar to the one in the example). Adding such handler is trivial once
  we have the functions for recursive file notifications.