### PR TITLE
Fix performance issue related to using lsp--equal-files

### DIFF
--- a/lsp-imenu.el
+++ b/lsp-imenu.el
@@ -111,14 +111,13 @@ SYM can be either DocumentSymbol or SymbolInformation."
 
 (defun lsp--symbol-filter (sym)
   "Determine if SYM is for the current document."
-  (if-let ((location (gethash "location" sym)))
-      ;; It's a SymbolInformation
-      (not
-       (lsp--equal-files
-        (lsp--uri-to-path (gethash "uri" (gethash "location" sym)))
-        (buffer-file-name)))
-    ;; It's a DocumentSymbol, which is always in the current buffer file.
-    nil))
+  ;; It's a SymbolInformation or DocumentSymbol, which is always in the current
+  ;; buffer file.
+  (when-let (location (gethash "location" sym))
+    (not
+     (equal
+      (find-buffer-visiting (lsp--uri-to-path (gethash "uri" (gethash "location" sym))))
+      (current-buffer)))))
 
 (defun lsp--get-symbol-type (sym)
   "The string name of the kind of SYM."

--- a/lsp-imenu.el
+++ b/lsp-imenu.el
@@ -115,7 +115,7 @@ SYM can be either DocumentSymbol or SymbolInformation."
   ;; buffer file.
   (when-let (location (gethash "location" sym))
     (not
-     (equal
+     (eq
       (find-buffer-visiting (lsp--uri-to-path (gethash "uri" (gethash "location" sym))))
       (current-buffer)))))
 

--- a/lsp-notifications.el
+++ b/lsp-notifications.el
@@ -95,22 +95,15 @@ server and put in `lsp--diagnostics'."
      :message (if source (format "%s: %s" source message) message)
      :original diag)))
 
-(defun lsp--equal-files (f1 f2)
-  (and f1 f2
-       (string-equal (file-truename f1) (file-truename f2))))
-
 (defun lsp--on-diagnostics (params workspace)
   "Callback for textDocument/publishDiagnostics.
 interface PublishDiagnosticsParams {
     uri: string;
     diagnostics: Diagnostic[];
 }"
-  (let ((file (lsp--uri-to-path (gethash "uri" params)))
-        (diagnostics (gethash "diagnostics" params)) buffer)
-    (setq buffer (cl-loop for buffer in (lsp--workspace-buffers workspace)
-                          when (lsp--equal-files (buffer-file-name buffer) file)
-                          return buffer
-                          finally return nil))
+  (let* ((file (lsp--uri-to-path (gethash "uri" params)))
+         (diagnostics (gethash "diagnostics" params))
+         (buffer (find-buffer-visiting file)))
 
     (when (or lsp-report-if-no-buffer buffer)
       (puthash file (mapcar #'lsp--make-diag diagnostics) lsp--diagnostics))


### PR DESCRIPTION
- I did performance testing I noticed that 25%(!) of the time is spent in
lsp--equal-files.

``` emacs-lisp
(with-current-buffer "PoolSubpage.java"
  (let ((file (lsp--uri-to-path (gethash "uri" params))))
    (message "Perf = %s" (benchmark-run 100 (find-buffer-visiting file)))
    (message "Perf = %s"(benchmark-run 100
       (cl-loop for buffer in (lsp--workspace-buffers lsp--cur-workspace)
                when (lsp--equal-files (buffer-file-name buffer) file)
                return buffer
                finally return nil)))))
```
Results in:
```
Perf = (0.073634171 0 0.0)
Perf = (4.673262101 1 0.3096860720000052)
```