### PR TITLE
Delete client-specific use-native-json and add lsp-use-native-json

### DIFF
--- a/test/lsp-io-test.el
+++ b/test/lsp-io-test.el
@@ -63,8 +63,8 @@
              (p (make-lsp--parser :workspace lsp--test-workspace))
              ((symbol-function 'message)
               (lambda (&rest args) (push (apply 'format args) log))))
-    (lsp--on-notification p (lsp--read-json "{\"jsonrpc\":\"2.0\",\"method\":\"window/logMessage\",\"params\":{\"type\":2,\"message\":\"readFile /some/path requested by TypeScript but content not available\"}}" nil))
-    (lsp--on-notification p (lsp--read-json "{\"jsonrpc\":\"2.0\",\"method\":\"window/logMessage\",\"params\":{\"type\":2,\"message\":\"Important message\"}}" nil))
+    (lsp--on-notification p (lsp--read-json "{\"jsonrpc\":\"2.0\",\"method\":\"window/logMessage\",\"params\":{\"type\":2,\"message\":\"readFile /some/path requested by TypeScript but content not available\"}}"))
+    (lsp--on-notification p (lsp--read-json "{\"jsonrpc\":\"2.0\",\"method\":\"window/logMessage\",\"params\":{\"type\":2,\"message\":\"Important message\"}}"))
     (should (equal log '("Important message")))))
 
 ;;; lsp-io-test.el ends here


### PR DESCRIPTION
The intention is to catch hash table cases that should be migrated to plists.

It is used by no client so we can repurpose its usage.