### PR TITLE
Add some gopls configuration settings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,3 +49,4 @@ Christian Kellner
 benjaminor
 Amos Bird
 AmaiKinono
+Muir Manders

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -34,6 +34,7 @@
 (require 'lsp-intelephense)
 (require 'lsp-css)
 (require 'lsp-xml)
+(require 'lsp-go)
 
 ;;; Bash
 (lsp-register-client
@@ -222,115 +223,6 @@ particular FILE-NAME and MODE."
                   :priority -1
                   :activation-fn 'lsp-clients-flow-activate-p
                   :server-id 'flow-ls))
-
-
-;;; GO language
-
-(defgroup lsp-clients-go nil
-  "Go language."
-  :group 'lsp-mode
-  :tag "Go language")
-
-(defcustom lsp-clients-go-server "bingo"
-  "The go language server executable to use."
-  :group 'lsp-clients-go
-  :risky t
-  :type 'file)
-
-(defcustom lsp-clients-go-server-args nil
-  "Extra arguments for the go language server."
-  :type '(repeat string)
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-func-snippet-enabled t
-  "Enable the returning of argument snippets on `func' completions, eg.
-`func(foo string, arg2 bar)'.  Requires code completion to be enabled."
-  :type 'boolean
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-gocode-completion-enabled t
-  "Enable code completion feature (using gocode)."
-  :type 'boolean
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-format-tool "goimports"
-  "The tool to be used for formatting documents.  Defaults to `goimports' if nil."
-  :type '(choice (const :tag "goimports" "goimports")
-                 (const :tag "gofmt" "gofmt"))
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-imports-local-prefix ""
-  "The local prefix (comma-separated string) that goimports will use."
-  :type 'string
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-max-parallelism nil
-  "The maximum number of goroutines that should be used to fulfill requests.
-This is useful in editor environments where users do not want results ASAP,
-but rather just semi quickly without eating all of their CPU.  When nil,
-defaults to half of your CPU cores."
-  :type '(choice integer (const nil "Half of CPU cores."))
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-use-binary-pkg-cache t
-  "Whether or not $GOPATH/pkg binary .a files should be used."
-  :type 'boolean
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-diagnostics-enabled t
-  "Whether diagnostics are enabled."
-  :type 'boolean
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-library-directories '("/usr")
-  "List of directories which will be considered to be libraries."
-  :group 'lsp-clients-go
-  :risky t
-  :type '(repeat string))
-
-(define-inline lsp-clients-go--bool-to-json (val)
-  (inline-quote (if ,val t :json-false)))
-
-(defun lsp-clients-go--make-init-options ()
-  "Init options for golang."
-  `(:funcSnippetEnabled ,(lsp-clients-go--bool-to-json lsp-clients-go-func-snippet-enabled)
-                        :disableFuncSnippet ,(lsp-clients-go--bool-to-json (not lsp-clients-go-func-snippet-enabled))
-                        :gocodeCompletionEnabled ,(lsp-clients-go--bool-to-json lsp-clients-go-gocode-completion-enabled)
-                        :formatTool ,lsp-clients-go-format-tool
-                        :goimportsLocalPrefix ,lsp-clients-go-imports-local-prefix
-                        :maxParallelism ,lsp-clients-go-max-parallelism
-                        :useBinaryPkgCache ,lsp-clients-go-use-binary-pkg-cache
-                        :diagnosticsEnabled ,lsp-clients-go-diagnostics-enabled))
-
-
-(lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection "gopls")
-                  :major-modes '(go-mode)
-                  :priority 0
-                  :initialization-options 'lsp-clients-go--make-init-options
-                  :server-id 'gopls
-                  :library-folders-fn (lambda (_workspace)
-                                        lsp-clients-go-library-directories)))
-
-(lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection
-                                   (lambda () (cons lsp-clients-go-server
-                                                    lsp-clients-go-server-args)))
-                  :major-modes '(go-mode)
-                  :priority -1
-                  :initialization-options 'lsp-clients-go--make-init-options
-                  :server-id 'go-bingo
-                  :library-folders-fn (lambda (_workspace)
-                                        lsp-clients-go-library-directories)))
-
-(lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection "go-langserver")
-                  :major-modes '(go-mode)
-                  :priority -2
-                  :initialization-options 'lsp-clients-go--make-init-options
-                  :server-id 'go-ls
-                  :library-folders-fn (lambda (_workspace)
-                                        lsp-clients-go-library-directories)))
 
 
 ;; PHP

--- a/lsp-go.el
+++ b/lsp-go.el
@@ -1,0 +1,159 @@
+;;; lsp-go.el --- Go Client settings             -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2019  Muir Manders
+
+;; Author: Muir Manders <muir@mnd.rs>
+;; Keywords:
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; lsp-go client
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-gopls nil
+  "Settings for gopls."
+  :group 'tools
+  :tag "Language Server")
+
+(defcustom lsp-gopls-use-placeholders t
+  "Cause gopls to provide placeholder parameter snippets when
+completing function calls."
+  :type 'boolean
+  :group 'lsp-gopls)
+
+(defcustom lsp-gopls-server-args nil
+  "Extra CLI arguments for gopls."
+  :type '(repeat string)
+  :group 'lsp-gopls)
+
+(lsp-register-custom-settings
+ '(("gopls.usePlaceholders" lsp-gopls-use-placeholders t)))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   (lambda () (cons "gopls" lsp-clients-go-server-args)))
+                  :major-modes '(go-mode)
+                  :priority 0
+                  :server-id 'gopls
+                  :library-folders-fn (lambda (_workspace)
+                                        lsp-clients-go-library-directories)))
+
+(defgroup lsp-clients-go nil
+  "Go language."
+  :group 'lsp-mode
+  :tag "Go language")
+
+(defcustom lsp-clients-go-server "bingo"
+  "The go language server executable to use."
+  :group 'lsp-clients-go
+  :risky t
+  :type 'file)
+
+(defcustom lsp-clients-go-server-args nil
+  "Extra arguments for the go language server."
+  :type '(repeat string)
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-func-snippet-enabled t
+  "Enable the returning of argument snippets on `func' completions, eg.
+`func(foo string, arg2 bar)'.  Requires code completion to be enabled."
+  :type 'boolean
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-gocode-completion-enabled t
+  "Enable code completion feature (using gocode)."
+  :type 'boolean
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-format-tool "goimports"
+  "The tool to be used for formatting documents.  Defaults to `goimports' if nil."
+  :type '(choice (const :tag "goimports" "goimports")
+                 (const :tag "gofmt" "gofmt"))
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-imports-local-prefix ""
+  "The local prefix (comma-separated string) that goimports will use."
+  :type 'string
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-max-parallelism nil
+  "The maximum number of goroutines that should be used to fulfill requests.
+This is useful in editor environments where users do not want results ASAP,
+but rather just semi quickly without eating all of their CPU.  When nil,
+defaults to half of your CPU cores."
+  :type '(choice integer (const nil "Half of CPU cores."))
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-use-binary-pkg-cache t
+  "Whether or not $GOPATH/pkg binary .a files should be used."
+  :type 'boolean
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-diagnostics-enabled t
+  "Whether diagnostics are enabled."
+  :type 'boolean
+  :group 'lsp-clients-go)
+
+(defcustom lsp-clients-go-library-directories '("/usr")
+  "List of directories which will be considered to be libraries."
+  :group 'lsp-clients-go
+  :risky t
+  :type '(repeat string))
+
+(define-inline lsp-clients-go--bool-to-json (val)
+  (inline-quote (if ,val t :json-false)))
+
+(defun lsp-clients-go--make-init-options ()
+  "Init options for golang."
+  `(:funcSnippetEnabled ,(lsp-clients-go--bool-to-json lsp-clients-go-func-snippet-enabled)
+                        :disableFuncSnippet ,(lsp-clients-go--bool-to-json (not lsp-clients-go-func-snippet-enabled))
+                        :gocodeCompletionEnabled ,(lsp-clients-go--bool-to-json lsp-clients-go-gocode-completion-enabled)
+                        :formatTool ,lsp-clients-go-format-tool
+                        :goimportsLocalPrefix ,lsp-clients-go-imports-local-prefix
+                        :maxParallelism ,lsp-clients-go-max-parallelism
+                        :useBinaryPkgCache ,lsp-clients-go-use-binary-pkg-cache
+                        :diagnosticsEnabled ,lsp-clients-go-diagnostics-enabled))
+
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   (lambda () (cons lsp-clients-go-server
+                                                    lsp-clients-go-server-args)))
+                  :major-modes '(go-mode)
+                  :priority -1
+                  :initialization-options 'lsp-clients-go--make-init-options
+                  :server-id 'go-bingo
+                  :library-folders-fn (lambda (_workspace)
+                                        lsp-clients-go-library-directories)))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection "go-langserver")
+                  :major-modes '(go-mode)
+                  :priority -2
+                  :initialization-options 'lsp-clients-go--make-init-options
+                  :server-id 'go-ls
+                  :library-folders-fn (lambda (_workspace)
+                                        lsp-clients-go-library-directories)))
+
+(provide 'lsp-go)
+;;; lsp-go.el ends here
+
+;; Local Variables:
+;; flycheck-disabled-checkers: (emacs-lisp-checkdoc)
+;; End:


### PR DESCRIPTION
- add "usePlaceholders" config value which causes gopls to give full
  function parameter snippets rather than just "()" snippet
- add lsp-gopls-server-args for adding more cli args. the most common
  is '("-logfile" "/tmp/gopls.log" "-rpc.trace") to make it log out
  all rpc activity. i didn't reuse the existing
  lsp-clients-go-server-args since gopls doesn't accept the same
  arguments as the previous go lsp servers.
- don't use the other go initialization-options with gopls since gopls
  doesn't support those
- move go client stuff into separate lsp-go package