### PR TITLE
Switch from autoload to fsharp/workspaceLoad

### DIFF
--- a/lsp-fsharp.el
+++ b/lsp-fsharp.el
@@ -108,13 +108,10 @@ To use the mono/.Net framework version, set this to \"https://ci.appveyor.com/ap
                                 `(:directory ,(lsp-workspace-root)
                                  :deep 10
                                  :excludedDirs ["paket-files" ".git" "packages" "node_modules"])))
-         (data (json-read-from-string (ht-get response "content"))))
-    (let-alist data
-      (let-alist (car (seq-filter (lambda (d)
-                                    (let-alist d
-                                      (equal .Type "directory")))
-                                  .Data.Found))
-        .Data.Fsprojs))))
+         (data (json-read-from-string (ht-get response "content")))
+         (found (cdr (assq 'Found (cdr (assq 'Data data)))))
+         (directory (car (seq-filter (lambda (d) (equal "directory" (cdr (assq 'Type d)))) found))))
+    (cdr (assq 'Fsprojs (cdr (assq 'Data directory))))))
 
 (defun lsp-fsharp--workspace-load (projects)
   "Load all of the provided PROJECTS."

--- a/lsp-fsharp.el
+++ b/lsp-fsharp.el
@@ -102,9 +102,31 @@ To use the mono/.Net framework version, set this to \"https://ci.appveyor.com/ap
   (append (list (lsp-fsharp--fsac-runtime-cmd) (lsp-fsharp--fsac-locate) "--mode" "lsp" "--background-service-enabled")
           lsp-fsharp-server-args))
 
+(defun lsp-fsharp--project-list ()
+  "Get the list of files we need to send to fsharp/workspaceLoad."
+  (let* ((response (lsp-request "fsharp/workspacePeek"
+                                `(:directory ,(lsp-workspace-root)
+                                 :deep 10
+                                 :excludedDirs ["paket-files" ".git" "packages" "node_modules"])))
+         (data (json-read-from-string (ht-get response "content"))))
+    (let-alist data
+      (let-alist (car (seq-filter (lambda (d)
+                                    (let-alist d
+                                      (equal .Type "directory")))
+                                  .Data.Found))
+        .Data.Fsprojs))))
+
+(defun lsp-fsharp--workspace-load (projects)
+  "Load all of the provided PROJECTS."
+  (lsp-request-async "fsharp/workspaceLoad"
+               `(:textDocuments ,(vconcat [] (mapcar (lambda (p) `(:uri ,p)) projects)))
+               (lambda (_)
+                 (lsp--info "Workspace Loaded!"))))
+
 (defun lsp-fsharp--make-init-options ()
   "Init options for F#."
-  `(:automaticWorkspaceInit t))
+  `()
+  )
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection 'lsp-fsharp--make-launch-cmd)
@@ -114,6 +136,9 @@ To use the mono/.Net framework version, set this to \"https://ci.appveyor.com/ap
                                              ("fsharp/fileParsed" #'ignore)
                                              ("fsharp/notifyWorkspacePeek" #'ignore))
                   :initialization-options 'lsp-fsharp--make-init-options
+                  :initialized-fn (lambda (workspace)
+                                    (with-lsp-workspace workspace
+                                      (lsp-fsharp--workspace-load (lsp-fsharp--project-list))))
                   :server-id 'fsac))
 
 (provide 'lsp-fsharp)


### PR DESCRIPTION
Previously, we were using `automaticWorkspaceInit` to get fsautocomplete to load up all of the workspaces. This works fine for simple projects, but fails on more complicated ones.

This PR implements the `fsharp/workspacePeek` and `fsharp/workspaceLoad` protocol, documented [here](https://github.com/fsharp/FsAutoComplete). In the future, it would probably be useful to expose a UI for selecting project files to load, but this is a good first start.