### PR TITLE
add julia to `lsp-language-id-configuration`

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -499,6 +499,7 @@ If set to `:none' neither of two will be enabled."
 
 (defvar lsp-language-id-configuration '((".*.vue" . "vue")
                                         (".*.tsx" . "typescriptreact")
+                                        (julia-mode . "julia")
                                         (java-mode . "java")
                                         (python-mode . "python")
                                         (lsp--render-markdown . "markdown")


### PR DESCRIPTION
There is a very nice Language Server implementation for julia: 
https://github.com/JuliaEditorSupport/LanguageServer.jl/

And an Emacs package for this:
https://github.com/non-Jedi/lsp-julia