### PR TITLE
Improve session folder handling and added events for handling them

### DIFF
--- a/README.org
+++ b/README.org
@@ -47,16 +47,13 @@
 
 ** Spacemacs
    [[https://github.com/emacs-lsp/lsp-mode][lsp-mode]] is included in spacemacs. Add ~lsp~ to ~dotspacemacs-configuration-layers~ and configure the language that you want to use to be backed by ~lsp~ backend.
-
 * Configuration
-  Add the following line in your configuration file where ~programming-mode-hook~ stands for the language specific hook like ~python-mode-hook~.  In addition, ~lsp-mode~ will automatically detect and configure [[https://github.com/emacs-lsp/lsp-ui][lsp-ui]] and [[https://github.com/tigersoldier/company-lsp][company-lsp]]. To turn off that behavior you could set ~lsp-auto-configure~ to ~nil~.
+  Add the following line in your configuration file:
   #+BEGIN_SRC emacs-lisp
     (require 'lsp)
-    ;; in case you are using client which is available as part of lsp refer to the
-    ;; table bellow for the clients that are distributed as part of lsp-mode.el
-    (require 'lsp-clients)
-    (add-hook 'programming-mode-hook 'lsp)
+    (add-hook 'XXX-mode-hook 'lsp)
   #+END_SRC
+  where ~XXX~ could be major mode like ~python~, ~java~, ~c++~. Alternatively, if you want to minimize you configuration you may use ~prog-mode-hook~. In case you do that, `lsp` will try to start for each programming mode and echo a message when there is no client registered for the current mode or if the corresponding server is not present. In addition, ~lsp-mode~ will automatically detect and configure [[https://github.com/emacs-lsp/lsp-ui][lsp-ui]] and [[https://github.com/tigersoldier/company-lsp][company-lsp]]. To turn off that behavior you could set ~lsp-auto-configure~ to ~nil~.
 
 * Supported languages
   Some of the servers are directly supported by ~lsp-mode~ by requiring
@@ -141,7 +138,13 @@
                       :major-modes '(python-mode)
                       :server-id 'pyls))
   #+END_SRC
-
+** FAQ
+*** How to configure a server with local variables?
+    Add ~lsp~ server call to ~hack-local-variables-hook~ which runs right after the local variables are loaded.
+    #+BEGIN_SRC emacs-lisp
+      (add-hook 'hack-local-variables-hook
+                (lambda () (when (derived-mode-p 'XXX-mode) (lsp))))
+    #+END_SRC
 ** See also
    - [[https://github.com/yyoncho/dap-mode][dap-mode]] - Debugger integration for ~lsp-mode~.
    - [[https://github.com/joaotavora/eglot][eglot]] - An alternative minimal LSP implementation.

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -281,12 +281,14 @@ finding the executable with `exec-path'."
   "Generate the language server startup command."
   `(,lsp-clients-clangd-executable ,@lsp-clients-clangd-args))
 
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   'lsp-clients--clangd-command)
+                  :major-modes '(c-mode c++-mode objc-mode)
+                  :server-id 'clangd))
+
 (defun lsp-clients-register-clangd ()
-  (lsp-register-client
-   (make-lsp-client :new-connection (lsp-stdio-connection
-                                     'lsp-clients--clangd-command)
-                    :major-modes '(c-mode c++-mode objc-mode)
-                    :server-id 'clangd)))
+  (warn "This call is no longer needed. clangd is now automatically registered. Delete lsp-clients-register-clangd call from your config."))
 
 
 ;; Dart

--- a/lsp.el
+++ b/lsp.el
@@ -850,13 +850,13 @@ WORKSPACE is the workspace that contains the diagnostics."
         (run-hooks 'lsp-after-diagnostics-hook)))))
 
 (with-eval-after-load 'flymake
-  (put 'lsp-note 'flymake-category 'flymake-note)
-  (put 'lsp-warning 'flymake-category 'flymake-warning)
-  (put 'lsp-error 'flymake-category 'flymake-error)
+  ;; (put 'lsp-note 'flymake-category 'flymake-note)
+  ;; (put 'lsp-warning 'flymake-category 'flymake-warning)
+  ;; (put 'lsp-error 'flymake-category 'flymake-error)
 
   (defun lsp--flymake-setup()
     "Setup flymake."
-    (flymake-mode-on)
+    (flymake-mode 1)
     (add-hook 'flymake-diagnostic-functions 'lsp--flymake-backend nil t)
     (add-hook 'lsp-after-diagnostics-hook 'lsp--flymake-after-diagnostics nil t))
 
@@ -882,9 +882,9 @@ WORKSPACE is the workspace that contains the diagnostics."
                                                          start
                                                          end
                                                          (case severity
-                                                           (1 'lsp-error)
-                                                           (2 'lsp-warning)
-                                                           (_ 'lsp-note))
+                                                           (1 :error)
+                                                           (2 :warning)
+                                                           (_ :note))
                                                          message)))))))
 
 (define-minor-mode lsp-mode ""


### PR DESCRIPTION
Fixes #512

- added `lsp-auto-require-clients` to remove the need to require lsp-clients.
  When set to t(default) it will autorequire lsp-clients.

- `lsp` command ignores the clients which binary is not present.

- `lsp` no longer throws an error when there is no client installed

- `lsp` will ask which client to power on if there are multiple clients for a
  single mode present(also if their binary is available). This will happen each
  time you open a new file. In order to disable that you will have to remove the
  server that you do not want to run from `lsp-clients`. Later, when we solve
  #405 we will be able to specify per project preferences like: ProjectA uses
  ccls, projectB uses clangd.

- If you want your client to run in parallel with other server you will have to
  specify `:add-on?` = t when registering the client.

- added 3 different message `lsp--info`, `lsp--warn` and `lsp--error`

- cleanup
- fixed support for tcp LANGUAGE server which apparently works only on Linux.

``` example registration
(lsp-register-client
 (make-lsp-client :new-connection (lsp-tcp-connection
                                   (lambda (port)
                                     `("php"
                                       ,(expand-file-name "~/.composer/vendor/felixfbecker/language-server/bin/php-language-server.php")
                                       ,(format "--tcp-server=localhost:%s" port)
                                       "--memory-limit=4095M")))
                  :major-modes '(php-mode)
                  :server-id 'php-ls))
```