### PR TITLE
lsp--uri-to-path: handle utf-8 path

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -768,7 +768,7 @@ On other systems, returns path without change."
   "Convert URI to a file path."
   (let* ((url (url-generic-parse-url (url-unhex-string uri)))
          (type (url-type url))
-         (file (url-filename url))
+         (file (decode-coding-string (url-filename url) locale-coding-system))
          (file-name (if (and type (not (string= type "file")))
                         (if-let ((handler (lsp--get-uri-handler type)))
                             (funcall handler uri)

--- a/test/lsp-common-test.el
+++ b/test/lsp-common-test.el
@@ -44,4 +44,11 @@
     (error (should (string= (error-message-string err)
                      "Unsupported file scheme: will-fail://file-path")))))
 
+(ert-deftest lsp--uri-to-path--handle-utf8 ()
+  (let ((lsp--uri-file-prefix "file:///")
+        (system-type 'windows-nt))
+    (should (equal (lsp--uri-to-path "file:///c:/Users/%E4%BD%A0%E5%A5%BD/") "c:/users/你好/")))
+  (let ((lsp--uri-file-prefix "file://"))
+    (should (equal (lsp--uri-to-path "/root/%E4%BD%A0%E5%A5%BD/%E8%B0%A2%E8%B0%A2") "/root/你好/谢谢"))))
+
 ;;; lsp-common-test.el ends here


### PR DESCRIPTION
See https://github.com/emacs-lsp/lsp-mode/issues/646

I had read somewhere that this kind of encoding problems are very tricky to handle. So this current solution may break things.