### PR TITLE
Enhancements to lsp-file-watch-ignored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,6 @@ all:
 	cask build
 
 test: all
-	cask exec ert-runner
+	cask exec ert-runner -t '!no-win'
 
 .PHONY: all test

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -271,23 +271,23 @@ the server has requested that."
   :group 'lsp-mode
   :package-version '(lsp-mode . "6.1"))
 
-(defcustom lsp-file-watch-ignored '(".idea"
-                                    ".ensime_cache"
-                                    ".eunit"
-                                    "node_modules"
-                                    ".git"
-                                    ".hg"
-                                    ".fslckout"
-                                    "_FOSSIL_"
-                                    ".bzr"
-                                    "_darcs"
-                                    ".tox"
-                                    ".svn"
-                                    ".stack-work"
-                                    ".bloop"
-                                    ".metals"
-                                    "target")
-  "List of directories which won't be monitored when creating file watches."
+(defcustom lsp-file-watch-ignored '("[/\\\\]\\.idea$"
+                                    "[/\\\\]\\.ensime_cache$"
+                                    "[/\\\\]\\.eunit$"
+                                    "[/\\\\]node_modules$"
+                                    "[/\\\\]\\.git$"
+                                    "[/\\\\]\\.hg$"
+                                    "[/\\\\]\\.fslckout$"
+                                    "[/\\\\]_FOSSIL_$"
+                                    "[/\\\\]\\.bzr$"
+                                    "[/\\\\]_darcs$"
+                                    "[/\\\\]\\.tox$"
+                                    "[/\\\\]\\.svn$"
+                                    "[/\\\\]\\.stack-work$"
+                                    "[/\\\\]\\.bloop$"
+                                    "[/\\\\]\\.metals$"
+                                    "[/\\\\]target$")
+  "List of regexps matching directory paths which won't be monitored when creating file watches."
   :group 'lsp-mode
   :type '(repeat string)
   :package-version '(lsp-mode . "6.1"))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -292,6 +292,9 @@ the server has requested that."
   :type '(repeat string)
   :package-version '(lsp-mode . "6.1"))
 
+;; Allow lsp-file-watch-ignored as a file or directory-local variable
+(put 'lsp-file-watch-ignored 'safe-local-variable 'lsp--string-listp)
+
 (defcustom lsp-after-uninitialized-hook nil
   "List of functions to be called after a Language Server has been uninitialized."
   :type 'hook
@@ -679,6 +682,10 @@ They are added to `markdown-code-lang-modes'")
 (defun seq-rest (sequence)
   "Return a sequence of the elements of SEQUENCE except the first one."
   (seq-drop sequence 1))
+
+(defun lsp--string-listp (sequence)
+  "Return t if all elements of SEQUENCE are strings, else nil."
+  (not (seq-find (lambda (x) (not (stringp x))) sequence)))
 
 (defun lsp--info (format &rest args)
   "Display lsp info message with FORMAT with ARGS."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -271,22 +271,29 @@ the server has requested that."
   :group 'lsp-mode
   :package-version '(lsp-mode . "6.1"))
 
-(defcustom lsp-file-watch-ignored '("[/\\\\]\\.idea$"
+(defcustom lsp-file-watch-ignored '(; SCM tools
+                                    "[/\\\\]\\.git$"
+                                    "[/\\\\]\\.hg$"
+                                    "[/\\\\]\\.bzr$"
+                                    "[/\\\\]_darcs$"
+                                    "[/\\\\]\\.svn$"
+                                    "[/\\\\]_FOSSIL_$"
+                                    ; IDE tools
+                                    "[/\\\\]\\.idea$"
                                     "[/\\\\]\\.ensime_cache$"
                                     "[/\\\\]\\.eunit$"
                                     "[/\\\\]node_modules$"
-                                    "[/\\\\]\\.git$"
-                                    "[/\\\\]\\.hg$"
                                     "[/\\\\]\\.fslckout$"
-                                    "[/\\\\]_FOSSIL_$"
-                                    "[/\\\\]\\.bzr$"
-                                    "[/\\\\]_darcs$"
                                     "[/\\\\]\\.tox$"
-                                    "[/\\\\]\\.svn$"
                                     "[/\\\\]\\.stack-work$"
                                     "[/\\\\]\\.bloop$"
                                     "[/\\\\]\\.metals$"
-                                    "[/\\\\]target$")
+                                    "[/\\\\]target$"
+                                    ; Autotools output
+                                    "[/\\\\]\\.deps$"
+                                    "[/\\\\]build-aux$"
+                                    "[/\\\\]autom4te.cache$"
+                                    "[/\\\\]\\.reference$")
   "List of regexps matching directory paths which won't be monitored when creating file watches."
   :group 'lsp-mode
   :type '(repeat string)


### PR DESCRIPTION
The first three of these commits are pretty straightforward.

The final one does a bit of rearrangement and adds new ignored directories for autotools generated output such as the .deps directory etc.  I don't know if this is appropriate or whether we should be requesting people update this themselves with their own personal stuff, but there're a number of relatively esoteric regexps in the list already so...

But I purposefully put this commit last so it could be left out of the merge if desired.