### PR TITLE
Avoid watching ignored folders on callbacks (#805)

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1058,7 +1058,7 @@ DELETE when `lsp-mode.el' is deleted.")
 
 (defun lsp-watch-root-folder (dir callback &optional watch)
   "Create recursive file notificaton watch in DIR.
-CALLBACK is the will be called when there are changes in any of
+CALLBACK will be called when there are changes in any of
 the monitored files. WATCHES is a hash table directory->file
 notification handle which contains all of the watch that
 already have been created."
@@ -1071,24 +1071,7 @@ already have been created."
            (file-notify-add-watch
             dir
             '(change)
-            (lambda (event)
-              (let ((file-name (cl-caddr event))
-                    (event-type (cadr event)))
-                (cond
-                 ((and (file-directory-p file-name)
-                       (equal 'created event-type))
-
-                  (lsp-watch-root-folder file-name callback watch)
-
-                  ;; process the files that are already present in
-                  ;; the directory.
-                  (->> (directory-files-recursively file-name ".*" t)
-                       (seq-do (lambda (f)
-                                 (unless (file-directory-p f)
-                                   (funcall callback (list nil 'created f)))))))
-                 ((and (not (file-directory-p file-name))
-                       (memq event-type '(created deleted changed)))
-                  (funcall callback event))))))
+            (lambda (event) (funcall 'lsp--folder-watch-callback event callback watch)))
            (lsp-watch-descriptors watch))
           (seq-do
            (-rpartial #'lsp-watch-root-folder callback watch)
@@ -1101,6 +1084,26 @@ already have been created."
       (error (lsp-log "Failed to create a watch for %s: message" (error-message-string err)))
       (file-missing (lsp-log "Failed to create a watch for %s: message" (error-message-string err))))
     watch))
+
+(defun lsp--folder-watch-callback (event callback watch)
+  (let ((file-name (cl-caddr event))
+        (event-type (cadr event)))
+    (cond
+     ((and (file-directory-p file-name)
+           (equal 'created event-type)
+           (not (lsp--string-match-any lsp-file-watch-ignored file-name)))
+
+      (lsp-watch-root-folder file-name callback watch)
+
+      ;; process the files that are already present in
+      ;; the directory.
+      (->> (directory-files-recursively file-name ".*" t)
+           (seq-do (lambda (f)
+                     (unless (file-directory-p f)
+                       (funcall callback (list nil 'created f)))))))
+     ((and (not (file-directory-p file-name))
+           (memq event-type '(created deleted changed)))
+      (funcall callback event)))))
 
 (defun lsp-kill-watch (watch)
   "Delete WATCH."


### PR DESCRIPTION
Fixes #805 by also applying the filer on the folder created event