### PR TITLE
Fix typo

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 [[https://gitter.im/emacs-lsp/lsp-mode][file:https://badges.gitter.im/emacs-lsp/lsp-mode.svg]]
 [[https://travis-ci.org/emacs-lsp/lsp-mode][file:https://travis-ci.org/emacs-lsp/lsp-mode.svg?branch=master]]
 
-#+ATTR_HTML: align="center"; margin-right="auto"; margin-left="auto"  
+#+ATTR_HTML: align="center"; margin-right="auto"; margin-left="auto"
 [[examples/logo.png]]
 
 * Language Server Protocol Support for Emacs
@@ -152,7 +152,7 @@
    - ~lsp-lens-show~ - Show lenses in the current file
    - ~lsp-lens-hide~ - Hide lenses in the current file
    - ~lsp-lens-mode~ (experimental) - Turn on/off lenses in the current file.
-   - ~lsp-save-logs~ - Save a trace of all messages to and from the language server to a given file. Only works when ~lsp-save-logs~ is non-nil.
+   - ~lsp-save-logs~ - Save a trace of all messages to and from the language server to a given file. Only works when ~lsp-trace~ is non-nil.
 ** Settings
    - ~lsp-print-io~ - If non-nil, print all messages to and from the language server to ~*lsp-log*~.
    - ~lsp-trace~ - If non-nil, keep a trace of all messages to and from the language server, which can be saved to a file with ~lsp-save-logs~.


### PR DESCRIPTION
I think `lsp-save-logs` depends on the `lsp-trace` variable.