### PR TITLE
Fix symlink handling in project root recognition

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2864,7 +2864,7 @@ Applies on type formatting."
 
 (defun lsp-workspace-root (&optional path)
   "Find the workspace root for the current file or PATH."
-  (when-let (file-name (or path (buffer-file-name)))
+  (when-let (file-name (f-canonical (or path (buffer-file-name))))
     (->> (lsp-session)
          (lsp-session-folders)
          (--first (f-ancestor-of? it file-name)))))
@@ -4812,12 +4812,13 @@ Returns nil if the project should not be added to the current SESSION."
 
 (defun lsp-find-session-folder (session file-name)
   "Look in the current SESSION for folder containing FILE-NAME."
-  (->> session
-       (lsp-session-folders)
-       (--filter (or (f-same? it file-name)
-                     (f-ancestor-of? it file-name)))
-       (--max-by (> (length it)
-                    (length other)))))
+  (let ((file-name-canonical (f-canonical file-name)))
+    (->> session
+	 (lsp-session-folders)
+	 (--filter (or (f-same? it file-name-canonical)
+                       (f-ancestor-of? it file-name-canonical)))
+	 (--max-by (> (length it)
+                      (length other))))))
 
 (defun lsp-find-workspace (server-id file-name)
   "Find workspace for SERVER-ID for FILE-NAME."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2864,10 +2864,10 @@ Applies on type formatting."
 
 (defun lsp-workspace-root (&optional path)
   "Find the workspace root for the current file or PATH."
-  (when-let (file-name (f-canonical (or path (buffer-file-name))))
+  (when-let (file-name (or path (buffer-file-name)))
     (->> (lsp-session)
          (lsp-session-folders)
-         (--first (f-ancestor-of? it file-name)))))
+         (--first (f-ancestor-of? it (f-canonical file-name))))))
 
 (defun lsp-on-revert ()
   "Executed when a file is reverted.


### PR DESCRIPTION
Current file-to-project folder recognition doesn't work when the project is located within a symlinked directory