### PR TITLE
Prevent void-function call when rendering markdown

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3417,7 +3417,11 @@ Stolen from `org-copy-visible'."
     (while (re-search-forward "^[-]+$" nil t)
       (replace-match ""))
 
-    (gfm-view-mode)
+    ;; markdown-mode v2.3 does not yet provide gfm-view-mode
+    (if (fboundp 'gfm-view-mode)
+	(gfm-view-mode)
+      (gfm-mode))
+
     (lsp--setup-markdown major-mode)))
 
 (defun lsp--fontlock-with-mode (str mode)


### PR DESCRIPTION
Hi there,

I ran into an issue with lsp-mode not rendering markdown properly. Not much of an elisp developer, but i traced it down to a call of gfm-view-mode which is not provided by markdown v 2.3.