### PR TITLE
lsp--client-capabilities: specify content format of hover

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1756,7 +1756,8 @@ disappearing, unset all the variables related to it."
                    :codeAction (:dynamicRegistration t)
                    :completion (:completionItem (:snippetSupport ,(if lsp-enable-snippet t :json-false)))
                    :signatureHelp (:signatureInformation (:parameterInformation (:labelOffsetSupport t)))
-                   :documentLink (:dynamicRegistration t))))
+                   :documentLink (:dynamicRegistration t)
+                   :hover (:contentFormat ["plaintext" "markdown"]))))
 
 (defun lsp--server-register-capability (reg)
   "Register capability REG."


### PR DESCRIPTION
This is necessary so that servers know lsp-ui is able to render markdown.

One thing that I would like to add is a way for the user to customize this value. Someone who doesn't want to use lsp-ui but only display the eldoc message in the minibuffer will probably deactivate markdown for example. I am not sure where this configuration value should be. In lsp-mode or in lsp-ui?

https://microsoft.github.io/language-server-protocol/specification#initialize

```typescript
/**
 * The client supports the follow content formats for the content
 * property. The order describes the preferred format of the client.
 */
contentFormat?: MarkupKind[];
```

https://github.com/emacs-lsp/lsp-ui/issues/246

I tested only with ocamlmerlin-lsp (a lsp server for ocaml).