### PR TITLE
lsp--flymake-backend: Force flymake to delete old diagnostics

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1053,7 +1053,11 @@ WORKSPACE is the workspace that contains the diagnostics."
                                                            (1 :error)
                                                            (2 :warning)
                                                            (t :note))
-                                                         message)))))))
+                                                         message))))
+             ;; This :region keyword forces flymake to delete old diagnostics in
+             ;; case the buffer hasn't changed since the last call to the report
+             ;; function. See https://github.com/joaotavora/eglot/issues/159
+             :region (cons (point-min) (point-max)))))
 
 (defun lsp--ht-get (tbl &rest keys)
   "Get nested KEYS in TBL."


### PR DESCRIPTION
This fixes a bug where flymake would not delete old diagnostics if the buffer
hasn't changed since the previous call to the report function. This can happen
e.g. if a change in another file removes the errors.

See https://github.com/joaotavora/eglot/issues/159 for details.

Relates to #674