### PR TITLE
Fix `when-let*` for Emacs 25 compatibility.

### DIFF
--- a/lsp.el
+++ b/lsp.el
@@ -54,6 +54,11 @@
 (require 'xref)
 (require 'tree-widget)
 
+(eval-when-compile
+  (when (version< emacs-version "26")
+    (defalias 'if-let* #'if-let)
+    (defalias 'when-let* #'when-let)))
+
 (defconst lsp--message-type-face
   `((1 . ,compilation-error-face)
     (2 . ,compilation-warning-face)


### PR DESCRIPTION
Without this, M-x lsp-restart-workspace didn't work, and byte-compiling
lsp.el produced these warnings among others:

    In lsp-find-workspace:
    lsp.el:3303:38:Warning: ‘(session (lsp-session))’ is a malformed function
    lsp.el:3306:61:Warning: reference to free variable ‘session’
    lsp.el:3308:84:Warning: reference to free variable ‘folder->servers’
    lsp.el:3309:30:Warning: reference to free variable ‘workspaces’

This is apparently because `when-let*` is new in Emacs 26.  The older
form was deprecated in the same version, so best to accept the newer
one; just add these shims to make Emacs 25 work.

See raxod502/el-patch#17 ; I borrowed the code from that maintainer's
patch.