### PR TITLE
lsp-clients: add lsp-clients-go-server-args

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -372,13 +372,13 @@ finding the executable with `exec-path'."
   :tag "Go language")
 
 (defcustom lsp-clients-go-server "bingo"
-  "The go-langageserver executable to use."
+  "The go language server executable to use."
   :group 'lsp-clients-go
   :risky t
   :type 'file)
 
-(defcustom lsp-clients-go-language-server-flags '("-gocodecompletion")
-  "Extra arguments for the go-langserver."
+(defcustom lsp-clients-go-server-args nil
+  "Extra arguments for the go language server."
   :type '(repeat string)
   :group 'lsp-clients-go)
 
@@ -443,7 +443,9 @@ defaults to half of your CPU cores."
     :diagnosticsEnabled ,lsp-clients-go-diagnostics-enabled))
 
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-clients-go-server))
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   (lambda () (cons lsp-clients-go-server
+                                                    lsp-clients-go-server-args)))
                   :major-modes '(go-mode)
                   :priority -1
                   :initialization-options 'lsp-clients-go--make-init-options


### PR DESCRIPTION
There are two client definitions for go: one hard-codes go-langserver, the
other one uses lsp-clients-go-server which is usually "bingo". The flags variable
isn't used at all. Remove it and add lsp-clients-go-server-args to match all other
languages.