### PR TITLE
lsp-go: support adding modules to library folders

### DIFF
--- a/lsp-go.el
+++ b/lsp-go.el
@@ -56,8 +56,7 @@ completing function calls."
                   :major-modes '(go-mode)
                   :priority 0
                   :server-id 'gopls
-                  :library-folders-fn (lambda (_workspace)
-                                        lsp-clients-go-library-directories)))
+                  :library-folders-fn 'lsp-clients-go--library-default-directories))
 
 (defgroup lsp-clients-go nil
   "LSP support for the Go Programming Language."
@@ -120,6 +119,33 @@ defaults to half of your CPU cores."
   :risky t
   :type '(repeat string))
 
+(defcustom lsp-clients-go-library-directories-include-go-modules t
+  "Whether or not $GOPATH/pkg/mod should be included as a library directory."
+  :type 'boolean
+  :group 'lsp-clients-go)
+
+(defun lsp-clients-go--library-default-directories (_workspace)
+  "Calculate go library directories.
+
+If `lsp-clients-go-library-directories-include-go-modules' is non-nil
+and the environment variable GOPATH is set this function will return
+$GOPATH/pkg/mod along with the value of
+`lsp-clients-go-library-directories'."
+  (let ((library-dirs lsp-clients-go-library-directories))
+    (when (and lsp-clients-go-library-directories-include-go-modules
+               (or (and (not (file-remote-p default-directory)) (executable-find "go"))
+                   (and (version<= "27.0" emacs-version) (with-no-warnings (executable-find "go" (file-remote-p default-directory))))))
+              (with-temp-buffer
+                (when (zerop (call-process "go" nil t nil "env" "GOPATH"))
+                  (setq library-dirs
+                        (append
+                         library-dirs
+                         (list
+                         (concat
+                          (string-trim-right (buffer-substring (point-min) (point-max)))
+                          "/pkg/mod")))))))
+    library-dirs))
+
 (define-inline lsp-clients-go--bool-to-json (val)
   (inline-quote (if ,val t :json-false)))
 
@@ -143,8 +169,7 @@ defaults to half of your CPU cores."
                   :priority -1
                   :initialization-options 'lsp-clients-go--make-init-options
                   :server-id 'go-bingo
-                  :library-folders-fn (lambda (_workspace)
-                                        lsp-clients-go-library-directories)))
+                  :library-folders-fn 'lsp-clients-go--library-default-directories))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection "go-langserver")
@@ -152,8 +177,7 @@ defaults to half of your CPU cores."
                   :priority -2
                   :initialization-options 'lsp-clients-go--make-init-options
                   :server-id 'go-ls
-                  :library-folders-fn (lambda (_workspace)
-                                        lsp-clients-go-library-directories)))
+                  :library-folders-fn 'lsp-clients-go--library-default-directories))
 
 (provide 'lsp-go)
 ;;; lsp-go.el ends here

--- a/lsp-go.el
+++ b/lsp-go.el
@@ -136,7 +136,7 @@ $GOPATH/pkg/mod along with the value of
                (or (and (not (file-remote-p default-directory)) (executable-find "go"))
                    (and (version<= "27.0" emacs-version) (with-no-warnings (executable-find "go" (file-remote-p default-directory))))))
               (with-temp-buffer
-                (when (zerop (call-process "go" nil t nil "env" "GOPATH"))
+                (when (zerop (process-file "go" nil t nil "env" "GOPATH"))
                   (setq library-dirs
                         (append
                          library-dirs
@@ -144,7 +144,9 @@ $GOPATH/pkg/mod along with the value of
                          (concat
                           (string-trim-right (buffer-substring (point-min) (point-max)))
                           "/pkg/mod")))))))
-    library-dirs))
+    (if (file-remote-p default-directory)
+        (mapcar (lambda (path) (concat (file-remote-p default-directory) path)) library-dirs)
+      library-dirs)))
 
 (define-inline lsp-clients-go--bool-to-json (val)
   (inline-quote (if ,val t :json-false)))


### PR DESCRIPTION
Recent versions of go added the concept of modules as a first class
system for managing third party dependencies. Modules are installed to
$GOPATH/pkg/mod and are set to have read-only file permissions. The
same module+version will be shared across multiple projects.

Jumping to these files should not trigger a prompt for starting a new
lsp server.

This adds logic to detect the modules directory and adds it to
library-folders automatically. This behavior can be disabled with the
customization `lsp-clients-go-library-directories-include-go-modules'.

We invoke the go tool to determine the path of the modules directory
instead of looking at the GOPATH environment variable directly. This
is necessary to determine the default GOPATH directory when the
environment variable isn't set.