### PR TITLE
Fixed compile error "Unknown rx symbol 'char'" " after emacs rewrite to rx library.

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -99,7 +99,7 @@ finding the executable with variable `exec-path'."
 
 (defun lsp-typescript-javascript-tsx-jsx-activate-p (filename &optional _)
   "Check if the javascript-typescript language server should be enabled based on FILENAME."
-  (string-match-p (rx (one-or-more char) "." (or "ts" "js") (opt "x") string-end) filename))
+  (string-match-p (rx (one-or-more anything) "." (or "ts" "js") (opt "x") string-end) filename))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()


### PR DESCRIPTION
Use 'anything' to match any character in the file basename.
The rewrite was this commit: https://github.com/emacs-mirror/emacs/commit/2ed71227c626c6cfdc684948644ccf3d9eaeb15b