### PR TITLE
Start angular-ls only in angular projects

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -504,7 +504,7 @@ responsiveness at the cost of possibile stability issues."
  (make-lsp-client :new-connection (lsp-stdio-connection
                                    (lambda () lsp-clients-angular-language-server-command))
                   :activation-fn (lambda (&rest _args)
-                                   (when (file-exists-p (concat (car (project-roots (project-current))) "angular.json"))
+                                   (when (file-exists-p (f-join (lsp-workspace-root) "angular.json"))
                                      (string-match-p ".*\.html$" (buffer-file-name))))
                   :priority -1
                   :add-on? t

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -504,7 +504,8 @@ responsiveness at the cost of possibile stability issues."
  (make-lsp-client :new-connection (lsp-stdio-connection
                                    (lambda () lsp-clients-angular-language-server-command))
                   :activation-fn (lambda (&rest _args)
-                                   (string-match-p ".*\.html$" (buffer-file-name)))
+                                   (when (file-exists-p (concat (car (project-roots (project-current))) "angular.json"))
+                                     (string-match-p ".*\.html$" (buffer-file-name))))
                   :priority -1
                   :add-on? t
                   :server-id 'angular-ls))


### PR DESCRIPTION
If `angular.json` in project's root is reliable indicator of angular project and If `(project-roots (project-current))` works on all supported versions of emacs, this could fix issue mentioned here https://github.com/emacs-lsp/lsp-mode/issues/966#issuecomment-528068671