### PR TITLE
Support CodeAction return value in lsp-execute-code-action

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -1848,11 +1848,12 @@ If ACTION is not set it will be selected from `lsp-code-actions'."
   (interactive (list
                 (lsp--select-action (lsp-get-or-calculate-code-actions))))
   (lsp--cur-workspace-check)
-  (let* ((command (gethash "command" action))
-         (action-handler (gethash command
-                                  (lsp--client-action-handlers
-                                   (lsp--workspace-client lsp--cur-workspace)))))
-    (if action-handler
+  (when-let ((edit (gethash "edit" action)))
+    (lsp--apply-workspace-edit edit))
+  (when-let ((command (gethash "command" action)))
+    (if-let ((action-handler (gethash command
+                                      (lsp--client-action-handlers
+                                       (lsp--workspace-client lsp--cur-workspace)))))
         (funcall action-handler action)
       (lsp--execute-command action))))
 


### PR DESCRIPTION
`textDocument/codeAction` returns `(Command | CodeAction)[] | null`

This patch applies `edit?: WorkspaceEdit;` if exists (which is an extra field CodeAction has, comparing with Command)

ccls now returns `CodeAction[]` for clang FixIts. Example:

* `void main() {}`
* `M-x lsp-execute-code-action` and select the action
* `int main() {}`