### PR TITLE
Check CAPS argument type in lsp-register-client-capabilities

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -704,7 +704,7 @@ entry, the value is set to the one that registers later.  Default
 leaf capability entries can not be overwritten."
   (lsp--cur-workspace-check)
   (cl-check-type package-name symbolp)
-  (cl-check-type package-name (or list function))
+  (cl-check-type caps (or list function))
   (let ((extra-client-capabilities
           (lsp--workspace-extra-client-capabilities lsp--cur-workspace)))
     (if (alist-get package-name extra-client-capabilities)


### PR DESCRIPTION
whether it is either list or function.

Relevant commit: https://github.com/emacs-lsp/lsp-mode/commit/d9e31de8a8e43fe39d2e14b96b90bd809a26ab8a