### PR TITLE
Handle invalid diagnostic regions more robustly

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1274,14 +1274,15 @@ WORKSPACE is the workspace that contains the diagnostics."
                                     (-let* (((&hash "line" "character") (gethash "start" range))
                                             (region (flymake-diag-region (current-buffer) (1+ line) character)))
                                       (setq start (car region) end (cdr region))))
-                                  (flymake-make-diagnostic (current-buffer)
-                                                           start
-                                                           end
-                                                           (cl-case severity
-                                                             (1 :error)
-                                                             (2 :warning)
-                                                             (t :note))
-                                                           message))))
+				  (when (and start end)
+                                    (flymake-make-diagnostic (current-buffer)
+                                                             start
+                                                             end
+                                                             (cl-case severity
+                                                               (1 :error)
+                                                               (2 :warning)
+                                                               (t :note))
+                                                             message)))))
                ;; This :region keyword forces flymake to delete old diagnostics in
                ;; case the buffer hasn't changed since the last call to the report
                ;; function. See https://github.com/joaotavora/eglot/issues/159

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1272,9 +1272,9 @@ WORKSPACE is the workspace that contains the diagnostics."
                                         ((start . end) (lsp--range-to-region range)))
                                   (when (= start end)
 				    (-let (((&hash "line" start-line "character") (gethash "start" range)))
-                                      (-if-let ((region (flymake-diag-region (current-buffer)
-									     (1+ start-line)
-									     character)))
+                                      (if-let ((region (flymake-diag-region (current-buffer)
+									    (1+ start-line)
+									    character)))
 					  (setq start (car region)
 						end (cdr region))
 					(save-excursion

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1271,18 +1271,27 @@ WORKSPACE is the workspace that contains the diagnostics."
                          (--map (-let* (((&hash "message" "severity" "range") (lsp-diagnostic-original it))
                                         ((start . end) (lsp--range-to-region range)))
                                   (when (= start end)
-                                    (-let* (((&hash "line" "character") (gethash "start" range))
-                                            (region (flymake-diag-region (current-buffer) (1+ line) character)))
-                                      (setq start (car region) end (cdr region))))
-				  (when (and start end)
-                                    (flymake-make-diagnostic (current-buffer)
-                                                             start
-                                                             end
-                                                             (cl-case severity
-                                                               (1 :error)
-                                                               (2 :warning)
-                                                               (t :note))
-                                                             message)))))
+				    (-let (((&hash "line" start-line "character") (gethash "start" range)))
+                                      (-if-let ((region (flymake-diag-region (current-buffer)
+									     (1+ start-line)
+									     character)))
+					  (setq start (car region)
+						end (cdr region))
+					(save-excursion
+					  (save-restriction
+					    (widen)
+					    (goto-char (point-min))
+					    (-let (((&hash "line" end-line) (gethash "end" range)))
+					      (setq start (point-at-bol (1+ start-line))
+						    end (point-at-eol (1+ end-line)))))))))
+                                  (flymake-make-diagnostic (current-buffer)
+                                                           start
+                                                           end
+                                                           (cl-case severity
+                                                             (1 :error)
+                                                             (2 :warning)
+                                                             (t :note))
+                                                           message))))
                ;; This :region keyword forces flymake to delete old diagnostics in
                ;; case the buffer hasn't changed since the last call to the report
                ;; function. See https://github.com/joaotavora/eglot/issues/159


### PR DESCRIPTION
Some programs, such as `pyflakes`, are buggy and report invalid ranges for some diagnostics.  For example, compare the two outputs: one from `pycodestyle` and the other from `pyflakes`:

```json
{
  "diagnostics": [
    {
      "severity": 1,
      "message": "EOF while scanning triple-quoted string literal",
      "range": {
        "end": {
          "character": 112,
          "line": 63
        },
        "start": {
          "character": 56,
          "line": 63
        }
      },
      "source": "pyflakes"
    },
    {
      "severity": 2,
      "code": "E901",
      "message": "E901 TokenError: EOF in multi-line string",
      "range": {
        "end": {
          "character": 12,
          "line": 62
        },
        "start": {
          "character": 8,
          "line": 62
        }
      },
      "source": "pycodestyle"
    }
  ],
  "uri": "file:///path/to/file.py"
}
```

The range reported by `pyflakes` is completely wrong and causes `flymake-diag-region` to return nil, which causes `start` and `end` to become nil, which gives in error in `flymake-make-diagnostic`.

This PR makes `lsp-mode` do nothing if such an invalid range is encountered.