### PR TITLE
Overhaul eldoc

### DIFF
--- a/README.org
+++ b/README.org
@@ -135,8 +135,6 @@ Replace ~(require 'lsp-mode)~ with the following if you use use-package.
   - ~lsp-imenu-container-name-separator~ - Separator string to use to separate the container name from the symbol while displaying imenu entries.
   - ~lsp-imenu-sort-methods~ - How to sort the imenu items. The value is a list of ~kind~, ~name~ or ~position~. Priorities are determined by the index of the element.
   - ~lsp-response-timeout~ - Number of seconds to wait for a response from the language server before timing out.
-  - ~lsp-hover-enabled~ - If non-nil, eldoc will display hover info when it is present. In case both signature and hover info are present and ~lsp-signature-enabled~ is t eldoc will display signature info.
-  - ~lsp-signature-enabled~ - If non-nil, eldoc will display signature info when it is present.
 ** Hooks
    ~lsp-mode~ provides a handful of hooks that can be used to extend and configure
    the behaviour of language servers. A full list of hooks is available in the


### PR DESCRIPTION
We request both hover and signatureHelp in the eldoc callback and we
face a choice when both are available.

Add a variable lsp-eldoc-prefer-signature-help to customize the
preference (defaults to t). This variable can be extended in the future
to take triggerCharacters and evil-insert-state into account.

There are some cons to send the signatureHelp request unconditionally because:

1. signatureHelp is a feature tightly connected with completion,
they are expensive in some language servers, and no good caching
mechanism. We may consider integrating triggerCharacters in the future.
2. signatureHelp may be state-aware: it is mostly useful in insert state.
In normal state (read-only browsing), its information can largely be
compensated by requesting hover on its function identifier.  There is a
very little loss by preferring hover.  On the other hand, the loss of
hover is hardly remedied by other methods.