### PR TITLE
Add Swift LSP language identifier

### DIFF
--- a/lsp.el
+++ b/lsp.el
@@ -354,7 +354,8 @@ than the second parameter.")
                                         (typescript-mode . "typescript")
                                         (reason-mode . "reason")
                                         (caml-mode . "ocaml")
-                                        (tuareg-mode . "ocaml"))
+                                        (tuareg-mode . "ocaml")
+                                        (swift-mode . "swift"))
   "Language id configuration.")
 
 (defvar lsp-method-requirements


### PR DESCRIPTION
Per https://code.visualstudio.com/docs/languages/identifiers

(Necessary to proceed to upgrade `lsp-sourcekit` to the latest `lsp-mode` API.)