### PR TITLE
Implement request tracing on the server side

### DIFF
--- a/README.org
+++ b/README.org
@@ -211,6 +211,7 @@
    - ~lsp-imenu-sort-methods~ - How to sort the imenu items. The value is a list of ~kind~, ~name~ or ~position~. Priorities are determined by the index of the element.
    - ~lsp-response-timeout~ - Number of seconds to wait for a response from the language server before timing out.
    - ~lsp-enable-file-watchers~ - If non-nil lsp-mode will watch the files in the workspace if the server has requested that.
+   - ~lsp-server-trace~ - Request trace mode on the language server.
 ** Screenshots
    - RUST Completion with company-lsp
      [[file:examples/completion.png]]

--- a/doc/src/lsp-mode-vars.adoc
+++ b/doc/src/lsp-mode-vars.adoc
@@ -435,3 +435,15 @@ Default value: `pass:[0.2]`
 
 Seconds of idle time to wait before showing symbol highlight.
 ____
+[id="lsp-server-trace"]
+- `lsp-server-trace`
+____
+Default value `pass:[nil]`
+
+Request tracing on the server side.
+The actual trace output at each level depends on the language server in use.
+Changes take effect only when a new session is started.
+
+Allowed options are ‘off’, ‘messages’, ‘verbose’ or `nil`. `nil` has the same
+effect as ‘off’.
+____

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -538,6 +538,18 @@ If set to `:none' neither of two will be enabled."
   :group 'lsp-mode
   :package-version '(lsp-mode . "6.1"))
 
+(defcustom lsp-server-trace nil
+  "Request tracing on the server side.
+The actual trace output at each level depends on the language server in use.
+Changes take effect only when a new session is started."
+  :type '(choice (const :tag "Disabled" "off")
+		 (const :tag "Messages only" "messages")
+		 (const :tag "Verbose" "verbose")
+		 (const :tag "Default (disabled)" nil))
+  :group 'lsp-mode
+  :package-version '(lsp-mode . "6.1"))
+
+
 (defvar-local lsp--flymake-report-fn nil)
 
 (defvar lsp-language-id-configuration '((".*\.vue$" . "vue")
@@ -4976,6 +4988,8 @@ SESSION is the active session."
                                 :rootUri (lsp--path-to-uri root)
                                 :capabilities (lsp--client-capabilities)
                                 :initializationOptions initialization-options)
+			  (when lsp-server-trace
+			    (list :trace lsp-server-trace))
                           (when (lsp--client-multi-root client)
                             (->> workspace-folders
                                  (-map (lambda (folder)


### PR DESCRIPTION
This provides a customizable variable `lsp-server-trace` to request, at initialization time, that the language server do tracing.

Options are documented in the [LSP spec](https://microsoft.github.io/language-server-protocol/specification#initialize).

This was briefly discussed on Gitter [here](https://gitter.im/emacs-lsp/lsp-mode?at=5d6f894f6d7c672b45b080f2)

