### PR TITLE
Fix invalid quote of defcustom const value

### DIFF
--- a/lsp-fsharp.el
+++ b/lsp-fsharp.el
@@ -36,9 +36,9 @@
 (defcustom lsp-fsharp-server-runtime 'net-core
   "The .NET runtime to use."
   :group 'lsp-fsharp
-  :type '(choice (const :tag "Use .Net Core" 'net-core)
-                 (const :tag "Use Mono" 'mono)
-                 (const :tag "Use .Net Framework" 'net-framework))
+  :type '(choice (const :tag "Use .Net Core" net-core)
+                 (const :tag "Use Mono" mono)
+                 (const :tag "Use .Net Framework" net-framework))
   :package-version '(lsp-mode . "6.1"))
 
 (defcustom lsp-fsharp-server-install-dir (locate-user-emacs-file "fsautocomplete/")


### PR DESCRIPTION
While the default value is correct:
```
ELISP> lsp-fsharp-server-runtime
net-core
ELISP> (type-of lsp-fsharp-server-runtime)
symbol
```

Trying to set `(customize-set-variable lsp-fsharp-server-runtime)` to `Mono` results in

```
ELISP> lsp-fsharp-server-runtime
'mono
ELISP> (type-of lsp-fsharp-server-runtime)
cons
``` 
 
And thus failing to start the server