### PR TITLE
Check hosts while looking for a session folder

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5667,13 +5667,22 @@ Returns nil if the project should not be added to the current SESSION."
           (t nil)))
     ('quit)))
 
+(defun lsp--files-same-host (f1 f2)
+  "Predicate on whether or not two files are on the same host."
+  (or (not (or (file-remote-p f1) (file-remote-p f2)))
+      (and (file-remote-p f1) 
+           (file-remote-p f2) 
+           (string-equal (tramp-file-name-host (tramp-dissect-file-name f1)) 
+                         (tramp-file-name-host (tramp-dissect-file-name f2))))))
+
 (defun lsp-find-session-folder (session file-name)
   "Look in the current SESSION for folder containing FILE-NAME."
   (let ((file-name-canonical (f-canonical file-name)))
     (->> session
          (lsp-session-folders)
-         (--filter (or (f-same? it file-name-canonical)
-                       (f-ancestor-of? it file-name-canonical)))
+         (--filter (and (lsp--files-same-host it file-name-canonical) 
+                        (or (f-same? it file-name-canonical)
+                            (f-ancestor-of? it file-name-canonical))))
          (--max-by (> (length it)
                       (length other))))))
 


### PR DESCRIPTION
This avoids the problem of attempting to connect to an unreachable
host associated with a different session. The logic is that we should
only consider sessions whose host is the same as that of the file used to
initiate the search for a relevant session.

Fixes #760