### PR TITLE
Initial support for Dart in lsp-client

### DIFF
--- a/README.org
+++ b/README.org
@@ -70,6 +70,7 @@
   | C++                   | [[https://clang.llvm.org/extra/clangd.html][clangd]]                      | Yes          | [[https://clang.llvm.org/extra/clangd.html][clangd]]                                         |          |
   | C++                   | [[https://github.com/cquery-project/cquery][cquery]]                      | [[https://github.com/cquery-project/emacs-cquery][emacs-cquery]] | [[https://github.com/cquery-project/cquery][cquery]]                                         |          |
   | CSS                   | [[https://github.com/vscode-langservers/vscode-css-languageserver-bin][css]]                         | Yes          | npm install -g vscode-css-languageserver-bin   |          |
+  | Dart                  | [[https://github.com/natebosch/dart_language_server][dart_language_server]]        | Yes          | pub global activate dart_language_server       |          |
   | Go                    | [[https://github.com/sourcegraph/go-langserver][go-langserver]]               | Yes          | go get -u github.com/sourcegraph/go-langserver |          |
   | Groovy                | [[https://github.com/palantir/language-servers][groovy-language-server]]      | Yes          | [[https://github.com/palantir/language-servers][groovy-language-server]]                         |          |
   | HTML                  | [[https://github.com/vscode-langservers/vscode-html-languageserver][html]]                        | Yes          | npm install -g vscode-html-languageserver-bin  |          |

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -289,5 +289,19 @@ finding the executable with `exec-path'."
                     :server-id 'clangd)))
 
 
+;; Dart
+(defcustom lsp-clients-dart-server-command
+  (expand-file-name "~/.pub-cache/bin/dart_language_server")
+  "Install directory for Dart_language_server"
+  :group 'lsp-dart
+  :type 'file)
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   lsp-clients-dart-server-command)
+                  :major-modes '(dart-mode)
+                  :server-id 'dart_language_server))
+
+
 (provide 'lsp-clients)
 ;;; lsp-clients.el ends here

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -292,7 +292,7 @@ finding the executable with `exec-path'."
 ;; Dart
 (defcustom lsp-clients-dart-server-command
   (expand-file-name "~/.pub-cache/bin/dart_language_server")
-  "Install directory for Dart_language_server"
+  "The dart_language_server executable to use."
   :group 'lsp-dart
   :type 'file)
 


### PR DESCRIPTION
[natebosch/dart_language_server](https://github.com/natebosch/dart_language_server) haven't implement debugger of Dart, so here goes no debugger support.