### PR TITLE
Proposed fix for tcp handling

### DIFF
--- a/lsp.el
+++ b/lsp.el
@@ -2994,8 +2994,7 @@ return the command to start the LS server."
 
       (set-process-filter tcp-client-connection filter)
       (set-process-sentinel tcp-client-connection sentinel)
-
-      (cons tcp-client-connection (list cmd-proc tcp-server)))))
+      (cons tcp-client-connection cmd-proc))))
 
 (defun lsp--auto-configure ()
   "Autoconfigure `lsp-ui', `company-lsp' if they are installed."


### PR DESCRIPTION
- added functions for checking and finding open ports

``` example registration
(lsp-register-client
 (make-lsp-client :new-connection (lsp-tcp-connection
                                   (lambda (port)
                                     `("php"
                                       ,(expand-file-name "~/.composer/vendor/felixfbecker/language-server/bin/php-language-server.php")
                                       ,(format "--tcp-server=localhost:%s" port)
                                       "--memory-limit=4095M")))
                  :major-modes '(php-mode)
                  :server-id 'php-ls))
```