### PR TITLE
[untested] Add basic support for clangd-style semantic highlighting

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3989,7 +3989,7 @@ unless overriden by a more specific face association."
   :group 'lsp-faces)
 
 (defface lsp-face-semhl-preprocessor
-  '((t :inherit font-lock-constant-face :bold t))
+  '((t :inherit font-lock-preprocessor-face))
   "Face used for semantic highlighting scopes matching entity.name.function.preprocessor.*,
 unless overriden by a more specific face association."
   :group 'lsp-faces)


### PR DESCRIPTION
Hi,

this PR is meant to be a basis for discussion, though it already seems to work pretty well on my machine (using Emacs 27 trunk, clang/clangd 10 also built from trunk). Some real and potential disadvantages I'm aware of:

- fontification is done exclusively through overlays (as opposed to emacs-ccls, which allows the user to choose between overlays and `font-lock`-based fontification). I didn't notice any speed issues, but older Emacs versions may not fare so well (cf. https://lists.gnu.org/archive/html/emacs-devel/2018-03/msg00886.html) (BTW, does anyone know what happened to the overlay branch? I thought it had been merged a long time ago but was unable to find evidence for that)

- highlights pushed by the server are always applied, even if the buffer in question isn't currently visible. Again, currently not a problem for me but may be a problem for others or with other language servers

- `lsp--facemap` should probably be a per-server thing, not per-buffer (?)

- so far I haven't tried to optimize the code; especially that `bindat` thing is so convenient I wonder how much I'm paying for that. That being said, the initial fontification run on a ~1000-line C++ file takes about 23ms on my 2014 MacBook Pro; an autogenerated 10000-line file takes ~250ms. Subsequent updates are incremental and do not introduce perceptible delay

- I believe the highlighting protocol is still in flux. Since (AFAIK) there's no currently released version of clangd with support for semantic highlighting, I'd suggest to have lsp-mode track clangd trunk builds as closely as possible

Also, this is the first time I've tried to extend `lsp-mode` in any way and I'm amazed how easy it was to add a useful feature, even if my approach may violate some best practices or style guides. Many thanks to the lsp authors!