### PR TITLE
Fix default typescript-plugins in typescript language server.

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -136,7 +136,7 @@ finding the executable with variable `exec-path'."
   :group 'lsp-typescript
   :type 'string)
 
-(defcustom lsp-clients-typescript-plugins nil
+(defcustom lsp-clients-typescript-plugins (vector)
   "The list of plugins to load.
 It should be a vector of plist with keys `:location' and `:name'
 where `:name' is the name of the package and `:location' is the


### PR DESCRIPTION
lsp typescript is expected a vector as its plugins if specified, the previous default `nil` is causing lsp typescript to stuck at initialization step.