### PR TITLE
Use HTTPS for package-archive URLs in lsp-start-plain.el

### DIFF
--- a/scripts/lsp-start-plain.el
+++ b/scripts/lsp-start-plain.el
@@ -35,8 +35,8 @@
 
 (setq debug-on-error t)
 
-(let* ((package-archives '(("melpa" . "http://melpa.org/packages/")
-                           ("gnu" . "http://elpa.gnu.org/packages/")))
+(let* ((package-archives '(("melpa" . "https://melpa.org/packages/")
+                           ("gnu" . "https://elpa.gnu.org/packages/")))
        (no-byte-compile t)
        (package-user-dir (expand-file-name (make-temp-name "lsp-tmp-elpa")
                                            user-emacs-directory))


### PR DESCRIPTION
Fetching and installing packages over plain HTTP might not be a good idea.