### PR TITLE
Async Imenu menu-bar

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3606,10 +3606,9 @@ perform the request synchronously."
       lsp--document-symbols
     (let ((method "textDocument/documentSymbol")
 	  (params `(:textDocument ,(lsp--text-document-identifier))))
+      (setq lsp--document-symbols-tick (buffer-chars-modified-tick))
       (if (not lsp--document-symbols-request-async)
-	  (setq lsp--document-symbols-tick (buffer-chars-modified-tick)
-		lsp--document-symbols (lsp-request method params))
-	(setq lsp--document-symbols-tick (buffer-chars-modified-tick))
+	  (setq lsp--document-symbols (lsp-request method params))
 	(lsp-request-async method params
 			   (lambda (document-symbols)
 			     (setq lsp--document-symbols document-symbols)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3604,19 +3604,18 @@ Else (e.g., due to intereactive use of `imenu' or `xref'),
 perform the request synchronously."
   (if (= (buffer-chars-modified-tick) lsp--document-symbols-tick)
       lsp--document-symbols
-    (if (not lsp--document-symbols-request-async)
-	(setq lsp--document-symbols-tick (buffer-chars-modified-tick)
-	      lsp--document-symbols (lsp-request
-				     "textDocument/documentSymbol"
-				     `(:textDocument ,(lsp--text-document-identifier))))
-      (lsp-request-async "textDocument/documentSymbol"
-			 `(:textDocument ,(lsp--text-document-identifier)
-					 :mode alive)
-			 (lambda (document-symbols)
-			   (setq lsp--document-symbols-tick (buffer-chars-modified-tick)
-				 lsp--document-symbols document-symbols)
-			   (lsp--imenu-refresh)))
-      lsp--document-symbols)))
+    (let ((method "textDocument/documentSymbol")
+	  (params `(:textDocument ,(lsp--text-document-identifier))))
+      (if (not lsp--document-symbols-request-async)
+	  (setq lsp--document-symbols-tick (buffer-chars-modified-tick)
+		lsp--document-symbols (lsp-request method params))
+	(lsp-request-async method params
+			   (lambda (document-symbols)
+			     (setq lsp--document-symbols-tick (buffer-chars-modified-tick)
+				   lsp--document-symbols document-symbols)
+			     (lsp--imenu-refresh))
+			   :mode 'alive)
+	lsp--document-symbols))))
 
 (advice-add 'imenu-update-menubar :around
 	    (lambda (oldfun &rest r)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3607,12 +3607,13 @@ perform the request synchronously."
     (let ((method "textDocument/documentSymbol")
 	  (params `(:textDocument ,(lsp--text-document-identifier))))
       (if (not lsp--document-symbols-request-async)
-	  (setq lsp--document-symbols-tick (buffer-chars-modified-tick)
-		lsp--document-symbols (lsp-request method params))
+	  (prog1
+	      (setq lsp--document-symbols (lsp-request method params))
+	    (setq lsp--document-symbols-tick (buffer-chars-modified-tick)))
 	(lsp-request-async method params
 			   (lambda (document-symbols)
-			     (setq lsp--document-symbols-tick (buffer-chars-modified-tick)
-				   lsp--document-symbols document-symbols)
+			     (setq lsp--document-symbols document-symbols
+				   lsp--document-symbols-tick (buffer-chars-modified-tick))
 			     (lsp--imenu-refresh))
 			   :mode 'alive)
 	lsp--document-symbols))))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3609,10 +3609,10 @@ perform the request synchronously."
       (if (not lsp--document-symbols-request-async)
 	  (setq lsp--document-symbols-tick (buffer-chars-modified-tick)
 		lsp--document-symbols (lsp-request method params))
+	(setq lsp--document-symbols-tick (buffer-chars-modified-tick))
 	(lsp-request-async method params
 			   (lambda (document-symbols)
-			     (setq lsp--document-symbols-tick (buffer-chars-modified-tick)
-				   lsp--document-symbols document-symbols)
+			     (setq lsp--document-symbols document-symbols)
 			     (lsp--imenu-refresh))
 			   :mode 'alive)
 	lsp--document-symbols))))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3607,13 +3607,12 @@ perform the request synchronously."
     (let ((method "textDocument/documentSymbol")
 	  (params `(:textDocument ,(lsp--text-document-identifier))))
       (if (not lsp--document-symbols-request-async)
-	  (prog1
-	      (setq lsp--document-symbols (lsp-request method params))
-	    (setq lsp--document-symbols-tick (buffer-chars-modified-tick)))
+	  (setq lsp--document-symbols-tick (buffer-chars-modified-tick)
+		lsp--document-symbols (lsp-request method params))
 	(lsp-request-async method params
 			   (lambda (document-symbols)
-			     (setq lsp--document-symbols document-symbols
-				   lsp--document-symbols-tick (buffer-chars-modified-tick))
+			     (setq lsp--document-symbols-tick (buffer-chars-modified-tick)
+				   lsp--document-symbols document-symbols)
 			     (lsp--imenu-refresh))
 			   :mode 'alive)
 	lsp--document-symbols))))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3605,13 +3605,16 @@ perform the request synchronously."
   (if (= (buffer-chars-modified-tick) lsp--document-symbols-tick)
       lsp--document-symbols
     (let ((method "textDocument/documentSymbol")
-	  (params `(:textDocument ,(lsp--text-document-identifier))))
-      (setq lsp--document-symbols-tick (buffer-chars-modified-tick))
+	  (params `(:textDocument ,(lsp--text-document-identifier)))
+	  (tick (buffer-chars-modified-tick)))
       (if (not lsp--document-symbols-request-async)
-	  (setq lsp--document-symbols (lsp-request method params))
+	  (prog1
+	      (setq lsp--document-symbols (lsp-request method params))
+	    (setq lsp--document-symbols-tick tick))
 	(lsp-request-async method params
 			   (lambda (document-symbols)
-			     (setq lsp--document-symbols document-symbols)
+			     (setq lsp--document-symbols document-symbols
+				   lsp--document-symbols-tick tick)
 			     (lsp--imenu-refresh))
 			   :mode 'alive)
 	lsp--document-symbols))))


### PR DESCRIPTION
Only vanilla `imenu` has been tested, and not `helm-imenu` or similar.  I tested all four combinations:

1. ```elisp
   (menu-bar-mode +1)
   (imenu-add-menubar-index)
   (setq imenu-auto-rescan nil)
    ```
2. ```elisp
   (menu-bar-mode +1)
   (imenu-add-menubar-index)
   (setq imenu-auto-rescan t)
    ```
3. ```elisp
   (menu-bar-mode -1)
   (setq imenu-auto-rescan nil)
    ```
4. ```elisp
   (menu-bar-mode -1)
   (setq imenu-auto-rescan t)
    ```

When `imenu-auto-rescan` is non-nil, both interactive results and menu-bar entry are always up-to-date; however, the menu-bar entry is updated asynchronously.  When it is nil, forcing a `*Rescan*` either through interactive use or the menu-bar entry brings everything up to date.