### PR TITLE
Fix rendering markdown string

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3075,8 +3075,8 @@ If INCLUDE-DECLARATION is non-nil, request the server to include declarations."
   "Fontlock STR with MODE."
   (condition-case nil
       (with-temp-buffer
-        (delay-mode-hooks (funcall mode))
         (insert str)
+        (delay-mode-hooks (funcall mode))
         (font-lock-ensure)
         (buffer-string))
     (error str)))


### PR DESCRIPTION
Insert string to temporary buffer before calling the major mode for the languge.
Some modes such as gfm-view-mode changes the temporary buffer to be read-only
and throws error if inserting after.