### PR TITLE
Ignore telemetry/event

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2901,7 +2901,8 @@ PARSER is the workspace parser used for handling the message."
           ("window/logMessage" 'lsp--window-log-message)
           ("textDocument/publishDiagnostics" 'lsp--on-diagnostics)
           ("textDocument/diagnosticsEnd" 'ignore)
-          ("textDocument/diagnosticsBegin" 'ignore)))
+          ("textDocument/diagnosticsBegin" 'ignore)
+          ("telemetry/event" 'ignore)))
 
 (defun lsp--on-notification (workspace notification)
   "Call the appropriate handler for NOTIFICATION."


### PR DESCRIPTION
Fixes #619 

Some servers send this event to track usage, etc., polluting the
warnings log. Nothing we want to do for now, so ignore them.