### PR TITLE
Revert "Optimize project root detection. "

### DIFF
--- a/lsp-methods.el
+++ b/lsp-methods.el
@@ -855,8 +855,7 @@ directory."
    (when (featurep 'projectile) (projectile-project-root))
    (when (featurep 'project)
      (when-let ((project (project-current)))
-       (car (project-roots project))))
-   default-directory))
+       (car (project-roots project))))))
 
 (defun lsp--read-from-file (file)
   "Read FILE content."


### PR DESCRIPTION
Reverts emacs-lsp/lsp-mode#470

#470 consisted of 7 commits changing the single place back and forth and that PR got merged with an open issue unaddressed. I don't understand why it got approved and merged eventually. Disregarding the below technical reason, the commits should have been squashed if it was to be merged.

The fallback to `default-directory` is not a good choice for many language servers as many of them are designed for projects, not arbitrary directories with a single file. I understand that in some circumstances the language servers are lenient and the single file is accepted, but please use:

* projectile: `(setq projectile-require-project-root nil)`. Use `projectile-ensure-project` as mentioned by @seagle0128 .
* project: `project-vc-external-root-functions`

Or if the behavior is really reasonable enough, make it a client-specific `:get-root` setting as @BooAA suggested.

The 7 commits made history browsing very difficult. I recommend making a force push to the state before that patch series. @vibhavp @yyoncho 