### PR TITLE
Multi LSP Server support

### DIFF
--- a/README-NEXT.md
+++ b/README-NEXT.md
@@ -1,0 +1,133 @@
+Emacs Language Server Client
+=========
+
+[![Join the chat at https://gitter.im/emacs-lsp/lsp-mode](https://badges.gitter.im/emacs-lsp/lsp-mode.svg)](https://gitter.im/emacs-lsp/lsp-mode?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+[![Build Status](https://travis-ci.org/emacs-lsp/lsp-mode.svg?branch=master)](https://travis-ci.org/emacs-lsp/lsp-mode)
+[![MELPA Stable](https://stable.melpa.org/packages/lsp-mode-badge.svg)](https://stable.melpa.org/#/lsp-mode)
+[![MELPA](http://melpa.org/packages/lsp-mode-badge.svg)](http://melpa.org/#/lsp-mode)
+
+Client for [Language Server Protocol](https://github.com/Microsoft/language-server-protocol/) (v3.0). [lsp-mode](https://github.com/emacs-lsp/lsp-mode) aims to provide IDE-like experience by providing optional integration with the most popular Emacs packages like `company`, `flycheck` and `projectile`.
+
+* As you type reporting of parsing and compilation errors (via [flycheck](https://github.com/flycheck/flycheck)/[lsp-ui](https://github.com/emacs-lsp/lsp-ui))
+* Code completion - using [company-lsp](https://github.com/tigersoldier/company-lsp) or builtin ```complete-at-point```
+* Hovers - using [lsp-ui](https://github.com/emacs-lsp/lsp-ui)
+* Code actions - using [lsp-ui](https://github.com/emacs-lsp/lsp-ui)
+* Code outline - using builtin [imenu](https://www.gnu.org/software/emacs/manual/html_node/emacs/Imenu.html)
+* Code navigation - using builtin [xref](https://www.gnu.org/software/emacs/manual/html_node/emacs/Xref.html)
+* Code lens (references/implementations) - using builtin [xref](https://www.gnu.org/software/emacs/manual/html_node/emacs/Xref.html)
+* Highlights
+* Code formatting
+* Visual debugger - [dap-mode](https://github.com/yyoncho/dap-mode/)
+
+## Installation
+
+### Install via melpa
+The recommended way to install `lsp-mode` is via `package.el` - the built-in package manager in Emacs. `lsp-mode` is available on the two major `package.el` community maintained repos - [MELPA Stable](http://stable.melpa.org) and [MELPA](http://melpa.org).
+
+### Spacemacs
+[lsp-mode](https://github.com/emacs-lsp/lsp-mode) is included in spacemacs. Add `lsp` to `dotspacemacs-configuration-layers` and configure the language that you want to use to be backed by `lsp` backend.
+
+<kbd>M-x</kbd> `package-install` <kbd>[RET]</kbd> `lsp-mode` <kbd>[RET]</kbd>
+
+## Configuration
+Add the following line in your configuration file where `programming-mode-hook` stands for the language specific hook like `python-mode-hook`.  In addition, `lsp-mode` will automatically detect and configure [lsp-ui](https://github.com/emacs-lsp/lsp-ui) and [company-lsp](https://github.com/tigersoldier/company-lsp). To turn off that behaviour you could set `lsp-auto-configure` to `nil`.
+``` emacs-lisp
+(require 'lsp)
+(add-hook 'programming-mode-hook 'lsp)
+```
+
+## Supported languages
+Some of the servers are directly supported by `lsp-mode` by requiring
+`lsp-clients.el` while other require isntalling additional package which provide
+server specific functionality.
+
+| Language           | Extension                                                                    |
+|--------------------|------------------------------------------------------------------------------|
+| Bash               | [Built-in](https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-clients.el) |
+| C (ccls)           | [emacs-ccls](https://github.com/MaskRay/emacs-ccls)                          |
+| C (clangd)         | [lsp-clangd](https://github.com/emacs-lsp/lsp-clangd)                        |
+| C (cquery)         | [emacs-cquery](https://github.com/cquery-project/emacs-cquery)               |
+| CSS                | [Built-in](https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-clients.el) |
+| Go                 | [Built-in](https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-clients.el) |
+| Groovy             | [Built-in](https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-clients.el) |
+| HTML               | [Built-in](https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-clients.el) |
+| Haskell            | [lsp-haskell](https://github.com/emacs-lsp/lsp-haskell)                      |
+| Java (Eclipse JDT) | [lsp-java](https://github.com/emacs-lsp/lsp-java)                            |
+| Javascript         | [lsp-javascript](https://github.com/emacs-lsp/lsp-javascript)                |
+| OCaml              | [lsp-ocaml](https://github.com/emacs-lsp/lsp-ocaml)                          |
+| PHP                | [lsp-php](https://github.com/emacs-lsp/lsp-php)                              |
+| Python             | [Built-in](https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-clients.el) |
+| Ruby               | [lsp-ruby](https://github.com/emacs-lsp/lsp-ruby)                            |
+| Rust               | [lsp-rust](https://github.com/emacs-lsp/lsp-rust)                            |
+| Scala              | [lsp-scala](https://github.com/rossabaker/lsp-scala)                         |
+| Vue                | [lsp-vue](https://github.com/emacs-lsp/lsp-vue)                              |
+## Examples
+
+### Completion
+Completion is provided with the native `completion-at-point` (<kbd>C</kbd>-<kbd>M</kbd>-<kbd>i</kbd>),
+and should therefore work with any other completion backend. Async completion is provided by
+[company-lsp](https://github.com/tigersoldier/company-lsp).
+
+![completion](./examples/completion.png)
+
+### `eldoc` (Help on hover)
+Hover support is provided with `eldoc`, which should be enabled automatically.
+
+![eldoc](./examples/eldoc.png)
+
+### Goto definition
+Use <kbd>M</kbd> - <kbd>.</kbd> (`xref-find-definition`)
+to find the definition for the symbol under point.
+
+![gotodef](./examples/goto-def.gif)
+
+### Symbol references
+Use <kbd>M</kbd> - <kbd>?</kbd> (`xref-find-references`)
+to find the references to the symbol under point.
+
+![ref](./examples/references.png)
+
+### Symbol Highlighting
+![sym_highlight](./examples/sym_highlight.gif)
+
+### Imenu
+Add
+```emacs-lisp
+(add-hook 'lsp-after-open-hook 'lsp-enable-imenu)
+```
+to your init file to enable imenu integration.
+
+![imenu-1](./examples/imenu-1.png)
+![imenu-2](./examples/imenu-2.png)
+
+#### With [helm-imenu](https://github.com/emacs-helm/helm)
+![helm-imenu](./examples/helm-imenu.gif)
+
+### Rename
+Use <kbd>M</kbd> - <kbd>x</kbd> `lsp-rename`.
+
+![rename](./examples/rename.gif)
+
+### Hooks
+
+`lsp-mode` provides a handful of hooks that can be used to extend and configure
+the behaviour of language servers. A full list of hooks is available in the
+[API documentation](./doc/API.org).
+
+## Adding support for languages
+See [API docs](./doc/API.org)
+
+Here it is the minimal configuration that is needed for new language server
+registation. Refer to the documentation of `lsp--client` for the additional
+settings supported on registration time.
+``` emacs-lisp
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection "pyls")
+                  :major-modes '(python-mode)
+                  :server-id 'pyls))
+```
+
+### See also
+[`dap-mode`](https://github.com/yyoncho/dap-mode) - Debugger integration for
+[`eglot`](https://github.com/joaotavora/eglot) - An alternative and lighter LSP implementation.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The library is designed to integrate with existing Emacs IDE frameworks
 
 _Note: Starting from version 4.0, flycheck support has been moved to the package [lsp-ui](https://github.com/emacs-lsp/lsp-ui)_
 
+_Note: Refer to [lsp-mode NEXT](./README-NEXT.md) for `lsp-mode` single entry point.
+
 ## Installation
 
 Clone this repository to a suitable path, and add

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -1,0 +1,203 @@
+;;; lsp.el --- LSP mode                              -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2018 Ivan Yonchovski
+
+;; Author: Ivan Yonchovski <ivan.yonchovski@tick42.com>
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Contains definitions for the simple clients.
+
+;;; Code:
+
+(require 'lsp)
+
+
+;; Python
+(defcustom lsp-clients-python-library-directories '("/usr/")
+  "List of directories which will be considered to be libraries."
+  :group 'lsp-python
+  :risky t
+  :type '(repeat string))
+
+;;; pyls
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection "pyls")
+                  :major-modes '(python-mode)
+                  :server-id 'pyls
+                  :library-folders-fn (lambda (_workspace)
+                                        lsp-clients-python-library-directories)))
+
+;;; CSS
+(defun lsp-clients-css--apply-code-action (action)
+  "Apply ACTION as workspace edit command."
+  (lsp--apply-text-edits (caddr (gethash "arguments" action))))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection '("css-langageserver" "--stdio"))
+                  :major-modes '(css-mode java-mode)
+                  :action-handlers (lsp-ht ("_css.applyCodeAction" 'lsp-clients-css--apply-code-action))
+                  :server-id 'css-ls))
+
+;;; Bash
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection '("bash-language-server" "start"))
+                  :major-modes '(sh-mode)
+                  :server-id 'bash-ls))
+
+;;; Groovy
+(defcustom lsp-groovy-server-install-dir
+  (locate-user-emacs-file "groovy-language-server/")
+  "Install directory for groovy-language-server.
+A slash is expected at the end.
+This directory shoud contain a file matching groovy-language-server-*.jar"
+  :group 'lsp-groovy
+  :risky t
+  :type 'directory)
+
+(defun lsp-groovy--lsp-command ()
+  "Generate LSP startup command."
+  `("java"
+    "-cp" ,(concat (file-truename lsp-groovy-server-install-dir) "*")
+    "com.palantir.ls.groovy.GroovyLanguageServer"))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection 'lsp-groovy--lsp-command)
+                  :major-modes '(groovy-mode)
+                  :server-id 'groovy-ls))
+
+;;; HTML
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection '("html-languageserver" "--stdio"))
+                  :major-modes '(html-mode sgml-mode mhtml-mode web-mode)
+                  :server-id 'html-ls))
+
+;;; Typescript
+(defcustom lsp-clients-typescript-server "typescript-language-server"
+  "The typescript-language-server executable to use.
+Leave as just the executable name to use the default behavior of
+finding the executable with `exec-path'."
+  :group 'lsp-typescript
+  :risky t
+  :type 'file)
+
+(defcustom lsp-clients-typescript-server-args '()
+  "Extra arguments for the typescript-language-server language server."
+  :group 'lsp-typescript
+  :risky t
+  :type '(repeat string))
+
+(defun lsp-typescript--ls-command ()
+  "Generate the language server startup command."
+  `(,lsp-clients-typescript-server
+    "--stdio"
+    ,@lsp-clients-typescript-server-args))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection '("typescript-language-server" "--stdio"))
+                  :major-modes '(typescript-mode js-mode)
+                  :server-id 'ts-ls))
+
+
+;;; GO language
+
+(defcustom lsp-clients-go-server "go-langageserver"
+  "The go-langageserver executable to use."
+  :group 'lsp-go
+  :risky t
+  :type 'file)
+
+(defcustom lsp-clients-go-executable-path (executable-find "go-langserver")
+  "Path to the go-langserver executable."
+  :type 'string
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-language-server-flags '("-gocodecompletion")
+  "Extra arguments for the go-langserver."
+  :type '(repeat string)
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-func-snippet-enabled t
+  "Enable the returning of argument snippets on `func' completions, eg.
+`func(foo string, arg2 bar)'.  Requires code completion to be enabled."
+  :type 'bool
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-gocode-completion-enabled t
+  "Enable code completion feature (using gocode)."
+  :type 'bool
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-format-tool "goimports"
+  "The tool to be used for formatting documents.  Defaults to `goimports' if nil."
+  :type '(choice (const :tag "goimports" "goimports")
+                 (const :tag "gofmt" "gofmt"))
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-imports-local-prefix ""
+  "The local prefix (comma-separated string) that goimports will use."
+  :type 'string
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-max-parallelism nil
+  "The maximum number of goroutines that should be used to fulfill requests.
+This is useful in editor environments where users do not want results ASAP,
+but rather just semi quickly without eating all of their CPU.  When nil,
+defaults to half of your CPU cores."
+  :type '(choice integer (const nil "Half of CPU cores."))
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-use-binary-pkg-cache t
+  "Whether or not $GOPATH/pkg binary .a files should be used."
+  :type 'bool
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-diagnostics-enabled t
+  "Whether diagnostics are enabled."
+  :type 'bool
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-library-directories '("/usr")
+  "List of directories which will be considered to be libraries."
+  :group 'lsp-go
+  :risky t
+  :type '(repeat string))
+
+(define-inline lsp-clients-go--bool-to-json (val)
+  (inline-quote (if ,val t :json-false)))
+
+(defun lsp-clients-go--make-init-options ()
+  "Init options for golang."
+  `(:funcSnippetEnabled ,(lsp-clients-go--bool-to-json lsp-clients-go-func-snippet-enabled)
+                        :gocodeCompletionEnabled ,(lsp-clients-go--bool-to-json lsp-clients-go-gocode-completion-enabled)
+                        :formatTool ,lsp-clients-go-format-tool
+                        :goimportsLocalPrefix ,lsp-clients-go-imports-local-prefix
+                        :maxParallelism ,lsp-clients-go-max-parallelism
+                        :useBinaryPkgCache ,lsp-clients-go-use-binary-pkg-cache
+                        :diagnosticsEnabled ,lsp-clients-go-diagnostics-enabled))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-clients-go-server))
+                  :major-modes '(go-mode)
+                  :extra-init-params 'lsp-clients-go--make-init-options
+                  :server-id 'go-ls
+                  :library-folders-fn (lambda (_workspace)
+                                        lsp-clients-go-library-directories)))
+
+
+(provide 'lsp-clients)
+;;; lsp-clients.el ends here


### PR DESCRIPTION
Fixes #225 #424 #376 #360 #280 #285 #264 #229 #117 #111 #335 #392 #390 #359 #340 #225

Higher level goals:

* Allow multiple servers to work in one project and in one file
* Make finding of project roots easier and more explicit for the users.
* Removed all synchronous calls from the server startup.
* Improved hadling of status messages.
* Implemented workspace folders support as a first class citisen instead of
  being a patch in the existing configuration.
* Simplified the code as much as possible

The following things are implemented:

1. Moved `lsp-mode` related code into single file. Now clients should either
require `lsp-mode` or `lsp`. After this CL `lsp-mode.el` and `lsp.el` extesions
like `ccls` and `lsp-ui` will be able to work against either of these.
`lsp-mode` will be used by default and if you want to use the new `lsp.el` you
should do `(require 'lsp)` before loading lsp-mode.

2. Introduced `lsp-session` which will be resposible for handling project
session configuration like:
* What currently imported projects.
* What server are running and the folders that are associated with the session.
* What folders are ignored and wont be used to initialize a project in it. The
session is persisted and automatically loaded the first time user calls `lsp`

3. Introduced `lsp-language-id-configuration` which will hold the configuration
"language" -> emacs major mode. This map is used to render eldoc information and
also to determine the language id when sending various notifications to the
server.

4. Restructored `lsp--client` by removing the runtime related
stuff (like last-id) so it can be used as a template for registration. This will
simplify the way lsp client registration and it will make easier to add new
functionality

5. lsp-ui and company-lsp should be adapted as well. I will prepare separate CLs.

6. Implemented frontend for reviewing what servers are running, which buffers
are managed, and so on the method have replaced the existing `lsp-capabilities`
method.

7. Reworked the modeline so it can provide info for the servers currently
handling current file.

8. Moved snippet configuration into `lsp-mode` from `company-lsp` since snippet
support will be needed as part of implementing snippet support in lsp-mode #350.
Aa a result it was possible to clean registration related methods since they
where used only by company-lsp.

9. Added the option each client to define the location of its libraries and thus
avoid starting LSP servers for library folders.

10. Method selection based on the configuration in `lsp-method->capabilities`.

Sample client implementation:

``` emacs-lisp
(lsp-register-client
 (make-lsp-client
  :new-connection (lsp-stdio-connection "pyls")
  :major-modes '(python-mode)
  :server-id 'pyls
  :library-folders-fn (lambda (_workspace)
                        (list "/usr/"))))
```
