### PR TITLE
[#610] Create custom activation function for typescript servers

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -108,11 +108,19 @@ finding the executable with variable `exec-path'."
   :risky t
   :type '(repeat string))
 
+(defun lsp-typescript-javascript-tsx-jsx-activate-p (filename major-mode)
+  "Checks if the javascript-typescript language server should be enabled
+based on FILE-NAME and MAJOR-MODE"
+  (or (member major-mode '(typescript-mode typescript-tsx-mode js-mode js2-mode rjsx-mode))
+      (and (eq major-mode 'web-mode)
+           (or (string-suffix-p ".tsx" filename t)
+               (string-suffix-p ".jsx" filename t)))))
+
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection
                                    (-const `(,lsp-clients-javascript-typescript-server
                                              ,@lsp-clients-typescript-javascript-server-args)))
-                  :major-modes '(typescript-mode typescript-tsx-mode js-mode js2-mode rjsx-mode)
+                  :activation-fn 'lsp-typescript-javascript-tsx-jsx-activate-p
                   :priority -2
                   :ignore-messages '("readFile .*? requested by TypeScript but content not available")
                   :server-id 'jsts-ls))


### PR DESCRIPTION
Fixes #610 

Typescript + TSX and sometimes Javascript + JSX are edited with web-mode which defaults to wanting an HTML language server in the current code.

This switches typescript-javascript over to using an activation function which checks for the known modes for javascript/typescript as well as checking for a file using web-mode to edit JSX or TSX.