### PR TITLE
support rustic-mode to connect rls.

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -468,6 +468,7 @@ If set to `:none' neither of two will be enabled."
                                         (python-mode . "python")
                                         (lsp--render-markdown . "markdown")
                                         (rust-mode . "rust")
+                                        (rustic-mode . "rust")
                                         (kotlin-mode . "kotlin")
                                         (css-mode . "css")
                                         (less-mode . "less")


### PR DESCRIPTION
Using rustic-mode, lsp-mode doesn't set languageId. It makes rls panic.