### PR TITLE
Refactor lsp-hover

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -17,7 +17,7 @@
 
 ;; Author: Vibhav Pant <vibhavp@gmail.com>
 ;; URL: https://github.com/emacs-lsp/lsp-mode
-;; Package-Requires: ((emacs "25.1"))
+;; Package-Requires: ((emacs "25.1") (dash "2.14.1") (dash-functional "2.14.1") (spinner "1.7.3"))
 ;; Version: 5.0
 
 ;;; Commentary:


### PR DESCRIPTION
The original code cancelled pending hover request, but this behavior is not used in any other language client I know about. textDocumenthover is fast so this is not very necessary.

To reduce hover requests, we cache "contents" and "range", and reuse "contents" if (point) is still within "range".

lsp--hover-callback is better using eldoc-message but after a movement operation, the echo area is cleared and eldoc-message does not redisplay the message. So use message for now.