### PR TITLE
Detect dart executable from dart-sdk-dir

### DIFF
--- a/lsp-dart.el
+++ b/lsp-dart.el
@@ -70,7 +70,7 @@
 
 (defun lsp-dart--analysis-server-command ()
   "Generate LSP startup command."
-  `("dart"
+  `(,(expand-file-name (f-join lsp-dart-sdk-dir "bin/dart"))
     ,(expand-file-name (f-join lsp-dart-sdk-dir "bin/snapshots/analysis_server.dart.snapshot"))
     "--lsp"))
 


### PR DESCRIPTION
Dart analysis server's version must be same as `dart` executable.
So we should detect dart executable from dart-sdk-dir.