### PR TITLE
Fix invalid usage of format function

### DIFF
--- a/lsp-fsharp.el
+++ b/lsp-fsharp.el
@@ -90,7 +90,7 @@ To use the mono/.Net framework version, set this to \"https://ci.appveyor.com/ap
   "Downloads the latest version of fsautocomplete, and set `lsp-fsharp-server-path'."
   (let* ((temp-file (make-temp-file "fsautocomplete" nil ".zip"))
          (install-dir-full (expand-file-name lsp-fsharp-server-install-dir))
-         (unzip-script (cond ((executable-find "unzip") (format "bash -c 'mkdir -p %s && unzip -qq %s -d %s'") install-dir-full temp-file install-dir-full)
+         (unzip-script (cond ((executable-find "unzip") (format "mkdir -p %s && unzip -qq %s -d %s" install-dir-full temp-file install-dir-full))
                              ((executable-find "powershell") (format "powershell -noprofile -noninteractive -nologo -ex bypass Expand-Archive -path '%s' -dest '%s'" temp-file install-dir-full))
                              (t (user-error (format "Unable to unzip server - file %s cannot be extracted, please extract it manually") temp-file)))))
     (url-copy-file lsp-fsharp-server-download-url temp-file t)


### PR DESCRIPTION
Also don't depend on `bash` and prevent wrapping command in a duplicate shell.

@TOTBWF
Trying to install `F#` server:

```
Debugger entered--Lisp error: (error "Not enough arguments for format string")
  format("bash -c 'mkdir -p %s && unzip -qq %s -d %s'")
  lsp-fsharp--fsac-install()
  lsp-fsharp--fsac-locate()
  lsp-fsharp--make-launch-cmd()
  lsp-resolve-final-function(lsp-fsharp--make-launch-cmd)
  #f(compiled-function () #<bytecode 0x1c30bdd>)()
```

Duplicate shell:

```
sudo execsnoop.py 
bash             12964  12504    0 /bin/bash -c bash -c 'mkdir -p /home/juergen/.emacs.d/fsautocomplete/ && unzip -qq /tmp/fsautocompletebq0sdD.zip -d /home/juergen/.emacs.d/fs
```
