### PR TITLE
Use lambda in server paths

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -222,9 +222,9 @@ based on FILE-NAME and MAJOR-MODE"
                (string-suffix-p ".jsx" filename t)))))
 
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection
-                                   (-const `(,lsp-clients-javascript-typescript-server
-                                             ,@lsp-clients-typescript-javascript-server-args)))
+ (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
+                                                          (cons lsp-clients-javascript-typescript-server
+                                                                lsp-clients-typescript-javascript-server-args)))
                   :activation-fn 'lsp-typescript-javascript-tsx-jsx-activate-p
                   :priority -3
                   :ignore-messages '("readFile .*? requested by TypeScript but content not available")
@@ -252,9 +252,9 @@ finding the executable with variable `exec-path'."
   :type '(repeat string))
 
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection
-                                   (-const `(,lsp-clients-typescript-server
-                                             ,@lsp-clients-typescript-server-args)))
+ (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
+                                                          (cons lsp-clients-typescript-server
+                                                                lsp-clients-typescript-server-args)))
                   :activation-fn 'lsp-typescript-javascript-tsx-jsx-activate-p
                   :priority -2
                   :ignore-messages '("readFile .*? requested by TypeScript but content not available")
@@ -333,9 +333,9 @@ particular FILE-NAME and MODE."
        (lsp-clients-flow-tag-file-present-p file-name)))
 
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection
-                                   (-const `(,lsp-clients-flow-server
-                                             ,@lsp-clients-flow-server-args)))
+ (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
+                                                          (cons lsp-clients-flow-server
+                                                                lsp-clients-flow-server-args)))
                   :priority -1
                   :activation-fn 'lsp-clients-flow-activate-p
                   :server-id 'flow-ls))
@@ -507,8 +507,8 @@ PARAMS progress report notification data."
   :type 'file)
 
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection
-                                   (-const lsp-clients-php-server-command))
+ (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
+                                                          (cons lsp-clients-php-server-command)))
                   :major-modes '(php-mode)
                   :priority -1
                   :server-id 'php-ls))
@@ -539,8 +539,8 @@ PARAMS progress report notification data."
                   string)))
 
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection
-                                   (-const lsp-ocaml-ocaml-lang-server-command))
+ (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
+                                                          (cons lsp-ocaml-ocaml-lang-server-command)))
                   :major-modes '(reason-mode caml-mode tuareg-mode)
                   :priority -1
                   :server-id 'ocaml-ls))
@@ -634,8 +634,8 @@ finding the executable with `exec-path'."
   :type 'file)
 
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection
-                                   (-const lsp-clients-elixir-server-executable))
+ (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
+                                                          (cons lsp-clients-elixir-server-executable)))
                   :major-modes '(elixir-mode)
                   :priority -1
                   :server-id 'elixir-ls))

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -508,7 +508,7 @@ PARAMS progress report notification data."
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
-                                                          (cons lsp-clients-php-server-command)))
+                                                          `(,lsp-clients-php-server-command)))
                   :major-modes '(php-mode)
                   :priority -1
                   :server-id 'php-ls))
@@ -540,7 +540,7 @@ PARAMS progress report notification data."
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
-                                                          (cons lsp-ocaml-ocaml-lang-server-command)))
+                                                          `(,lsp-ocaml-ocaml-lang-server-command)))
                   :major-modes '(reason-mode caml-mode tuareg-mode)
                   :priority -1
                   :server-id 'ocaml-ls))
@@ -635,7 +635,7 @@ finding the executable with `exec-path'."
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
-                                                          (cons lsp-clients-elixir-server-executable)))
+                                                          `(,lsp-clients-elixir-server-executable)))
                   :major-modes '(elixir-mode)
                   :priority -1
                   :server-id 'elixir-ls))

--- a/test/lsp-clients-test.el
+++ b/test/lsp-clients-test.el
@@ -66,13 +66,13 @@
 (ert-deftest lsp-flow-should-activate-on-flow-project ()
   ;; Set `js-mode' ON and check that a Flow project activates the Flow
   ;; LSP client.
-  (js-mode)
-  (should (lsp-clients-flow-activate-p (concat test-location "fixtures/SampleFlowProject/src/sample.js") nil)))
+  (let ((major-mode 'js-mode))
+    (should (lsp-clients-flow-activate-p (concat test-location "fixtures/SampleFlowProject/src/sample.js") nil))))
 
 (ert-deftest lsp-flow-should-not-activate-on-typescript-project ()
   ;; Set `js-mode' ON and check that a TypeScript project does not
   ;; activate the Flow LSP client.
-  (js-mode)
-  (should (not (lsp-clients-flow-activate-p (concat test-location "fixtures/SampleTypeScriptProject/src/sample.ts") nil))))
+  (let ((major-mode 'js-mode))
+    (should (not (lsp-clients-flow-activate-p (concat test-location "fixtures/SampleTypeScriptProject/src/sample.ts") nil)))))
 
 ;;; lsp-clients-test.el ends here


### PR DESCRIPTION
As discussed in Gitter.

To make sure users can configure server paths per project (maybe via `.dir-locals.el` or
from a major mode hook), it may be better to construct the final server path at runtime via a lambda.