### PR TITLE
Add new lsp-deferred entry point.

### DIFF
--- a/README.org
+++ b/README.org
@@ -84,6 +84,10 @@
      #+END_SRC
      where ~XXX~ could be major mode like ~python~, ~java~, ~c++~. Alternatively, if you want to minimize you configuration you may use ~prog-mode-hook~. In case you do that, ~lsp~ will try to start for each programming mode and echo a message when there is no client registered for the current mode or if the corresponding server is not present. In addition, ~lsp-mode~ will automatically detect and configure [[https://github.com/emacs-lsp/lsp-ui][lsp-ui]] and [[https://github.com/tigersoldier/company-lsp][company-lsp]]. To turn off that behavior you could set ~lsp-auto-configure~ to ~nil~.
 
+     To defer LSP server startup (and DidOpen notifications) until the buffer is visible you can use ~lsp-deferred~ instead of ~lsp~:
+     #+BEGIN_SRC emacs-lisp
+       (add-hook 'XXX-mode-hook #'lsp-deferred)
+     #+END_SRC
 **** Spacemacs
      [[https://github.com/emacs-lsp/lsp-mode][lsp-mode]] is included in spacemacs develop branch. Add ~lsp~ to ~dotspacemacs-configuration-layers~ and configure the language that you want to use to be backed by ~lsp~ backend.
 **** use-package
@@ -102,7 +106,15 @@
        (use-package dap-mode)
        ;; (use-package dap-LANGUAGE) to load the dap adapter for your language
      #+END_SRC
-*** How it works?
+
+     To defer LSP server startup (and DidOpen notifications) until the buffer is visible you can use ~lsp-deferred~ instead of ~lsp~:
+     #+BEGIN_SRC emacs-lisp
+       (use-package lsp-mode
+         :hook (XXX-mode . lsp-deferred)
+         :commands (lsp lsp-deferred))
+     #+END_SRC
+
+*** How does it work?
     ~lsp-mode~ has predefined list of server configurations (loaded in ~lsp-clients.el~) containing a mapping from ~major-mode~ to the server configuration or by using activation function. In addition to the default server configuration located in ~lsp-clients.el~ there are few languages servers which require separate package(check [[#supported-languages][Supported languages]]). When you open a file from a particular project ~lsp-mode~ and call ~lsp~ command ~lsp-mode~ will look for server registrations able to handle current file. If there is such client ~lsp-mode~ will look for the project root. If you open a file from the project for the first time you will be prompted to define the current project root. Once the project root is selected it is saved in ~lsp-session~ file and it will be loaded the next time you start Emacs so you no longer will be asked for a project root when you open a file from that project. Later if you want to change the project root you may use ~lsp-workspace-folder-remove~ to remove the project and call ~lsp-workspace-folder-add~ to add the root. If you want to force starting a particular language server in a file you may use ~C-u~ ~M-x~ ~lsp~ which will prompt you to select language server to start.
 ** Supported languages
    Some of the servers are directly supported by ~lsp-mode~ by requiring


### PR DESCRIPTION
You can use lsp-deferred instead of lsp in your major mode hooks. This
will defer starting the LSP server and adding the file to the LSP
server until the buffer is actually visible in Emacs. This can make
startup a lot faster because it avoids sending all open files at once
to the LSP server when starting Emacs or restarting the workspace.

Fixes #792