### PR TITLE
Show flymake diagnostics immediately when they arrive

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1047,14 +1047,16 @@ WORKSPACE is the workspace that contains the diagnostics."
 
   (defun lsp--flymake-after-diagnostics ()
     "Handler for `lsp-after-diagnostics-hook'"
-    (when lsp--flymake-report-fn
-      (lsp--flymake-backend lsp--flymake-report-fn)
-      (remove-hook 'lsp-after-diagnostics-hook 'lsp--flymake-after-diagnostics t)))
+    (when (and lsp--flymake-report-fn flymake-mode)
+      (lsp--flymake-update-diagnostics)))
 
   (defun lsp--flymake-backend (report-fn &rest _args)
     "Flymake backend."
-    (setq lsp--flymake-report-fn report-fn)
-    (funcall report-fn
+    (setq lsp--flymake-report-fn report-fn))
+
+  (defun lsp--flymake-update-diagnostics ()
+    "Report new diagnostics to flymake."
+    (funcall lsp--flymake-report-fn
              (-some->> (lsp-diagnostics)
                        (gethash buffer-file-name)
                        (--map (-let* (((&hash "message" "severity" "range") (lsp-diagnostic-original it))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -385,7 +385,6 @@ If set to `:none' neither of two will be enabled."
   :group 'lsp-mode)
 
 (defvar-local lsp--flymake-report-fn nil)
-(defvar-local lsp--flymake-report-pending nil)
 
 (defvar lsp-language-id-configuration '((java-mode . "java")
                                         (python-mode . "python")
@@ -1047,12 +1046,18 @@ WORKSPACE is the workspace that contains the diagnostics."
 
   (defun lsp--flymake-after-diagnostics ()
     "Handler for `lsp-after-diagnostics-hook'"
-    (when (and lsp--flymake-report-fn flymake-mode)
-      (lsp--flymake-update-diagnostics)))
+    (cond
+     ((and lsp--flymake-report-fn flymake-mode)
+      (lsp--flymake-update-diagnostics))
+     ((not flymake-mode)
+      (setq lsp--flymake-report-fn nil))))
 
   (defun lsp--flymake-backend (report-fn &rest _args)
     "Flymake backend."
-    (setq lsp--flymake-report-fn report-fn))
+    (let ((first-run (null lsp--flymake-report-fn)))
+      (setq lsp--flymake-report-fn report-fn)
+      (when first-run
+        (lsp--flymake-update-diagnostics))))
 
   (defun lsp--flymake-update-diagnostics ()
     "Report new diagnostics to flymake."


### PR DESCRIPTION
This changes the flymake backend to show diagnostics as soon as they come in from the language server instead of only when flymake decides to call our backend function. This fixes some occurrences of stale diagnostics and is also how eglot works.

Fixes #674