### PR TITLE
Improve Flow files detection support

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -282,11 +282,18 @@ finding the executable with variable `exec-path'."
   :risky t
   :type '(repeat string))
 
-(defun lsp-clients-flow-tag-present-p (file-name)
+(defun lsp-clients-flow-tag-file-present-p (file-name)
   "Checks if the '// @flow' or `/* @flow */' tag is present in
 the contents of FILE-NAME."
   (with-temp-buffer
     (insert-file-contents file-name)
+    (lsp-clients-flow-tag-string-present-p (buffer-string))))
+
+(defun lsp-clients-flow-tag-string-present-p (file-contents)
+  "Helper for `lsp-clients-flow-tag-file-present-p' that works
+with the file contents."
+  (with-temp-buffer
+    (insert file-contents)
     (save-excursion
       (goto-char (point-min))
       (let (stop found)
@@ -302,6 +309,8 @@ the contents of FILE-NAME."
                  (setq found t)
                  (setq stop t))
                 ((looking-at "//")
+                 (forward-line))
+                ((looking-at "*")
                  (forward-line))
                 ((looking-at "/\\*")
                  (save-excursion
@@ -321,7 +330,7 @@ there is a .flowconfig file in the folder hierarchy."
 particular FILE-NAME and MODE."
   (and (derived-mode-p 'js-mode 'web-mode 'js2-mode 'flow-js2-mode 'rjsx-mode)
        (lsp-clients-flow-project-p file-name)
-       (lsp-clients-flow-tag-present-p file-name)))
+       (lsp-clients-flow-tag-file-present-p file-name)))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection

--- a/test/fixtures/SampleFlowProject/src/sample.js
+++ b/test/fixtures/SampleFlowProject/src/sample.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+function square(n: number): number {
+    return n * n;
+}
+
+square(2);

--- a/test/fixtures/SampleTypeScriptProject/src/sample.ts
+++ b/test/fixtures/SampleTypeScriptProject/src/sample.ts
@@ -1,0 +1,7 @@
+function greeter(person) {
+    return "Hello, " + person;
+}
+
+let user = "Jane User";
+
+document.body.innerHTML = greeter(user);

--- a/test/lsp-clients-test.el
+++ b/test/lsp-clients-test.el
@@ -1,0 +1,78 @@
+;;; lsp-clients-test.el --- unit tests for lsp-clients.el -*- lexical-binding: t -*-
+
+;; Copyright (C) 2019 Daniel Martín <mardani29@yahoo.es>.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+(require 'lsp-clients)
+(require 'js) ;; Standard mode in Emacs for JS.
+
+(defconst test-location (file-name-directory (or load-file-name buffer-file-name)))
+
+;; Some of the different flavors of the @flow tag we may
+;; encounter, and things we don't want to match.
+(defconst lsp-flow-regular-tag "// @flow")
+(defconst lsp-flow-c-style-tag "/* @flow */")
+(defconst lsp-flow-simple-multiline-tag
+  "/**
+    * @flow
+    */")
+(defconst lsp-flow-multiline-with-comments-before-tag
+  "/**
+    * This is a wonderful Flow file.
+    *
+    * Author: Awesome programmer.
+    *
+    * @flow
+    */")
+(defconst lsp-flow-wrong-tag
+  "/**
+    * @notflow
+    */")
+(defconst lsp-flow-but-not-in-comment-tag "@flow")
+
+(ert-deftest lsp-flow-regular-tag-detection ()
+  (should (lsp-clients-flow-tag-string-present-p lsp-flow-regular-tag)))
+
+(ert-deftest lsp-flow-c-style-tag-detection ()
+  (should (lsp-clients-flow-tag-string-present-p lsp-flow-c-style-tag)))
+
+(ert-deftest lsp-flow-simple-multiline-tag-detection ()
+  (should (lsp-clients-flow-tag-string-present-p lsp-flow-simple-multiline-tag)))
+
+(ert-deftest lsp-flow-simple-multiline-with-comments-before-tag-detection ()
+  (should (lsp-clients-flow-tag-string-present-p lsp-flow-multiline-with-comments-before-tag)))
+
+(ert-deftest lsp-flow-wrong-tag-detection ()
+  (should (not (lsp-clients-flow-tag-string-present-p lsp-flow-wrong-tag))))
+
+(ert-deftest lsp-flow-but-not-in-comment-tag-detection ()
+  (should (not (lsp-clients-flow-tag-string-present-p lsp-flow-but-not-in-comment-tag))))
+
+(ert-deftest lsp-flow-should-activate-on-flow-project ()
+  ;; Set `js-mode' ON and check that a Flow project activates the Flow
+  ;; LSP client.
+  (js-mode)
+  (should (lsp-clients-flow-activate-p (concat test-location "fixtures/SampleFlowProject/src/sample.js") nil)))
+
+(ert-deftest lsp-flow-should-not-activate-on-typescript-project ()
+  ;; Set `js-mode' ON and check that a TypeScript project does not
+  ;; activate the Flow LSP client.
+  (js-mode)
+  (should (not (lsp-clients-flow-activate-p (concat test-location "fixtures/SampleTypeScriptProject/src/sample.ts") nil))))
+
+;;; lsp-clients-test.el ends here


### PR DESCRIPTION
Enable the Flow LSP client when we encounter a file with the following
comment:

```
/**
 * Documentation about an abstraction.
 *
 * @flow
 */

```
Previously, we enabled the TS client automatically in this case.

Also, this commit adds some unit testing for the Flow detection logic.