### PR TITLE
Use featurep to check for yasnippet

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2472,10 +2472,10 @@ disappearing, unset all the variables related to it."
                                                                                                   "source.organizeImports"])))))))
                       (completion . ((completionItem . ((snippetSupport . ,(if lsp-enable-snippet
                                                                                (or
-                                                                                (fboundp 'yas-expand-snippet)
+                                                                                (featurep 'yasnippet)
                                                                                 (warn (concat
-                                                                                       "Yasnippet is not required but `lsp-enable-snippet' is set to `t'. "
-                                                                                       "You must either required yasnippet or disable snippet support."))
+                                                                                       "Yasnippet is not yet loaded, but `lsp-enable-snippet' is set to `t'. "
+                                                                                       "You must either (require 'yasnippet), or disable snippet support."))
                                                                                 t)
                                                                              :json-false))
                                                         (documentationFormat . ["markdown"])))


### PR DESCRIPTION
Also clarify the grammar of the warning message (this was the original reason for this PR) but I do think that `featurep` would be better than checking if a function is bound, since the name could potentially change