### PR TITLE
Modify to expand "~" to the absolute path

### DIFF
--- a/lsp-intelephense.el
+++ b/lsp-intelephense.el
@@ -82,7 +82,7 @@
   language server."
   :type '(choice (:tag "off" "messages" "verbose")))
 
-(defcustom lsp-intelephense-storage-path (locate-user-emacs-file "lsp-cache")
+(defcustom lsp-intelephense-storage-path (expand-file-name (locate-user-emacs-file "lsp-cache"))
   "Optional absolute path to storage dir."
   :group 'lsp-php-ip
   :type 'directory)


### PR DESCRIPTION
## About

- Modify to expand "~" to the absolute path

## Why

- When I'm using `lsp-mode` + `intelephense` (for PHP), I found `~` direcrtory in my repo's root

<img width="432" alt="スクリーンショット 2019-04-22 19 05 13" src="https://user-images.githubusercontent.com/10488/56495720-950d7200-6531-11e9-949b-f22ea1e6c5f6.png">


## What I changed

- I think `intelephense` does not expand the "~" to the absolute path
    - So, I use `expand-file-name` to convert "~" to the absolute path

## Note

```
(locate-user-emacs-file "lsp-cache") [C-j]
"~/.emacs.d/lsp-cache"
```

```
(expand-file-name (locate-user-emacs-file "lsp-cache")) [C-j]
"/Users/suzuki/.emacs.d/lsp-cache"
```