### PR TITLE
Fix missing face attr val + prefer new attr names

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -648,7 +648,7 @@ must be used for handling a particular message.")
   :group 'lsp-faces)
 
 (defface lsp-face-highlight-write
-  '((t :inherit highlight :italic t))
+  '((t :inherit highlight :slant italic))
   "Face used for highlighting symbols being written to."
   :group 'lsp-faces)
 
@@ -3941,7 +3941,7 @@ unless overriden by a more specific face association."
   :group 'lsp-faces)
 
 (defface lsp-face-semhl-field-static
-  '((t :inherit lsp-face-semhl-field :italic t))
+  '((t :inherit lsp-face-semhl-field :slant italic))
   "Face used for semantic highlighting scopes matching variable.other.field.static.*,
 unless overriden by a more specific face association."
   :group 'lsp-faces)
@@ -3971,7 +3971,7 @@ unless overriden by a more specific face association."
   :group 'lsp-faces)
 
 (defface lsp-face-semhl-static-method
-  '((t :inherit lsp-face-semhl-function :italic ))
+  '((t :inherit lsp-face-semhl-function :slant italic))
   "Face used for semantic highlighting scopes matching entity.name.function.method.static.*,
 unless overriden by a more specific face association."
   :group 'lsp-faces)
@@ -3989,7 +3989,7 @@ unless overriden by a more specific face association."
   :group 'lsp-faces)
 
 (defface lsp-face-semhl-namespace
-  '((t :inherit font-lock-type-face :bold t))
+  '((t :inherit font-lock-type-face :weight bold))
   "Face used for semantic highlighting scopes matching entity.name.namespace.*,
 unless overriden by a more specific face association."
   :group 'lsp-faces)
@@ -4001,13 +4001,13 @@ unless overriden by a more specific face association."
   :group 'lsp-faces)
 
 (defface lsp-face-semhl-type-template
-  '((t :inherit font-lock-type-face :italic t))
+  '((t :inherit font-lock-type-face :slant italic))
   "Face used for semantic highlighting scopes matching entity.name.type.template.*,
 unless overriden by a more specific face association."
   :group 'lsp-faces)
 
 (defface lsp-face-semhl-type-primitive
-  '((t :inherit font-lock-type-face :italic t))
+  '((t :inherit font-lock-type-face :slant italic))
   "Face used for semantic highlighting scopes matching storage.type.primitive.*,
 unless overriden by a more specific face association."
   :group 'lsp-faces)


### PR DESCRIPTION
This fixes a small bug resulting from [omitting a `t` value for the `:italic` attribute of `lsp-face-semhl-static-method`](https://github.com/emacs-lsp/lsp-mode/blob/d4b94e4629495dc102960f82c26a71d5ea6c9b2d/lsp-mode.el#L3986) and prefers `:slant` and `:weight` attributes to `:italic` and `:bold`.  The bug can manifest when [`face-attr-match-p`](https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/faces.el?h=emacs-26.3#n1777) is called with `lsp-face-semhl-static-method` (`plist-put` throws an error because the face spec fails to satisfy `plistp` since it is missing a value for the `:italic` key).  I've not made an issue for this since the bug is small and trivial to fix.

The change to use `:slant` and `:weight:` is maybe debatable, but its worth noting that `:italic t` and `:bold t` are essentially aliases for `:slant italic` and `:weight bold`, and are only kept around for backward compatibility. `:slant` and `:weight` have been available since at least Emacs 20.4 and admit a wider range of values.