### PR TITLE
Polish flymake

### DIFF
--- a/lsp.el
+++ b/lsp.el
@@ -599,6 +599,10 @@ INHERIT-INPUT-METHOD will be proxied to `completing-read' without changes."
               (point))
           (error (point)))))))
 
+(defun lsp--range-to-region (range)
+  (cons (lsp--position-to-point (gethash "start" range))
+        (lsp--position-to-point (gethash "end" range))))
+
 (defmacro lsp-define-stdio-client (&rest _rest)
   "No op - only for backward compatibility.")
 
@@ -807,34 +811,42 @@ WORKSPACE is the workspace that contains the diagnostics."
       (with-current-buffer buffer
         (run-hooks 'lsp-after-diagnostics-hook)))))
 
-(eval-after-load 'flymake
-  '(progn
-     (defun lsp--flymake-setup()
-       "Setup flymake."
-       (flymake-mode-on)
-       (add-hook 'flymake-diagnostic-functions 'lsp--flymake-backend nil t)
-       (add-hook 'lsp-after-diagnostics-hook 'lsp--flymake-after-diagnostics nil t))
+(with-eval-after-load 'flymake
+  (put 'lsp-note 'flymake-category 'flymake-note)
+  (put 'lsp-warning 'flymake-category 'flymake-warning)
+  (put 'lsp-error 'flymake-category 'flymake-error)
 
-     (defun lsp--flymake-after-diagnostics ()
-       "Handler for `lsp-after-diagnostics-hook'"
-       (when lsp--flymake-report-fn
-         (lsp--flymake-backend lsp--flymake-report-fn)
-         (remove-hook 'lsp-after-diagnostics-hook 'lsp--flymake-after-diagnostics t)))
+  (defun lsp--flymake-setup()
+    "Setup flymake."
+    (flymake-mode-on)
+    (add-hook 'flymake-diagnostic-functions 'lsp--flymake-backend nil t)
+    (add-hook 'lsp-after-diagnostics-hook 'lsp--flymake-after-diagnostics nil t))
 
-     (defun lsp--flymake-backend (report-fn &rest _args)
-       "Flymake backend."
-       (funcall report-fn
-                (-some->> (lsp-diagnostics)
-                          (gethash buffer-file-name)
-                          (--map (-let (((&hash "message" "severity" "range" (&hash "start" "end")) (lsp-diagnostic-original it)))
-                                   (flymake-make-diagnostic (current-buffer)
-                                                            (lsp--position-to-point start)
-                                                            (lsp--position-to-point end)
-                                                            (case severity
-                                                              (1 :error)
-                                                              (2 :warning)
-                                                              (_ :success))
-                                                            message))))))))
+  (defun lsp--flymake-after-diagnostics ()
+    "Handler for `lsp-after-diagnostics-hook'"
+    (when lsp--flymake-report-fn
+      (lsp--flymake-backend lsp--flymake-report-fn)
+      (remove-hook 'lsp-after-diagnostics-hook 'lsp--flymake-after-diagnostics t)))
+
+  (defun lsp--flymake-backend (report-fn &rest _args)
+    "Flymake backend."
+    (funcall report-fn
+             (-some->> (lsp-diagnostics)
+                       (gethash buffer-file-name)
+                       (--map (-let* (((&hash "message" "severity" "range") (lsp-diagnostic-original it))
+                                      ((start . end) (lsp--range-to-region range)))
+                                (when (= start end)
+                                  (-let* (((&hash "line" "character") (gethash "start" range))
+                                          (region (flymake-diag-region (current-buffer) (1+ line) character)))
+                                    (setq start (car region) end (cdr region))))
+                                (flymake-make-diagnostic (current-buffer)
+                                                         start
+                                                         end
+                                                         (case severity
+                                                           (1 'lsp-error)
+                                                           (2 'lsp-warning)
+                                                           (_ 'lsp-note))
+                                                         message)))))))
 
 (define-minor-mode lsp-mode ""
   nil nil nil
@@ -1487,13 +1499,12 @@ interface TextDocumentEdit {
 
 (defun lsp--apply-text-edit (text-edit)
   "Apply the edits described in the TextEdit object in TEXT-EDIT."
-  (let* ((range (gethash "range" text-edit))
-         (start-point (lsp--position-to-point (gethash "start" range)))
-         (end-point (lsp--position-to-point (gethash "end" range))))
+  (-let* (((&hash "newText" "range") text-edit)
+          ((start . end) (lsp--range-to-region range)))
     (save-excursion
-      (goto-char start-point)
-      (delete-region start-point end-point)
-      (insert (gethash "newText" text-edit)))))
+      (goto-char start)
+      (delete-region start end)
+      (insert newText))))
 
 (defun lsp--capability (cap &optional capabilities)
   "Get the value of capability CAP.  If CAPABILITIES is non-nil, use them instead."


### PR DESCRIPTION
* When range.start = range.end, e.g. error: expected ';' at end of declaration
      The overlay is empty and thus invisible. Use flymake-diag-region to
      make the overlay visible.
* Create error types lsp-{error,warning,note} (:success did not exist)
* Add lsp--range-to-region to simplify code
