### PR TITLE
[WIP] Show workspace diagnostics in the mode line

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1131,6 +1131,25 @@ PARAMS - the data sent from WORKSPACE."
                  (lsp--workspace-diagnostics it))))
     result))
 
+(defun lsp-diagnostics-by-severity (file-diagnostics)
+  "Return diagnostics from FILE-DIAGNOSTICS, grouped by
+  diagnostic severity."
+  (-group-by 'lsp-diagnostic-severity file-diagnostics))
+
+(defun lsp-calculate-diagnostic-statistics (file-diagnostics)
+  "Calculate FILE-DIAGNOSTICS statistics in format
+  'error/warning/information/hint'."
+  (string-join
+   (-map (-lambda ((severity . diagnostics))
+           (number-to-string (length diagnostics)))
+         (lsp-diagnostics-by-severity file-diagnostics))
+   "/"))
+
+(defun lsp--calculate-workspaces-diag-statistics ()
+  "Calculate diagnostic statistics for all workspaces in a session."
+  (let ((workspace-diagnostics (-flatten (ht-values (lsp-diagnostics)))))
+    (lsp-calculate-diagnostic-statistics workspace-diagnostics)))
+
 (cl-defstruct lsp-diagnostic
   (range nil :read-only t)
   ;; range has the form (:start (:line N :column N) :end (:line N :column N) )

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -67,6 +67,12 @@
     (3 . ,compilation-message-face)
     (4 . ,compilation-info-face)))
 
+(defconst lsp--message-type-help-echo
+  `((1 . "Number of errors in open LSP workspaces.")
+    (2 . "Number of warnings in open LSP workspaces.")
+    (3 . "Number of messages in open LSP workspaces.")
+    (4 . "Number of information in open LSP workspaces.")))
+
 (defconst lsp--errors
   '((-32700 "Parse Error")
     (-32600 "Invalid Request")

--- a/test/lsp-diagnostic-test.el
+++ b/test/lsp-diagnostic-test.el
@@ -1,0 +1,71 @@
+;;; lsp-diagnostic-test.el --- unit tests for diagnostic-related routines in lsp-mode -*- lexical-binding: t -*-
+
+;; Copyright (C) 2019 Daniel Martín <mardani29@yahoo.es>.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+(require 'lsp-mode)
+
+(defvar lsp--test-diagnostics
+  (list
+   (make-lsp-diagnostic
+   :line 1
+   :column 4
+   :severity 1)
+
+   (make-lsp-diagnostic
+    :line 53
+    :column 4
+    :severity 2)
+
+   (make-lsp-diagnostic
+    :line 46
+    :column 7
+    :severity 3)
+
+   (make-lsp-diagnostic
+    :line 100
+    :column 23
+    :severity 2)
+
+   (make-lsp-diagnostic
+    :line 98
+    :column 12
+    :severity 3))
+  "Some sample `lsp-diagnostic' structures for testing.")
+
+(ert-deftest lsp-diagnostics-by-severity ()
+  ;; Check diagnostics of severity 1.
+  (should (equal (list
+                  (make-lsp-diagnostic :line 1 :column 4 :severity 1))
+                 (cdr (assq '1 (lsp-diagnostics-by-severity lsp--test-diagnostics)))))
+  ;; Check diagnostics of severity 2.
+  (should (equal (list
+                   (make-lsp-diagnostic :line 53 :column 4 :severity 2)
+                   (make-lsp-diagnostic :line 100 :column 23 :severity 2))
+                 (cdr (assq '2 (lsp-diagnostics-by-severity lsp--test-diagnostics)))))
+  ;; Check diagnostics of severity 3,
+  (should (equal (list
+                  (make-lsp-diagnostic :line 46 :column 7 :severity 3)
+                  (make-lsp-diagnostic :line 98 :column 12 :severity 3))
+                 (cdr (assq '3 (lsp-diagnostics-by-severity lsp--test-diagnostics))))))
+
+(ert-deftest lsp-calculate-diagnostic-statistics ()
+  (should (equal "1/2/2" (lsp-calculate-diagnostic-statistics lsp--test-diagnostics)))
+  (let ((modified-diagnostics (remove (make-lsp-diagnostic :line 1 :column 4 :severity 1) lsp--test-diagnostics)))
+    (should (equal "2/2" (lsp-calculate-diagnostic-statistics modified-diagnostics))))
+  (should (equal "" (lsp-calculate-diagnostic-statistics '()))))


### PR DESCRIPTION
Adds a new minor mode to show workspace diagnostics in the Emacs mode line.