### PR TITLE
Optimize project root detection. 

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -852,8 +852,7 @@ directory."
 (defun lsp--suggest-project-root ()
   "Get project root."
   (or
-   (when (featurep 'projectile)
-     (projectile-ensure-project (projectile-project-root)))
+   (when (featurep 'projectile) (projectile-project-root))
    (when (featurep 'project)
      (when-let ((project (project-current)))
        (car (project-roots project))))

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -558,11 +558,11 @@ interface TextDocumentItem {
     text: string;
 }"
   (inline-quote
-   (let ((language-id-fn (lsp--client-language-id (lsp--workspace-client lsp--cur-workspace))))
-     (list :uri (lsp--buffer-uri)
-           :languageId (funcall language-id-fn (current-buffer))
-           :version (lsp--cur-file-version)
-           :text (buffer-substring-no-properties (point-min) (point-max))))))
+    (let ((language-id-fn (lsp--client-language-id (lsp--workspace-client lsp--cur-workspace))))
+      (list :uri (lsp--buffer-uri)
+	      :languageId (funcall language-id-fn (current-buffer))
+	      :version (lsp--cur-file-version)
+	      :text (buffer-substring-no-properties (point-min) (point-max))))))
 
 ;; Clean up the entire state of lsp mode when Emacs is killed, to get rid of any
 ;; pending language servers.
@@ -2355,19 +2355,19 @@ If WORKSPACE is not specified the `lsp--cur-workspace' will be used."
   (setq workspace (or workspace lsp--cur-workspace))
   (let ((watches (lsp--workspace-watches workspace)))
     (cl-loop for (dir glob-patterns) in to-watch do
-             (lsp-create-watch
-              dir
-              (mapcar 'eshell-glob-regexp glob-patterns)
-              (lambda (event)
-                (let ((lsp--cur-workspace workspace))
-                  (lsp-send-notification
-                   (lsp-make-notification
-                    "workspace/didChangeWatchedFiles"
-                    (list :changes
-                          (list
-                           :type (alist-get (cadr event) lsp--file-change-type)
-                           :uri (lsp--path-to-uri (caddr event))))))))
-              watches))))
+      (lsp-create-watch
+        dir
+        (mapcar 'eshell-glob-regexp glob-patterns)
+        (lambda (event)
+          (let ((lsp--cur-workspace workspace))
+            (lsp-send-notification
+              (lsp-make-notification
+                "workspace/didChangeWatchedFiles"
+                (list :changes
+                  (list
+                    :type (alist-get (cadr event) lsp--file-change-type)
+                    :uri (lsp--path-to-uri (caddr event))))))))
+        watches))))
 
 (defun lsp--on-set-visitied-file-name (old-func &rest args)
   "Advice around function `set-visited-file-name'.

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -558,11 +558,11 @@ interface TextDocumentItem {
     text: string;
 }"
   (inline-quote
-    (let ((language-id-fn (lsp--client-language-id (lsp--workspace-client lsp--cur-workspace))))
-      (list :uri (lsp--buffer-uri)
-	      :languageId (funcall language-id-fn (current-buffer))
-	      :version (lsp--cur-file-version)
-	      :text (buffer-substring-no-properties (point-min) (point-max))))))
+   (let ((language-id-fn (lsp--client-language-id (lsp--workspace-client lsp--cur-workspace))))
+     (list :uri (lsp--buffer-uri)
+           :languageId (funcall language-id-fn (current-buffer))
+           :version (lsp--cur-file-version)
+           :text (buffer-substring-no-properties (point-min) (point-max))))))
 
 ;; Clean up the entire state of lsp mode when Emacs is killed, to get rid of any
 ;; pending language servers.
@@ -855,7 +855,8 @@ directory."
    (when (featurep 'projectile) (projectile-project-root))
    (when (featurep 'project)
      (when-let ((project (project-current)))
-       (car (project-roots project))))))
+       (car (project-roots project))))
+   default-directory))
 
 (defun lsp--read-from-file (file)
   "Read FILE content."

--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -855,10 +855,9 @@ directory."
    (when (featurep 'projectile)
      (projectile-ensure-project (projectile-project-root)))
    (when (featurep 'project)
-     (let ((project (project-current)))
-       (if project
-           (car (project-roots project))
-         default-directory)))))
+     (when-let ((project (project-current)))
+       (car (project-roots project))))
+   default-directory))
 
 (defun lsp--read-from-file (file)
   "Read FILE content."


### PR DESCRIPTION
Logic: detecting via projectile or project; If nil, use the current directory.

Fix https://github.com/emacs-lsp/lsp-python/issues/28.
