### PR TITLE
Fix content-length parsing for case without space after Content-Length:

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3916,7 +3916,7 @@ WORKSPACE is the active workspace."
       ;; screwed up with a previous Content-Length
       (error "No Content-Length header"))))
 
-(defun lsp--trim-left (s)
+(defun s-trim-left (s)
   "Remove whitespace at the beginning of S."
   (if (string-match "\\`[ \t\n\r]+" s)
       (replace-match "" t t s)
@@ -3929,7 +3929,7 @@ WORKSPACE is the active workspace."
     (unless pos
       (signal 'lsp-invalid-header-name (list s)))
     (setq key (substring s 0 pos)
-          val (lsp--trim-left (substring s (+ 1 pos))))
+          val (s-trim-left (substring s (+ 1 pos))))
     (when (string-equal key "Content-Length")
       (cl-assert (cl-loop for c across val
                           when (or (> c ?9) (< c ?0)) return nil

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3916,6 +3916,12 @@ WORKSPACE is the active workspace."
       ;; screwed up with a previous Content-Length
       (error "No Content-Length header"))))
 
+(defun lsp--trim-left (s)
+  "Remove whitespace at the beginning of S."
+  (if (string-match "\\`[ \t\n\r]+" s)
+      (replace-match "" t t s)
+    s))
+
 (defun lsp--parse-header (s)
   "Parse string S as a LSP (KEY . VAL) header."
   (let ((pos (string-match "\:" s))
@@ -3923,7 +3929,7 @@ WORKSPACE is the active workspace."
     (unless pos
       (signal 'lsp-invalid-header-name (list s)))
     (setq key (substring s 0 pos)
-          val (substring s (+ 2 pos)))
+          val (lsp--trim-left (substring s (+ 1 pos))))
     (when (string-equal key "Content-Length")
       (cl-assert (cl-loop for c across val
                           when (or (> c ?9) (< c ?0)) return nil

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3916,12 +3916,6 @@ WORKSPACE is the active workspace."
       ;; screwed up with a previous Content-Length
       (error "No Content-Length header"))))
 
-(defun s-trim-left (s)
-  "Remove whitespace at the beginning of S."
-  (if (string-match "\\`[ \t\n\r]+" s)
-      (replace-match "" t t s)
-    s))
-
 (defun lsp--parse-header (s)
   "Parse string S as a LSP (KEY . VAL) header."
   (let ((pos (string-match "\:" s))

--- a/test/lsp-io-test.el
+++ b/test/lsp-io-test.el
@@ -28,15 +28,23 @@
   (let* ((p (make-lsp--parser :workspace lsp--test-workspace))
          (messages-in '("Content-Length: 2\r\n\r\n{}"
                         "Content-Length: 2\r\n\r\n{}"
+                        "Content-Length:2\r\n\r\n{}"
                         "Content-Length: 2\r\n\r\n{}"
+                        "Content-Length:2\r\n\r\n{}"
                         "Content-Length: 2\r\n\r\n{}"
                         "Content-Length: 2\r\n\r\n{}"))
          (messages (lsp--parser-read p (string-join messages-in))))
-    (should (equal messages '("{}" "{}" "{}" "{}" "{}")))))
+    (should (equal messages '("{}" "{}" "{}" "{}" "{}" "{}" "{}")))))
 
 (ert-deftest lsp--parser-read--multibyte ()
   (let* ((p (make-lsp--parser :workspace lsp--test-workspace))
 				 (message-in "Content-Length: 3\r\n\r\n\xe2\x80\x99")
+         (messages (lsp--parser-read p message-in)))
+    (should (equal messages '("’")))))
+
+(ert-deftest lsp--parser-read--multibyte-nospace ()
+  (let* ((p (make-lsp--parser :workspace lsp--test-workspace))
+				 (message-in "Content-Length:3\r\n\r\n\xe2\x80\x99")
          (messages (lsp--parser-read p message-in)))
     (should (equal messages '("’")))))
 


### PR DESCRIPTION
Certain LSP server doesn't have space in between Content-Length: header and the numeric value after (Content-Length:42), e.g cppextensions for vscode (https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools). 