### PR TITLE
adjust lsp--calculate-root for nest project when lsp-auto-guess-root …

### DIFF
--- a/lsp.el
+++ b/lsp.el
@@ -3326,10 +3326,12 @@ Returns nil if the project should not be added to the current SESSION."
         (--first (f-ancestor-of? it file-name))
         not)
    (or
+    (when lsp-auto-guess-root
+      (lsp--suggest-project-root))
     (lsp-find-session-folder session file-name)
-    (if lsp-auto-guess-root
-        (lsp--suggest-project-root)
-      (lsp--find-root-interactively session)))))
+    (unless lsp-auto-guess-root
+      (lsp--find-root-interactively session))
+    )))
 
 (defun lsp--try-open-in-library-workspace ()
   "Try opening current file as library file in any of the active workspace.


### PR DESCRIPTION
Fixes #533
Project root detection logic : auto-guess-root 'ignored' in nested projects

I have a large project with nest project,and set lsp-auto-guess-root to t.

First, I open a source file in rootproject directly,Second open the subpproject file then only one lsp server start.

rootproject
|---- .projectile
|---- subproject
|      |---- .projectile

