### PR TITLE
Fix defcustom for lsp-hover-text-function

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -355,9 +355,9 @@ before saving a document."
 (defcustom lsp-hover-text-function 'lsp--text-document-hover-string
   "The LSP method to use to display text on hover."
   :type '(choice (function :tag "textDocument/hover"
-                           'lsp--text-document-hover-string)
+                           lsp--text-document-hover-string)
                  (function :tag "textDocument/signatureHelp"
-                           'lsp--text-document-signature-help))
+                           lsp--text-document-signature-help))
   :group 'lsp-mode)
 
 ;;;###autoload


### PR DESCRIPTION
I noticed the customize variable for `lsp-hover-text-function` didn't work if you tried to change it via the menu. Comparing to some `defcustom` of function values in the emacs tree ([example](https://github.com/emacs-mirror/emacs/blob/973d10a34b23f2ce5acc00a90ec9767e6237fefa/lisp/gnus/gnus-dired.el#L67-L84)) we shouldn't quote the functions in the option structure (the entire :type arg is already quoted, so we're effectively double quoting them)
