### PR TITLE
Highlight active parameter with face eldoc-highlight-function-argument

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1757,13 +1757,15 @@ type MarkupKind = 'plaintext' | 'markdown';"
     (when (and signature-help
                (lsp--point-is-within-bounds-p start end)
                (eq (current-buffer) buffer) (eldoc-display-message-p))
-      (let* ((active-signature-number
-              (or (gethash "activeSignature" signature-help) 0))
-             (active-signature (nth
-                                active-signature-number
-                                (gethash "signatures" signature-help))))
-        (when active-signature
-          (eldoc-message (gethash "label" active-signature)))))))
+      (when-let* ((sig-i (gethash "activeSignature" signature-help))
+                  (sig (seq-elt (gethash "signatures" signature-help) sig-i)))
+        (if-let* ((param-i (gethash "activeParameter" signature-help))
+                  (param (gethash "label" (seq-elt (gethash "parameters" sig) param-i)))
+                  (parts (split-string (gethash "label" sig) param)))
+            (eldoc-message (concat (car parts)
+                            (propertize param 'face 'eldoc-highlight-function-argument)
+                            (string-join (cdr parts) param)))
+         (eldoc-message (gethash "label" sig)))))))
 
 ;; NOTE: the code actions cannot currently be applied. There is some non-GNU
 ;; code to do this in the lsp-haskell module. We still need a GNU version, here.


### PR DESCRIPTION
```cpp
int foo(int a, int b, int c = 7) {
  return a+ b + c;
}

int main() {
  foo(1, 2<point>, 3);
}
```

In ccls, this was rendered as `foo(int a, int b, int c = 7) -> int` before, and now `foo(int a, <strong>int b</strong>, int c = 7) -> int`.

Similar approaches are used by

LanguageClient-neovim src/languageclient.rs

eglot (but it trims the signature label `  (propertize (replace-regexp-in-string "(.*$" "(" label)` which will remove `-> return_type`)