### PR TITLE
Support floating point value in lsp--line-character-to-point

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -992,7 +992,9 @@ INHERIT-INPUT-METHOD will be proxied to `completing-read' without changes."
             (widen)
             (goto-char (point-min))
             (forward-line line)
-            (forward-char character)
+            (if (integerp character)
+                (forward-char character)
+              (end-of-line))
             (point))
         (error (point))))))
 


### PR DESCRIPTION
`rls` returns a large floating number for "end of line". This PR enables `lsp--line-character-to-point` to handle such results.

Here is an example.
```rust
fn main() {
    panic!("foo");
}
```
`M-x lsp-format-buffer` emits the following output.
```rust
fn main() {
        panic!("foo");    panic!("foo");
}
```
```
[Trace - 06:01:33 AM] Sending request 'textDocument/formatting - (31)'.
Params: {
  "textDocument": {
    "uri": "***/main.rs"
  },
  "options": {
    "tabSize": 8,
    "insertSpaces": true
  }
}


[Trace - 06:01:33 AM] Received response 'textDocument/formatting - (31)' in 2ms.
Result: [
  {
    "newText": "        panic!(\"foo\");",
    "range": {
      "end": {
        "character": 1.8446744073709552e+19,
        "line": 1
      },
      "start": {
        "character": 0,
        "line": 1
      }
    }
  }
]
```