### PR TITLE
Fix client capabilities when lsp-enable-file-watchers is nil

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2459,7 +2459,7 @@ disappearing, unset all the variables related to it."
                    (applyEdit . t)
                    (symbol . ((symbolKind . ((valueSet . ,(apply 'vector (number-sequence 1 26)))))))
                    (executeCommand . ((dynamicRegistration . :json-false)))
-                   (didChangeWatchedFiles . ,(when lsp-enable-file-watchers '((dynamicRegistration . t))))
+                   ,@(when lsp-enable-file-watchers '((didChangeWatchedFiles . ((dynamicRegistration . t)))))
                    (workspaceFolders . t)
                    (configuration . t)))
      (textDocument . ((declaration . ((linkSupport . t)))


### PR DESCRIPTION
----------------------

Fixes https://github.com/MaskRay/ccls/issues/482

The specification says `didChangeWatchedFiles` is optional, but it does not say the value can be null.
```typescript
	/**
	 * Capabilities specific to the `workspace/didChangeWatchedFiles` notification.
	 */
	didChangeWatchedFiles?: {
		/**
		 * Did change watched files notification supports dynamic registration. Please note
		 * that the current protocol doesn't support static configuration for file changes
		 * from the server side.
		 */
		dynamicRegistration?: boolean;
	};
```