### PR TITLE
Fixed #400 .

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1878,13 +1878,13 @@ Optionally, CALLBACK is a function that accepts a single argument, the code lens
                                    "textDocument/formatting"
                                    (lsp--make-document-formatting-params)))))
     (if (fboundp 'replace-buffer-contents)
-        (let ((current-buffer (current-buffer)))
-          (with-temp-buffer
+        (let* ((current-buffer (current-buffer))
+               (temp-buffer (get-buffer-create "*lsp-format*")))
+          (with-current-buffer temp-buffer
             (insert-buffer-substring-no-properties current-buffer)
             (lsp--apply-text-edits edits)
-            (let ((temp-buffer (current-buffer)))
-              (with-current-buffer current-buffer
-                (replace-buffer-contents temp-buffer)))))
+            (copy-to-buffer current-buffer (point-min) (point-max))
+            (kill-buffer temp-buffer)))
       (let ((point (point))
             (w-start (window-start)))
         (lsp--apply-text-edits edits)

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1877,20 +1877,12 @@ Optionally, CALLBACK is a function that accepts a single argument, the code lens
   (let ((edits (lsp--send-request (lsp--make-request
                                    "textDocument/formatting"
                                    (lsp--make-document-formatting-params)))))
-    (if (fboundp 'replace-buffer-contents)
-        (let* ((current-buffer (current-buffer))
-               (temp-buffer (get-buffer-create "*lsp-format*")))
-          (with-current-buffer temp-buffer
-            (insert-buffer-substring-no-properties current-buffer)
-            (lsp--apply-text-edits edits)
-            (copy-to-buffer current-buffer (point-min) (point-max))
-            (kill-buffer temp-buffer)))
-      (let ((point (point))
-            (w-start (window-start)))
-        (lsp--apply-text-edits edits)
-        (goto-char point)
-        (goto-char (line-beginning-position))
-        (set-window-start (selected-window) w-start)))))
+    (let ((point (point))
+          (w-start (window-start)))
+      (lsp--apply-text-edits edits)
+      (goto-char point)
+      (goto-char (line-beginning-position))
+      (set-window-start (selected-window) w-start))))
 
 (defun lsp--make-document-range-formatting-params (start end)
   "Make DocumentRangeFormattingParams for selected region.


### PR DESCRIPTION
This fixed #400 .

In #400 

```elisp
(if (fboundp 'replace-buffer-contents)
    (let ((current-buffer (current-buffer)))
      (with-temp-buffer
        (insert "'''你好啊你好啊'''\ndef hello():\n    pass")
        (let ((temp-buffer (current-buffer)))
          (with-current-buffer current-buffer
            (replace-buffer-contents temp-buffer))))))
```

get 

```
'''你好啊你好啊'''
def hello():def hello
```

which isn't a correct answer.

In my fixing, 

```elisp
(if (fboundp 'replace-buffer-contents)
    (let* ((current-buffer (current-buffer))
           (temp-buffer (get-buffer-create "*lsp-format*")))
      (with-current-buffer temp-buffer
        (insert "'''你好啊你好啊'''\ndef hello():\n    pass")
        (copy-to-buffer current-buffer (point-min) (point-max))
        (kill-buffer temp-buffer))))
```

will get the answer

```
'''你好啊你好啊'''
def hello():
    pass
```

which is the excepted one.