### PR TITLE
Fix indices for sync-methods

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -353,9 +353,9 @@ If WORKSPACE is not specified defaults to lsp--cur-workspace."
 
 (defconst lsp--capabilities
   `(("textDocumentSync" . ("Document sync method" .
-                           ((1 . "None")
-                            (2 . "Send full contents")
-                            (3 . "Send incremental changes."))))
+                           ((0 . "None")
+                            (1 . "Send full contents")
+                            (2 . "Send incremental changes."))))
     ("hoverProvider" . ("The server provides hover support" . boolean))
     ("completionProvider" . ("The server provides completion support" . boolean))
     ("signatureHelpProvider" . ("The server provides signature help support" . boolean))


### PR DESCRIPTION
Maybe I'm missing something, but shouldn't the indices match with the ones defined as constant?