### PR TITLE
Refactor lsp--start

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -222,10 +222,7 @@ Optional arguments:
                     :use-native-json use-native-json)))
       (when initialize-fn
         (funcall initialize-fn client))
-      (let ((root (funcall (lsp--client-get-root client))))
-        (if (lsp--should-start-p root)
-            (lsp--start client extra-init-params)
-          (message "Not initializing project %s" root))))))
+      (lsp--start client extra-init-params))))
 
 (cl-defmacro lsp-define-tcp-client (name language-id get-root command host port
                                      &key docstring
@@ -338,10 +335,7 @@ Optional arguments:
                     :use-native-json use-native-json)))
       (when initialize-fn
         (funcall initialize-fn client))
-      (let ((root (funcall (lsp--client-get-root client))))
-        (if (lsp--should-start-p root)
-            (lsp--start client extra-init-params)
-          (message "Not initializing project %s" root))))))
+      (lsp--start client extra-init-params))))
 
 (defvar-local lsp-status nil
   "The current status of the LSP server.")


### PR DESCRIPTION
* Deduplicate lsp--enable-tcp-client and lsp--enable-stdio-client
* Allow :get-root to be nil
* Root is now: (or (when root-fn (funcall root-fn))
                   (lsp--suggest-project-root))
  That is, :get-root in lsp-* adapters is used to override projectile/project roots.
  But most adapters can leave :get-root unspecified to get a sensible value from projectile/project.
  If root is nil (you probably need (setq projectile-require-root t)), the adapter will not initialize the workspace.

* Don't suggest default-directory in lsp--suggest-project-root.
  Use (or (lsp--suggest-project-root) default-directory) instead in workspaceFolders