### PR TITLE
missing dash?

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3376,7 +3376,7 @@ Returns nil if the project should not be added to the current SESSION."
 
 (defun lsp-find-workspace (server-id file-name)
   "Find workspace for SERVER-ID for FILE-NAME."
-  (when-let* ((session (lsp-session))
+  (-when-let* ((session (lsp-session))
               (folder->servers (lsp-session-folder->servers session))
               (workspaces (if file-name
                               (gethash (lsp-find-session-folder session file-name) folder->servers)


### PR DESCRIPTION
using `GNU Emacs 25.2.1 (x86_64-pc-linux-gnu, X toolkit, Xaw3d scroll bars) of 2018-08-27, modified by Debian`

I had this problem `Symbol’s value as variable is void: session` which seems to be a missing `-` (possibly a emacs 25 peculiarity re `when-let*`).