### PR TITLE
Add config option to disable pylint when using lsp-pyls.

### DIFF
--- a/lsp-pyls.el
+++ b/lsp-pyls.el
@@ -103,6 +103,10 @@ complexity."
   "List of modules to import on startup"
   :type '(repeat string))
 
+(defcustom lsp-pyls-plugins-pylint-enabled t
+  "Enable or disable the plugin."
+  :type 'boolean)
+
 (defcustom lsp-pyls-plugins-pycodestyle-enabled t
   "Enable or disable the plugin."
   :type 'boolean)
@@ -216,6 +220,7 @@ at all."
    ("pyls.plugins.pycodestyle.filename" lsp-pyls-plugins-pycodestyle-filename)
    ("pyls.plugins.pycodestyle.exclude" lsp-pyls-plugins-pycodestyle-exclude)
    ("pyls.plugins.pycodestyle.enabled" lsp-pyls-plugins-pycodestyle-enabled t)
+   ("pyls.plugins.pylint.enabled" lsp-pyls-plugins-pylint-enabled t)
    ("pyls.plugins.preload.modules" lsp-pyls-plugins-preload-modules)
    ("pyls.plugins.preload.enabled" lsp-pyls-plugins-preload-enabled t)
    ("pyls.plugins.mccabe.threshold" lsp-pyls-plugins-mccabe-threshold)


### PR DESCRIPTION
It appears this plugin's configuration wasn't added to lsp-mode.
[pylint_lint.py](https://github.com/palantir/python-language-server/blob/18f3c3f06f36b5e5ff3dae1436e85ef3eb5d7264/pyls/plugins/pylint_lint.py)

With this patch in my lsp-mode checkout, if I change the invocation to `pyls -vvv`, I can see pylint in the `Disabled checkers` log statement in the `*pyls::stderr*` buffer. Also, don't see the pylint errors anymore.