### PR TITLE
Support for the Fortran-language-server

### DIFF
--- a/README.org
+++ b/README.org
@@ -80,6 +80,7 @@ Replace ~(require 'lsp-mode)~ with the following if you use use-package.
   | CSS                   | [[https://github.com/vscode-langservers/vscode-css-languageserver-bin][css]]                         | Yes           | npm install -g vscode-css-languageserver-bin   |          |
   | Dart                  | [[https://github.com/natebosch/dart_language_server][dart_language_server]]        | Yes           | pub global activate dart_language_server       |          |
   | Elixir                | [[https://github.com/JakeBecker/elixir-ls][elixir-ls]]                   | Yes           | [[https://github.com/JakeBecker/elixir-ls][elixir-ls]]                                      |          |
+  | Fortran               | [[https://github.com/hansec/fortran-language-server][fortran-language-server]]     | Yes | pip install fortran-language-server |          |
   | Go                    | [[https://github.com/saibing/bingo][bingo]]                       | Yes           | [[https://github.com/saibing/bingo/wiki/Install][bingo]]                                         |          |
   | Groovy                | [[https://github.com/palantir/language-servers][groovy-language-server]]      | Yes           | [[https://github.com/palantir/language-servers][groovy-language-server]]                         |          |
   | HTML                  | [[https://github.com/vscode-langservers/vscode-html-languageserver][html]]                        | Yes           | npm install -g vscode-html-languageserver-bin  |          |
@@ -95,6 +96,7 @@ Replace ~(require 'lsp-mode)~ with the following if you use use-package.
   | Swift                 | [[https://github.com/apple/sourcekit-lsp][sourcekit-LSP]]               | [[https://github.com/emacs-lsp/lsp-sourcekit][lsp-sourcekit]] | [[https://github.com/apple/sourcekit-lsp][sourcekit-LSP]]                                  |          |
   | Vue                   | [[https://github.com/vuejs/vetur/tree/master/server][vue-language-server]]         | Yes           | npm install -g vue-language-server             |          |
 
+  
 * Commands
   - ~lsp-describe-session~ - Display session folders and running servers.
   - ~lsp-describe-thing-at-point~ - Display help for the thing at point.

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -380,6 +380,39 @@ finding the executable with `exec-path'."
                   :priority -1
                   :server-id 'elixir-ls))
 
+;; Fortran
+(defcustom lsp-clients-fortls-executable "fortls"
+  "The fortls executable to use.
+Leave as just the executable name to use the default behavior of
+finding the executable with `exec-path'."
+  :group 'lsp-fortran
+  :risky t
+  :type 'file)
+
+(defcustom lsp-clients-fortls-args '()
+  "Extra arguments for the fortls executable"
+  :group 'lsp-fortran
+  :risky t
+  :type '(repeat string))
+
+(defun lsp-clients--fortls-command ()
+  "Generate the language server startup command."
+  `(,lsp-clients-fortls-executable,@lsp-clients-fortls-args))
+
+(defun fortls--suggest-project-root ()
+  (and (memq major-mode '(f90-mode))
+       (when-let (dir (locate-dominating-file default-directory ".fortls"))
+         (expand-file-name dir))))
+
+(advice-add 'lsp--suggest-project-root :before-until #'fortls--suggest-project-root)
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   'lsp-clients--fortls-command)
+                  :major-modes '(f90-mode)
+                  :priority -1
+                  :server-id 'fortls))
+
 
 (provide 'lsp-clients)
 ;;; lsp-clients.el ends here

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -404,8 +404,6 @@ finding the executable with `exec-path'."
        (when-let (dir (locate-dominating-file default-directory ".fortls"))
          (expand-file-name dir))))
 
-(advice-add 'lsp--suggest-project-root :before-until #'fortls--suggest-project-root)
-
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection
                                    'lsp-clients--fortls-command)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -383,7 +383,8 @@ than the second parameter.")
                                         (caml-mode . "ocaml")
                                         (tuareg-mode . "ocaml")
                                         (swift-mode . "swift")
-                                        (elixir-mode . "elixir"))
+                                        (elixir-mode . "elixir")
+                                        (f90-mode . "fortran"))
   "Language id configuration.")
 
 (defvar lsp-method-requirements


### PR DESCRIPTION
Added support for the [fortls](https://github.com/hansec/fortran-language-server) via 
a configuration inside ```lsp-clients.el```.