### PR TITLE
lsp-mode: add lsp-organize-imports

### DIFF
--- a/README.org
+++ b/README.org
@@ -137,8 +137,9 @@
 ** Commands
    - ~lsp-describe-session~ - Display session folders and running servers.
    - ~lsp-describe-thing-at-point~ - Display help for the thing at point.
-   - ~lsp-execute-code-action~ - Execute code action.
+   - ~lsp-execute-code-action~ - Execute code action
    - ~lsp-format-buffer~ - Format current buffer
+   - ~lsp-organize-imports~ - Organize library imports
    - ~lsp-goto-implementation~ - Go to implementation
    - ~lsp-goto-type-definition~ - Go to type definition
    - ~lsp-rename~ - Rename symbol at point

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3497,6 +3497,11 @@ If ACTION is not set it will be selected from `lsp-code-actions'."
                             (lsp--make-document-range-formatting-params s e))))
     (lsp--apply-formatting edits)))
 
+(defun lsp-organize-imports ()
+  "Perform the source.organizeImports code action."
+  (interactive)
+  (lsp-execute-code-action-by-kind "source.organizeImports"))
+
 (defun lsp--apply-formatting (edits)
   (if (fboundp 'replace-buffer-contents)
       (let ((current-buffer (current-buffer)))


### PR DESCRIPTION
Improved version of #759 which wraps the `source.organizeImports` code action.