### PR TITLE
Elixir-ls executable depends on system version

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -614,7 +614,10 @@ finding the executable with `exec-path'."
   :group 'lsp-mode
   :tag "Elixir")
 
-(defcustom lsp-clients-elixir-server-executable "language_server.sh"
+(defcustom lsp-clients-elixir-server-executable
+  (if (equal system-type 'windows-nt)
+      "language_server.bat"
+    "language_server.sh")
   "The elixir-language-server executable to use.
 Leave as just the executable name to use the default behavior of
 finding the executable with `exec-path'."


### PR DESCRIPTION
Windows should use `language_server.bat`
*nix should use `language_server.sh`

Here is a link to the end of the thread where an end user encountered the issue: https://elixirforum.com/t/emacs-elixir-setup-configuration-wiki/19196/43?u=axelson