### PR TITLE
Autoload and mark file-watch variables as safe to use in dir-locals

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -299,6 +299,7 @@ the server has requested that."
   :type 'boolean
   :group 'lsp-mode
   :package-version '(lsp-mode . "6.1"))
+;;;###autoload(put 'lsp-enable-file-watchers 'safe-local-variable #'booleanp)
 
 (defcustom lsp-file-watch-ignored '(; SCM tools
                                     "[/\\\\]\\.git$"
@@ -694,6 +695,7 @@ must be used for handling a particular message.")
 Set to nil to disable the warning."
   :type 'number
   :group 'lsp-mode)
+;;;###autoload(put 'lsp-file-watch-threshold 'safe-local-variable (lambda (i) (or (numberp i) (not i))))
 
 (defvar lsp-custom-markup-modes
   '((rust-mode "no_run" "rust,no_run" "rust,ignore" "rust,should_panic"))


### PR DESCRIPTION
If this is not autoloaded, then it is only marked as safe from the
defcustom macro *after* the package is loaded.
This may be to late if someone opens a project with
those variables set as dir-local but he has not
loaded lsp-mode before.