### PR TITLE
Provide lsp-mode in correct file

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -24,7 +24,7 @@
 
 ;;; Code:
 
-
 (require 'lsp)
+(provide 'lsp-mode)
 
 ;;; lsp-mode.el ends here

--- a/lsp.el
+++ b/lsp.el
@@ -3405,6 +3405,5 @@ such."
     (lsp-mode 1)
     (when lsp-auto-configure (lsp--auto-configure))))
 
-(provide 'lsp-mode)
 (provide 'lsp)
 ;;; lsp.el ends here


### PR DESCRIPTION
The tools used to maintain the Emacsmirror automatically determine the
libraries provided by a package by looking for emacs-lisp files that
provide a feature matching their filename (sans extension obviously).
This is done to avoid false-positives.

These tools get confused if features are provided in files that do not
match, as was the case here.