### PR TITLE
Initial support for running docker over locally hosted files

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -920,7 +920,7 @@ INHERIT-INPUT-METHOD will be proxied to `completing-read' without changes."
   ;; SENTINEL.  FILTER should be used as process filter for
   ;; COMMUNICATION-PROCESS, and SENTINEL should be used as process sentinel for
   ;; COMMAND-PROCESS.
-  (new-connection nil :read-only t)
+  (new-connection nil)
 
   ;; ‘ignore-regexps’ is a list of regexps.  When a data packet from the
   ;; language server matches any of these regexps, it will be ignored.  This is
@@ -1000,7 +1000,13 @@ INHERIT-INPUT-METHOD will be proxied to `completing-read' without changes."
   (remote? nil)
 
   ;; ‘completion-in-comments?’ t if the client supports completion in comments.
-  (completion-in-comments? nil))
+  (completion-in-comments? nil)
+
+  ;; ‘path->uri-fn’ the function to use for path->uri convertion for the client.
+  (path->uri-fn nil)
+
+  ;; ‘uri->path-fn’ the function to use for uri->path convertion for the client.
+  (uri->path-fn nil))
 
 ;; from http://emacs.stackexchange.com/questions/8082/how-to-get-buffer-position-given-line-number-and-column-number
 (defun lsp--line-character-to-point (line character)
@@ -1059,6 +1065,14 @@ On other systems, returns path without change."
 
 (defun lsp--uri-to-path (uri)
   "Convert URI to a file path."
+  (if-let (fn (->> (lsp-workspaces)
+                       (-keep (-compose #'lsp--client-uri->path-fn #'lsp--workspace-client))
+                       (cl-first)))
+      (funcall fn uri)
+    (lsp--uri-to-path-1 uri)))
+
+(defun lsp--uri-to-path-1 (uri)
+  "Convert URI to a file path."
   (let* ((url (url-generic-parse-url (url-unhex-string uri)))
          (type (url-type url))
          (file (decode-coding-string (url-filename url) locale-coding-system))
@@ -1086,11 +1100,18 @@ On other systems, returns path without change."
   "Implemented only to make `company-lsp' happy.
 DELETE when `lsp-mode.el' is deleted.")
 
-(defun lsp--path-to-uri (path)
-  "Convert PATH to a uri."
+(defun lsp--path-to-uri-1 (path)
   (concat lsp--uri-file-prefix
           (url-hexify-string (expand-file-name (or (file-remote-p path 'localname t) path))
                              url-path-allowed-chars)))
+
+(defun lsp--path-to-uri (path)
+  "Convert PATH to a uri."
+  (if-let (uri-fn (->> (lsp-workspaces)
+                       (-keep (-compose #'lsp--client-path->uri-fn #'lsp--workspace-client))
+                       (cl-first)))
+      (funcall uri-fn path)
+    (lsp--path-to-uri-1 path)))
 
 (defun lsp--string-match-any (regex-list str)
   "Given a list of REGEX-LIST and STR return the first matching regex if any."
@@ -4946,6 +4967,19 @@ SESSION is the active session."
                (eq client client-or-list))))))
    lsp-disabled-clients))
 
+(defun lsp--create-matching-clients? (buffer-major-mode remote?)
+  (-lambda (client)
+    (and (and (or (-some-> client lsp--client-activation-fn (funcall buffer-file-name buffer-major-mode))
+                  (and (not (lsp--client-activation-fn client))
+                       (-contains? (lsp--client-major-modes client) buffer-major-mode)
+                       (eq (---truthy? remote?) (---truthy? (lsp--client-remote? client)))))
+              (-some-> client lsp--client-new-connection (plist-get :test?) funcall))
+         (or (null lsp-enabled-clients)
+             (or (member (lsp--client-server-id client) lsp-enabled-clients)
+                 (ignore (lsp--info "Client %s is not in lsp-enabled-clients"
+                                    (lsp--client-server-id client)))))
+         (not (lsp--client-disabled-p buffer-major-mode (lsp--client-server-id client))))))
+
 (defun lsp--find-clients (buffer-major-mode file-name)
   "Find clients which can handle BUFFER-MAJOR-MODE.
 SESSION is the currently active session. The function will also
@@ -4954,17 +4988,7 @@ remote machine and vice versa."
   (let ((remote? (file-remote-p file-name)))
     (-when-let (matching-clients (->> lsp-clients
                                       hash-table-values
-                                      (-filter (-lambda (client)
-                                                 (and (and (or (-some-> client lsp--client-activation-fn (funcall buffer-file-name buffer-major-mode))
-                                                               (and (not (lsp--client-activation-fn client))
-                                                                    (-contains? (lsp--client-major-modes client) buffer-major-mode)
-                                                                    (eq (---truthy? remote?) (---truthy? (lsp--client-remote? client)))))
-                                                           (-some-> client lsp--client-new-connection (plist-get :test?) funcall))
-                                                      (or (null lsp-enabled-clients)
-                                                          (or (member (lsp--client-server-id client) lsp-enabled-clients)
-                                                              (ignore (lsp--info "Client %s is not in lsp-enabled-clients"
-                                                                                 (lsp--client-server-id client)))))
-                                                      (not (lsp--client-disabled-p buffer-major-mode (lsp--client-server-id client))))))))
+                                      (-filter (lsp--create-matching-clients? buffer-major-mode remote?))))
       (lsp-log "Found the following clients for %s: %s"
                file-name
                (s-join ", "


### PR DESCRIPTION
* Added the capability to override the paths to point to another location in the
docker container

Here it is sample implementation docker support:

``` emacs-lisp
(defun lsp--docker-uri->path (path-mappings docker-container-name uri)
  (let ((path (lsp--uri-to-path-1 uri)))
    (-if-let ((local . remote) (-first (-lambda ((_ . docker-path))
                                         (s-contains? docker-path path))
                                       path-mappings))
        (s-replace remote local path)
      (format "/docker:%s:%s" docker-container-name path))))

(defun lsp--docker-path->uri (path-mappings path)
  (lsp--path-to-uri-1
   (-if-let ((local . remote) (-first (-lambda ((local-path . _))
                                        (s-contains? local-path path))
                                      path-mappings))
       (s-replace local remote path)
     (user-error path))))

(cl-defun lsp-docker-register-client (&key server-id
                                           docker-server-id
                                           path-mappings
                                           docker-image-id
                                           docker-container-name
                                           priority
                                           server-command)

  (if-let ((client (copy-lsp--client (gethash server-id lsp-clients))))
      (progn
        (when priority (setf (lsp--client-priority client) priority))
        (setf (lsp--client-server-id client) docker-server-id
              (lsp--client-uri->path-fn client) (-partial #'lsp--docker-uri->path
                                                          path-mappings
                                                          docker-container-name)
              (lsp--client-path->uri-fn client) (-partial #'lsp--docker-path->uri path-mappings)
              (lsp--client-new-connection client) (lsp-stdio-connection
                                                   (lambda ()
                                                     (split-string
                                                      (--doto (format "docker run --name %s --rm -i %s %s %s"
                                                                      docker-container-name
                                                                      (->> path-mappings
                                                                           (-map (-lambda ((path . docker-path))
                                                                                   (format "-v %s:%s" path docker-path)))
                                                                           (s-join " "))
                                                                      docker-image-id
                                                                      server-command)
                                                        (message "XXXX %s" it))
                                                      " "))))
        (lsp-register-client client))
    (user-error "No such client %s" server-id)))

(ignore
 (lsp-docker-register-client
  :server-id 'rls
  :priority 1
  :docker-server-id 'rls-docker
  :docker-image-id "96c0b09ce0fe"
  :docker-container-name "rls-container3"
  :server-command "/root/.cargo/bin/rls"
  :path-mappings '(("/home/kyoncho/Sources/rust/rs-font-lock/" . "/mount-dir/rs-font-lock/" ))))
```