### PR TITLE
Set default-directory before make-process

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -38,10 +38,11 @@
   :lighter (:eval (lsp-mode-line))
   :group 'lsp-mode)
 
-(defun lsp--make-stdio-connection (name command command-fn stderr)
+(defun lsp--make-stdio-connection (name command command-fn get-root-fn stderr)
   (lambda (filter sentinel)
     (let* ((command (if command-fn (funcall command-fn) command))
-           (final-command (if (consp command) command (list command))))
+           (final-command (if (consp command) command (list command)))
+           (default-directory (if get-root-fn (funcall get-root-fn) default-directory)))
       (unless (executable-find (nth 0 final-command))
         (error (format "Couldn't find executable %s" (nth 0 final-command))))
       (let ((proc (make-process
@@ -212,6 +213,7 @@ Optional arguments:
                                      (symbol-name name)
                                      command
                                      command-fn
+                                     root-directory-fn
                                      stderr)
                     :stderr stderr
                     :get-root root-directory-fn


### PR DESCRIPTION
Shadow the global default-directory with a local let binding before calling `make-process` in order to start the subprocess in the commands `get-root` directory.

Motivation: the change was required in order to get lsp-haskell to work
