### PR TITLE
Add dart-mode language-id

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -555,7 +555,8 @@ If set to `:none' neither of two will be enabled."
                                         (ruby-mode . "ruby")
                                         (enh-ruby-mode . "ruby")
                                         (f90-mode . "fortran")
-                                        (elm-mode . "elm"))
+                                        (elm-mode . "elm")
+                                        (dart-mode . "dart"))
   "Language id configuration.")
 
 (defvar lsp-method-requirements


### PR DESCRIPTION
Added language-id for dart-mode. Related to https://github.com/dart-lang/sdk/issues/37011