### PR TITLE
lsp--flymake-backend: Fix typo in case expression

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1052,7 +1052,7 @@ WORKSPACE is the workspace that contains the diagnostics."
                                                          (case severity
                                                            (1 :error)
                                                            (2 :warning)
-                                                           (_ :note))
+                                                           (t :note))
                                                          message)))))))
 
 (defun lsp--ht-get (tbl &rest keys)


### PR DESCRIPTION
This leads to flymake diagnostics with `nil` as type, which in turn leads to
`nil` in the overlay property of the diagnostic. On flymake-1.0.5 (The one
shipped with emacs 26.1 is not affected), this triggers an error in the report
handler, which disables the lsp backend, which leads to stale error indicators
in the buffer.