### PR TITLE
Fix typo within lsp-metals-sources-scan

### DIFF
--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -107,7 +107,7 @@ more customizations like using environment variables."
 (defun lsp-metals-sources-scan ()
   "Walk all files in the workspace and index where symbols are defined."
   (interactive)
-  (lsp-send-execute-command "source-scan" ()))
+  (lsp-send-execute-command "sources-scan" ()))
 
 (defun lsp-metals--doctor-render (html)
   "Render the Metals doctor html in the current buffer."


### PR DESCRIPTION
According to this: https://github.com/scalameta/metals/blob/5b32788701b2a1c7970c3b124def457cfce6c59c/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala#L37

we miss here 's' for `sources-scan` command.