### PR TITLE
lsp-mode: fix boolan conversion in client capabilities

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1721,7 +1721,7 @@ disappearing, unset all the variables related to it."
                                                 :hierarchicalDocumentSymbolSupport t)
                    :formatting (:dynamicRegistration t)
                    :codeAction (:dynamicRegistration t)
-                   :completion (:completionItem (:snippetSupport ,lsp-enable-snippet))
+                   :completion (:completionItem (:snippetSupport ,(if lsp-enable-snippet t :json-false)))
                    :signatureHelp (:signatureInformation (:parameterInformation (:labelOffsetSupport t)))
                    :documentLink (:dynamicRegistration t))))
 


### PR DESCRIPTION
This change ensures that "snippetSupport" is sent as JSON true or false
instead of true or null.