### PR TITLE
Change `lsp-print-io` to `lsp-log-io` in README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -181,7 +181,7 @@
    - ~lsp-lens-hide~ - Hide lenses in the current file
    - ~lsp-lens-mode~ (experimental) - Turn on/off lenses in the current file.
 ** Settings
-   - ~lsp-print-io~ - If non-nil, print all messages to and from the language server to ~*lsp-log*~.
+   - ~lsp-log-io~ - If non-nil, print all messages to and from the language server to ~*lsp-log*~.
    - ~lsp-print-performance~ - If non-nil, print performance info. to ~*lsp-log*~.
    - ~lsp-inhibit-message~ - If non-nil, inhibit the message echo via ~inhibit-message~.
    - ~lsp-report-if-no-buffer~ - If non nil the errors will be reported even when the file is not open.
@@ -242,7 +242,7 @@
 
    [[file:https://graphs.waffle.io/emacs-lsp/lsp-mode/throughput.svg]]
 ** Troubleshooting
-   - set ~lsp-print-io~ to ~t~ to inspect communication between client and the server.
+   - set ~lsp-log-io~ to ~t~ to inspect communication between client and the server.
    - ~lsp-describe-session~ will show the current projects roots + the started severs and allows inspecting the server capabilities.
    #+caption: Describe session
    [[file:examples/describe.png]]


### PR DESCRIPTION
Due to the obsolete of `lsp-print-io`, I supplanted it by `lsp-log-io` in order to prevent the `README.org` from outdated version