### PR TITLE
Add enh-ruby-mode as alternative to ruby-mode

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -441,7 +441,7 @@ PARAMS progress report notification data."
 ;; Ruby
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection '("solargraph" "stdio"))
-                  :major-modes '(ruby-mode)
+                  :major-modes '(ruby-mode enh-ruby-mode)
                   :priority -1
                   :multi-root t
                   :server-id 'ruby-ls))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -397,6 +397,8 @@ If set to `:none' neither of two will be enabled."
                                         (tuareg-mode . "ocaml")
                                         (swift-mode . "swift")
                                         (elixir-mode . "elixir")
+                                        (ruby-mode . "ruby")
+                                        (enh-ruby-mode . "ruby")
                                         (f90-mode . "fortran"))
   "Language id configuration.")
 


### PR DESCRIPTION
[`enh-ruby-mode`](https://github.com/zenspider/enhanced-ruby-mode) is an alternative `ruby-mode`. This PR is to add that mode to the Ruby LSP client.