### PR TITLE
Fix return value of lsp-eldoc-function

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3198,9 +3198,7 @@ If INCLUDE-DECLARATION is non-nil, request the server to include declarations."
    (lambda (fn)
      (condition-case nil
          (funcall fn)
-       (lsp-capability-not-supported nil))
-     nil))
-  eldoc-last-message)
+       (lsp-capability-not-supported nil)))))
 
 (defvar-local lsp--highlight-bounds nil)
 (defvar-local lsp--highlight-timer nil)


### PR DESCRIPTION
The documentation of `eldoc-documentation-function` says:

> It should return nil if there's no doc appropriate for the context.

`lsp-eldoc-function` was always returning eldoc-last-message. Because
of this, the last message displayed by eldoc would not disappear when
the point is moved in a place where no doc is available or
lsp-eldoc-hook returns nil and doesn't call lsp-hover.

The downside is that moving the point inside the same identifier might
trigger a refresh of the eldoc message, even if it is the same. Maybe
it is possible to fix this problem by changing `lsp-hover`. So that it
returns the documentation string instead of calling `eldoc-message`.