### PR TITLE
Make sure lsp--capability never errors

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1064,7 +1064,7 @@ interface TextDocumentEdit {
 
 (define-inline lsp--capability (cap &optional capabilities)
   "Get the value of capability CAP.  If CAPABILITIES is non-nil, use them instead."
-  (inline-quote (gethash ,cap (or ,capabilities (lsp--server-capabilities)))))
+  (inline-quote (gethash ,cap (or ,capabilities (lsp--server-capabilities) (make-hash-table)))))
 
 (defvar-local lsp--before-change-vals nil
   "Store the positions from the `lsp-before-change' function


### PR DESCRIPTION
There are lots of code that call (lsp--capability) assuming the server is ready, thus not providing a default capabilities hash table, but that's not always the case for slow servers like JS/TS/Flow. If those (lsp-langserver-enable) are used as major mode hooks, and if lsp-ui is enabled, lots of code like [lsp-ui-sideline](https://github.com/emacs-lsp/lsp-ui/blob/master/lsp-ui-sideline.el#L400) will make a request to the language server as soon as the major mode is on but before the server is ready, in which case (get-hash) will be given a nil instead of a hash table, and errors out. This PR fixes it.