### PR TITLE
Don't steal focus when showing helping at point

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1963,7 +1963,7 @@ If INCLUDE-DECLARATION is non-nil, request the server to include declarations."
              (insert (lsp--render-on-hover-content contents t))
              (goto-char (point-min))
              (view-mode t)
-             (current-buffer))))
+             (display-buffer (current-buffer)))))
       (lsp--info "No content at point."))))
 
 (defun lsp--point-in-bounds-p (bounds)


### PR DESCRIPTION
When using go-mode, I found it pretty helpful to not loose focus from the
current buffer when showing doc at point. I've inspired by
https://github.com/dominikh/go-mode.el/blob/v1.5.0/go-mode.el#L292
and used `display-buffer` in the corresponding function to achieve this
behavior.

I believe this is more user-friendly than the current behaviour, therefore
suggesting this as the default behavior for this function.