### PR TITLE
Cleanup lsp-mode.el public interface

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -404,5 +404,27 @@ If WORKSPACE is not specified defaults to lsp--cur-workspace."
       (view-mode 1))
     (switch-to-buffer buffer-name)))
 
+(defun lsp-get-renderer (language)
+  "Return a function to fontify a string in LANGUAGE."
+  (thread-last lsp--cur-workspace
+    lsp--workspace-client
+    lsp--client-string-renderers
+    (assoc-string language)
+    cdr))
+
+(defun lsp-workspace-root (&optional _path)
+  "Find the workspace root for the current file."
+  (when lsp--cur-workspace
+    (lsp--workspace-root lsp--cur-workspace)))
+
+(defun lsp-buffer-language ()
+  "Get language for the current buffer."
+  (when-let (language-id-fn (lsp--client-language-id (lsp--workspace-client lsp--cur-workspace)))
+    (funcall language-id-fn (current-buffer))))
+
+(defun lsp-diagnostics ()
+  "Return diagnostics."
+  lsp--diagnostics)
+
 (provide 'lsp-mode)
 ;;; lsp-mode.el ends here


### PR DESCRIPTION
The packages like `lsp-ui` and `company-lsp` do use some internal `lsp-mode`
functions. This CL defines them so then can be implmeneted by `lsp.el` (see #469)

This will allow `lsp-ui` and `company-lsp` to work aganst both `lsp.el` and
`lsp-mode.el`.