### PR TITLE
tramp: change -icrnl to raw

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3412,7 +3412,7 @@ returns the command to execute."
   (list :connect (lambda (filter sentinel name)
                    (let* ((final-command (lsp-resolve-final-function local-command))
                           ;; wrap with stty to disable converting \r to \n
-                          (wrapped-command (append '("stty" "-icrnl" ";") final-command))
+                          (wrapped-command (append '("stty" "raw" ";") final-command))
                           (process-name (generate-new-buffer-name name)))
                      (let ((proc (apply 'start-file-process-shell-command process-name
                                         (format "*%s*" process-name) wrapped-command)))


### PR DESCRIPTION
-icrnl is a subset of raw, and raw mode seems to handle more
situations correctly than just -icrnl.

@Kypert does this work for you?