### PR TITLE
Add language id config for hack/hack-mode

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -558,6 +558,7 @@ If set to `:none' neither of two will be enabled."
                                         (mhtml-mode . "html")
                                         (go-mode . "go")
                                         (haskell-mode . "haskell")
+                                        (hack-mode . "hack")
                                         (php-mode . "php")
                                         (json-mode . "json")
                                         (rjsx-mode . "javascript")


### PR DESCRIPTION
Summary: there is already a hack client in lsp-mode, this adds an appropriate language id for it.

Test Plan: load a file in hack mode, M-x lsp => no longer get the warning about missing language id