### PR TITLE
document/onHover improvements

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -26,8 +26,10 @@
 
 (defconst lsp--file-change-type
   `((created . 1)
-     (changed . 2)
-     (deleted . 3)))
+    (changed . 2)
+    (deleted . 3)))
+
+(defconst lsp-default-renderer-language "DEFAULT")
 
 ;; A ‘lsp--client’ object describes the client-side behavior of a language
 ;; server.  It is used to start individual server processes, each of which is
@@ -218,7 +220,7 @@
   ;; ‘metadata’ is a generic storage for workspace specific data. It is
   ;; accessed via `lsp-workspace-set-metadata' and `lsp-workspace-set-metadata'
   (metadata (make-hash-table :test 'equal))
-              
+
   ;; contains all the file notification watches that have been created for the
   ;; current workspace in format filePath->file notification handle.
   (watches (make-hash-table :test 'equal)))
@@ -311,6 +313,14 @@ whitelist, or does not match any pattern in the blacklist."
 ;;;###autoload
 (defcustom lsp-enable-eldoc t
   "Enable `eldoc-mode' integration."
+  :type 'boolean
+  :group 'lsp-mode)
+
+;;;###autoload
+(defcustom lsp-eldoc-render-all t
+  "Define whether all of the returned by document/onHover will be displayed.
+
+If `lsp-markup-display-all' is set to nil `eldoc' will show only the first element."
   :type 'boolean
   :group 'lsp-mode)
 
@@ -1529,6 +1539,24 @@ Returns xref-item(s)."
     (when lsp-enable-eldoc
       (funcall lsp-hover-text-function))))
 
+(defun lsp-describe-thing-at-point ()
+  "Display the full documentation of the thing at point."
+  (interactive)
+  (lsp--cur-workspace-check)
+  (let* ((client (lsp--workspace-client lsp--cur-workspace))
+         (renderers (lsp--client-string-renderers client))
+         (contents (gethash "contents" (lsp--send-request
+                                        (lsp--make-request "textDocument/hover"
+                                                           (lsp--text-document-position-params))))))
+    (pop-to-buffer
+     (with-current-buffer (get-buffer-create "*lsp-help*")
+       (let ((inhibit-read-only t))
+         (erase-buffer)
+         (insert (lsp--render-on-hover-content contents renderers t))
+         (goto-char (point-min))
+         (view-mode t)
+         (current-buffer))))))
+
 (defvar-local lsp--cur-hover-request-id nil)
 
 (defun lsp--text-document-hover-string ()
@@ -1553,6 +1581,14 @@ type MarkedString = string | { language: string; value: string };"
         lsp--cur-hover-request-id (plist-get body :id))
       (cl-assert (integerp lsp--cur-hover-request-id)))))
 
+(defun lsp--render-markup-content-1 (kind content)
+  (if (functionp lsp-render-markdown-markup-content)
+    (let ((out (funcall lsp-render-markdown-markup-content kind content)))
+      (cl-assert (stringp out) t
+        "value returned by lsp-render-markdown-markup-content should be a string")
+      out)
+    content))
+
 (defun lsp--render-markup-content (content)
   "Render MarkupContent object CONTENT.
 
@@ -1561,15 +1597,8 @@ export interface MarkupContent {
         value: string;
 }"
   (let ((kind (gethash "kind" content))
-         (content (gethash "value" content))
-         out)
-    (if (functionp lsp-render-markdown-markup-content)
-      (progn
-        (setq out (funcall lsp-render-markdown-markup-content kind content))
-        (cl-assert (stringp out) t
-          "value returned by lsp-render-markdown-markup-content should be a string")
-        out)
-      content)))
+        (content (gethash "value" content)))
+    (lsp--render-markup-content-1 kind content)))
 
 (define-inline lsp--point-is-within-bounds-p (start end)
   "Return whether the current point is within START and END."
@@ -1582,33 +1611,58 @@ export interface MarkupContent {
     (inline-quote (and (hash-table-p ,obj)
                     (gethash "kind" ,obj nil) (gethash "value" ,obj nil)))))
 
+(defun lsp--render-on-hover-content (contents renderers render-all)
+  "Render the content received from 'document/onHover' request.
+
+RENDERERS - client renderers to use.
+CONTENTS  - MarkedString | MarkedString[] | MarkupContent
+RENDER-ALL if set to nil render only the first element from CONTENTS."
+  (string-join
+   (mapcar
+    (lambda (e)
+      (let (renderer)
+        (cond
+         ;; hash table, language renderer set
+         ((and (hash-table-p e)
+               (setq renderer (cdr (assoc-string
+                                    (gethash "language" e lsp-default-renderer-language)
+                                    renderers))))
+          (when (gethash "value" e nil)
+            (funcall renderer (gethash "value" e))))
+
+         ;; hash table - workspace renderer not set
+         ;; trying to render using global renderer
+         ((lsp--markup-content-p e) (lsp--render-markup-content e))
+
+         ;; hash table - anything other has failed
+         ((hash-table-p e) (gethash "value" e nil))
+
+         ;; string, default workspace renderer set
+         ((setq renderer (cdr (assoc-string lsp-default-renderer-language renderers)))
+          (funcall renderer e))
+
+         ;; no rendering
+         (t e))))
+    (if (listp contents)
+        (if render-all
+            contents
+          (list (car contents)))
+      (list contents)))
+   "\n"))
+
 ;; start and end are the bounds of the symbol at point
 (defun lsp--make-hover-callback (renderers start end buffer)
   (lambda (hover)
     (with-current-buffer buffer
       (setq lsp--cur-hover-request-id nil))
     (when (and hover
-            (lsp--point-is-within-bounds-p start end)
-            (eq (current-buffer) buffer) (eldoc-display-message-p))
+               (lsp--point-is-within-bounds-p start end)
+               (eq (current-buffer) buffer) (eldoc-display-message-p))
       (let ((contents (gethash "contents" hover)))
         (when contents
-          (eldoc-message
-           ;; contents: MarkedString | MarkedString[] | MarkupContent
-           (if (lsp--markup-content-p contents)
-               (lsp--render-markup-content hover)
-
-             (mapconcat (lambda (e)
-                          (let (renderer)
-                            (if (hash-table-p e)
-                                (if (setq renderer
-                                          (cdr (assoc-string
-                                                (gethash "language" e)
-                                                renderers)))
-                                    (when (gethash "value" e nil)
-                                      (funcall renderer (gethash "value" e)))
-                                  (gethash "value" e))
-                              e)))
-                        (if (listp contents) contents (list contents)) "\n"))))))))
+          (eldoc-message (lsp--render-on-hover-content contents
+                                                       renderers
+                                                       lsp-eldoc-render-all)))))))
 
 (defun lsp-provide-marked-string-renderer (client language renderer)
   (cl-check-type language string)
@@ -1744,7 +1798,8 @@ Optionally, CALLBACK is a function that accepts a single argument, the code lens
         #'(lambda (lenses)
             (with-current-buffer buf
               (setq lsp-code-lenses lenses)
-              (funcall callback lenses)))))))
+              (when callback
+                (funcall callback lenses))))))))
 
 (defun lsp--make-document-formatting-options ()
   (let ((json-false :json-false))

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -320,7 +320,8 @@ whitelist, or does not match any pattern in the blacklist."
 (defcustom lsp-eldoc-render-all t
   "Define whether all of the returned by document/onHover will be displayed.
 
-If `lsp-markup-display-all' is set to nil `eldoc' will show only the first element."
+If `lsp-markup-display-all' is set to nil `eldoc' will show only
+the symbol information."
   :type 'boolean
   :group 'lsp-mode)
 

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -29,7 +29,7 @@
     (changed . 2)
     (deleted . 3)))
 
-(defconst lsp-default-renderer-language "DEFAULT")
+(defconst lsp-default-renderer-language "__default__renderer__language")
 
 ;; A ‘lsp--client’ object describes the client-side behavior of a language
 ;; server.  It is used to start individual server processes, each of which is


### PR DESCRIPTION
1. Added option(lsp-eldoc-render-all) to display only the first message from the list retrieved from
the server.
2. Added option to specify default client renderer via
lsp-default-renderer-language.
3. Added function to display help on demand(lsp-describe-thing-at-point)