### PR TITLE
Add scala to lsp-language-id-configuration.

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -509,6 +509,7 @@ If set to `:none' neither of two will be enabled."
 
 (defvar lsp-language-id-configuration '((".*.vue" . "vue")
                                         (".*.tsx" . "typescriptreact")
+                                        (scala-mode . "scala")
                                         (julia-mode . "julia")
                                         (java-mode . "java")
                                         (python-mode . "python")


### PR DESCRIPTION
As discussed - add scala to list of lsp language configurations so we can maintain and refactor in one place.