### PR TITLE
Show function signature on hover instead of full help.

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1505,7 +1505,7 @@ Returns xref-item(s)."
     (when (and (lsp--capability "codeActionProvider") lsp-enable-codeaction)
       (lsp--text-document-code-action))
     (when lsp-enable-eldoc
-      (lsp--text-document-hover-string))))
+      (lsp--text-document-signature-help))))
 
 (defvar-local lsp--cur-hover-request-id nil)
 


### PR DESCRIPTION
Fixes https://github.com/emacs-lsp/lsp-mode/issues/235. I guess this is premature since we are waiting for discussion/consensus, but IMO Eldoc is clearly the wrong tool for displaying full help pages, and the current behavior is just not useful. (At least it is not useful in Python or R, the two languages I use most often.) I'm submitting this PR in an attempt to move this issue toward a solution, even if we're not ready to merge it yet.