### PR TITLE
Should not include the comma in the enum list.

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -52,7 +52,7 @@
   '(
     :plugins.jedi_completion.enabled t
     :plugins.jedi_definition.follow_imports t
-    ;; List of configuration sources to use. (enum: ["pycodestyle", "pyflakes"])
+    ;; List of configuration sources to use. (enum: ["pycodestyle" "pyflakes"])
     :configurationSources ["pycodestyle"]
     ;; Enable or disable the plugin.
     :plugins.jedi_completion.enabled t


### PR DESCRIPTION
Although I'm not sure if it's a good idea to remove the comma here, it can reduce the confusion when setting up and avoid directly using `["pycodestyle", "pyflakes"]` instead of the correct `["pycodestyle" "pyflakes"]` or `'("pycodestyle" "pyflakes")`.

`["pycodestyle", "pyflakes"]` will cause exception in pyls, no actions will be released then. But, the other two will not be like that.