### PR TITLE
add custom variable to control skip hover on empty line

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3694,9 +3694,8 @@ RENDER-ALL - nil if only the signature should be rendered."
   (if (and lsp--hover-saved-bounds
            (lsp--point-in-bounds-p lsp--hover-saved-bounds))
       (lsp--eldoc-message lsp--eldoc-saved-message)
-    (let* ((whitespace-or-newline (looking-at "[[:space:]\n]"))
-           (skip-hover (and lsp-hover-skip-whitespace-or-newline whitespace-or-newline)))
-      (unless skip-hover
+    (let* ((whitespace-or-newline (looking-at "[[:space:]\n]")))
+      (unless whitespace-or-newline
         (setq lsp--hover-saved-bounds nil
               lsp--eldoc-saved-message nil)
         (let ((request-id (cl-incf lsp-hover-request-id)) (pending 0))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -392,11 +392,6 @@ This flag affects only server which do not support incremental update."
   :type 'boolean
   :group 'lsp-mode)
 
-(defcustom lsp-hover-skip-whitespace-or-newline nil
-  "If non-nil, hover request will not be sent when cursor is at whitespace or newline."
-  :type 'boolean
-  :group 'lsp-mode)
-
 (defcustom lsp-eldoc-enable-signature-help t
   "If non-nil, eldoc will display signature help when it is present."
   :type 'boolean

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3690,9 +3690,9 @@ RENDER-ALL - nil if only the signature should be rendered."
            (lsp--point-in-bounds-p lsp--hover-saved-bounds))
       (lsp--eldoc-message lsp--eldoc-saved-message)
     (let* ((whitespace-or-newline (looking-at "[[:space:]\n]")))
+      (setq lsp--hover-saved-bounds nil
+            lsp--eldoc-saved-message nil)
       (unless whitespace-or-newline
-        (setq lsp--hover-saved-bounds nil
-              lsp--eldoc-saved-message nil)
         (let ((request-id (cl-incf lsp-hover-request-id)) (pending 0))
           (when (and lsp-eldoc-enable-hover (lsp--capability "hoverProvider"))
             (cl-incf pending)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -392,6 +392,11 @@ This flag affects only server which do not support incremental update."
   :type 'boolean
   :group 'lsp-mode)
 
+(defcustom lsp-hover-skip-whitespace-or-newline nil
+  "If non-nil, hover request will not be sent when cursor is at whitespace or newline."
+  :type 'boolean
+  :group 'lsp-mode)
+
 (defcustom lsp-eldoc-enable-signature-help t
   "If non-nil, eldoc will display signature help when it is present."
   :type 'boolean
@@ -3689,44 +3694,46 @@ RENDER-ALL - nil if only the signature should be rendered."
   (if (and lsp--hover-saved-bounds
            (lsp--point-in-bounds-p lsp--hover-saved-bounds))
       (lsp--eldoc-message lsp--eldoc-saved-message)
-
-    (setq lsp--hover-saved-bounds nil
-          lsp--eldoc-saved-message nil)
-    (let ((request-id (cl-incf lsp-hover-request-id)) (pending 0))
-      (when (and lsp-eldoc-enable-hover (lsp--capability "hoverProvider"))
-        (cl-incf pending)
-        (lsp-request-async
-         "textDocument/hover"
-         (lsp--text-document-position-params)
-         (lambda (hover)
-           (when (and (eq request-id lsp-hover-request-id))
-             (when hover
-               (when-let (range (gethash "range" hover))
-                 (setq lsp--hover-saved-bounds (lsp--range-to-region range)))
-               (-let (((&hash "contents") hover))
-                 (when-let (message
-                            (and contents (lsp--render-on-hover-content contents lsp-eldoc-render-all)))
-                   (when (or (and (not lsp-eldoc-prefer-signature-help) (setq pending 1))
+    (let* ((whitespace-or-newline (looking-at "[[:space:]\n]"))
+           (skip-hover (and lsp-hover-skip-whitespace-or-newline whitespace-or-newline)))
+      (unless skip-hover
+        (setq lsp--hover-saved-bounds nil
+              lsp--eldoc-saved-message nil)
+        (let ((request-id (cl-incf lsp-hover-request-id)) (pending 0))
+          (when (and lsp-eldoc-enable-hover (lsp--capability "hoverProvider"))
+            (cl-incf pending)
+            (lsp-request-async
+             "textDocument/hover"
+             (lsp--text-document-position-params)
+             (lambda (hover)
+               (when (and (eq request-id lsp-hover-request-id))
+                 (when hover
+                   (when-let (range (gethash "range" hover))
+                     (setq lsp--hover-saved-bounds (lsp--range-to-region range)))
+                   (-let (((&hash "contents") hover))
+                     (when-let (message
+                                (and contents (lsp--render-on-hover-content contents lsp-eldoc-render-all)))
+                       (when (or (and (not lsp-eldoc-prefer-signature-help) (setq pending 1))
+                                 (not lsp--eldoc-saved-message))
+                         (setq lsp--eldoc-saved-message message)))))
+                 (when (zerop (cl-decf pending))
+                   (lsp--eldoc-message lsp--eldoc-saved-message))
+                 (run-hook-with-args 'lsp-on-hover-hook hover)))
+             :error-handler #'ignore))
+          (when (and lsp-eldoc-enable-signature-help (lsp--capability "signatureHelpProvider"))
+            (cl-incf pending)
+            (lsp-request-async
+             "textDocument/signatureHelp"
+             (lsp--text-document-position-params)
+             (lambda (signature)
+               (when (eq request-id lsp-hover-request-id)
+                 (when-let (message (and signature (lsp--signature->eldoc-message signature)))
+                   (when (or (and lsp-eldoc-prefer-signature-help (setq pending 1))
                              (not lsp--eldoc-saved-message))
-                     (setq lsp--eldoc-saved-message message)))))
-             (when (zerop (cl-decf pending))
-               (lsp--eldoc-message lsp--eldoc-saved-message))
-             (run-hook-with-args 'lsp-on-hover-hook hover)))
-         :error-handler #'ignore))
-      (when (and lsp-eldoc-enable-signature-help (lsp--capability "signatureHelpProvider"))
-        (cl-incf pending)
-        (lsp-request-async
-         "textDocument/signatureHelp"
-         (lsp--text-document-position-params)
-         (lambda (signature)
-           (when (eq request-id lsp-hover-request-id)
-             (when-let (message (and signature (lsp--signature->eldoc-message signature)))
-               (when (or (and lsp-eldoc-prefer-signature-help (setq pending 1))
-                         (not lsp--eldoc-saved-message))
-                 (setq lsp--eldoc-saved-message message)))
-             (when (zerop (cl-decf pending))
-               (lsp--eldoc-message lsp--eldoc-saved-message))))
-         :error-handler #'ignore)))))
+                     (setq lsp--eldoc-saved-message message)))
+                 (when (zerop (cl-decf pending))
+                   (lsp--eldoc-message lsp--eldoc-saved-message))))
+             :error-handler #'ignore)))))))
 
 (defun lsp--select-action (actions)
   "Select an action to execute from ACTIONS."


### PR DESCRIPTION
One of my LSP server apps will crash if received hover request on empty line. This change will add the feature to skip sending hover request to LSP server on empty lines.

