### PR TITLE
pyls rope completion is disabled by default

### DIFF
--- a/lsp-pyls.el
+++ b/lsp-pyls.el
@@ -256,7 +256,7 @@ dot."
   :group 'lsp-pyls
   :package-version '(lsp-mode . "6.1"))
 
-(defcustom lsp-pyls-plugins-rope-completion-enabled t
+(defcustom lsp-pyls-plugins-rope-completion-enabled nil
   "Enable or disable the plugin."
   :type 'boolean
   :group 'lsp-pyls


### PR DESCRIPTION
Closes #923 
according to https://github.com/palantir/python-language-server/commit/af4dcb325d70629435456ce253275edbb84877e1
rope completion should be disabled by default. As well as Jedi completion
works generally faster.