### PR TITLE
Remove 2 spaces setting from editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,4 +8,3 @@ insert_final_newline = true
 
 [*.el]
 indent_style = space
-indent_size = 2


### PR DESCRIPTION
The 2 spaces setting in the editor config was causing incorrect formatting of
some of the blocks e. g.:

```
(let ((a b)
       (d c)))
```
... instead of
```
(let ((a b)
      (d c)))
```