### PR TITLE
Reset lsp--flymake-report-fn on initialization

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1093,6 +1093,7 @@ WORKSPACE is the workspace that contains the diagnostics."
   (with-eval-after-load 'flymake
     (defun lsp--flymake-setup()
       "Setup flymake."
+      (setq lsp--flymake-report-fn nil)
       (flymake-mode 1)
       (add-hook 'flymake-diagnostic-functions 'lsp--flymake-backend nil t)
       (add-hook 'lsp-after-diagnostics-hook 'lsp--flymake-after-diagnostics nil t))


### PR DESCRIPTION
This ensures that `lsp--flymake-report-fn` is not left over from an old lsp
session. This case was triggered e.g. by calling `lsp-restart-workspace` and
resulted in errors like:

```
flymake--handle-report: Wrong type argument: flymake--backend-state, nil
```