### PR TITLE
Fix issue that the role of the `-client-activation-fn` is offset in `…

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4387,7 +4387,8 @@ remote machine and vice versa."
                      hash-table-values
                      (-filter (-lambda (client)
                                 (and (or (-some-> client lsp--client-activation-fn (funcall buffer-file-name buffer-major-mode))
-                                         (and (-contains? (lsp--client-major-modes client) buffer-major-mode)
+                                         (and (not (lsp--client-activation-fn client))
+                                              (-contains? (lsp--client-major-modes client) buffer-major-mode)
                                               (eq (---truthy? remote?) (---truthy? (lsp--client-remote? client)))))
                                      (-some-> client lsp--client-new-connection (plist-get :test?) funcall)))))
       (lsp-log "Found the following clients for %s: %s"


### PR DESCRIPTION
…lsp--find-clients`

If the `-client-activation-fn` exists, then should not check the `-major-modes`.

Flowing is a minimal testing configuration:
https://gist.github.com/twlz0ne/a34bee2f5b2b62772ebe42756a1fb469