### PR TITLE
Add option to keep the diagnostics if there is no open buffer

### DIFF
--- a/lsp-notifications.el
+++ b/lsp-notifications.el
@@ -24,6 +24,11 @@
   :type 'boolean
   :group 'lsp-mode)
 
+(defcustom lsp-report-if-no-buffer t
+  "If non nil the errors will be reported even when the file is not open."
+  :type 'boolean
+  :group 'lsp-mode)
+
 (defun lsp--window-show-message (params &optional workspace)
   "Send the server's messages to message, inhibit if `lsp-inhibit-message' is set,
 or the message matches one of this client's :ignore-messages"
@@ -106,8 +111,11 @@ interface PublishDiagnosticsParams {
                           when (lsp--equal-files (buffer-file-name buffer) file)
                           return buffer
                           finally return nil))
+
+    (when (or lsp-report-if-no-buffer buffer)
+      (puthash file (mapcar #'lsp--make-diag diagnostics) lsp--diagnostics))
+
     (when buffer
-      (puthash file (mapcar #'lsp--make-diag diagnostics) lsp--diagnostics)
       (with-current-buffer buffer
         (run-hooks 'lsp-after-diagnostics-hook)))))
 


### PR DESCRIPTION
- Whithout this CL you won't be able to check the errors on project level.