### PR TITLE
Check derived mode when decided to activate Flow

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -201,7 +201,7 @@ there is a .flowconfig file in the folder hierarchy."
 (defun lsp-clients-flow-activate-p (file-name major-mode)
   "Checks if the Flow language server should be enabled for a
 particular FILE-NAME and MAJOR-MODE."
-  (and (member major-mode '(js-mode js2-mode flow-js2-mode rjsx-mode))
+  (and (derived-mode-p 'js-mode 'web-mode 'js2-mode 'flow-js2-mode 'rjsx-mode)
        (lsp-clients-flow-project-p file-name)
        (lsp-clients-flow-tag-present-p file-name)))
 


### PR DESCRIPTION
This change enhances the eligible mode pool by introducing `web-mode`, and uses
`derived-mode-p` to check if the current major mode is either one of the modes
passed or derived from them.

This ensures the Flow LSP is correctly activated for custom modes derived from
one of the popular choices.