### PR TITLE
Pipe stderr for tramp connections

### DIFF
--- a/README.org
+++ b/README.org
@@ -237,7 +237,7 @@
                          :server-id 'pyls-remote))
      #+END_SRC
 **** Dealing with stderr
-    With TRAMP, Emacs does not have an easy way to distinguish stdout and stderr, so when the underlying LSP process writes to stderr, it breaks the ~lsp-mode~ parser. As a workaround, redirect stderr to ~/dev/null~ in the shell code, e.g. use the following ~:new-connection~ argument in the ~make-lsp-client~ call: ~(lsp-tramp-connection "/path/to/server 2>/dev/null")~.
+    With TRAMP, Emacs does not have an easy way to distinguish stdout and stderr, so when the underlying LSP process writes to stderr, it breaks the ~lsp-mode~ parser. As a workaround, ~lsp-mode~ is redirecting stderr to ~/tmp/<process-name>-<id>~stderr~.
 ** Limitations
 *** File watches
     When some of the workspaces that are active in the current project requests file notifications via ~workspace/didChangeWatchedFiles~ ~lsp-mode~ will start monitoring each of the folders in the workspace for changes. In case your project contains a lot of files you might want to disable file monitoring via ~lsp-enable-file-watchers~ (you may use dir-locals).

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -345,6 +345,8 @@ This flag affects only server which do not support incremental update."
   :group 'lsp-mode
   :package-version '(lsp-mode . "6.1"))
 
+(defvar lsp--stderr-index 0)
+
 (defvar lsp--delayed-requests nil)
 (defvar lsp--delay-timer nil)
 
@@ -4704,15 +4706,22 @@ should return the command to start the LS server."
                 (cons tcp-client-connection cmd-proc)))
    :test? (lambda () (executable-find (cl-first (funcall command-fn 0))))))
 
-(defun lsp-tramp-connection (local-command)
+(defun lsp-tramp-connection (local-command &optional generate-error-file-fn)
   "Create LSP stdio connection named name.
 LOCAL-COMMAND is either list of strings, string or function which
 returns the command to execute."
   (list :connect (lambda (filter sentinel name)
                    (let* ((final-command (lsp-resolve-final-function local-command))
                           ;; wrap with stty to disable converting \r to \n
-                          (wrapped-command (append '("stty" "raw" ";") final-command))
-                          (process-name (generate-new-buffer-name name)))
+                          (process-name (generate-new-buffer-name name))
+                          (wrapped-command (append '("stty" "raw" ";")
+                                                   final-command
+                                                   (list
+                                                    (concat "2>"
+                                                            (or (when generate-error-file-fn
+                                                                  (funcall generate-error-file-fn name))
+                                                                (format "/tmp/%s-%s-stderr" name
+                                                                        (cl-incf lsp--stderr-index))))))))
                      (let ((proc (apply 'start-file-process-shell-command process-name
                                         (format "*%s*" process-name) wrapped-command)))
                        (set-process-sentinel proc sentinel)


### PR DESCRIPTION
- Fixes #914

- when using lsp over tramp stderr and stdout are not separated, so pipe stderr
  locally to avoid breaking the parser