### PR TITLE
Fix hover text not updating

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3813,12 +3813,11 @@ RENDER-ALL - nil if only the signature should be rendered."
   (if (and lsp--hover-saved-bounds
            (lsp--point-in-bounds-p lsp--hover-saved-bounds))
       (lsp--eldoc-message lsp--eldoc-saved-message)
+    (setq lsp--hover-saved-bounds nil
+          lsp--eldoc-saved-message nil)
     (let* ((whitespace-or-newline (looking-at "[[:space:]\n]")))
       (if whitespace-or-newline
-          (progn
-            (setq lsp--hover-saved-bounds nil
-                  lsp--eldoc-saved-message nil)
-            (lsp--eldoc-message nil))
+          (lsp--eldoc-message nil)
         (let ((request-id (cl-incf lsp-hover-request-id)) (pending 0))
           (when (and lsp-eldoc-enable-hover (lsp--capability "hoverProvider"))
             (cl-incf pending)


### PR DESCRIPTION
```
When moving point from one position with one hover text directly to
another position with a different hover text, the echo area was not
being updated; instead, the previous hover text was being redisplayed.

This was due to the previous message being saved in
lsp--eldoc-saved-message, and redisplayed from there. The only
circumstance in which the variable was cleared was when point was
moved to whitespace and "hovered" there.

Fix this by clearing lsp--eldoc-saved-message as soon as it is clear
that its contents is no longer valid, i.e., before sending a
textDocument/hover request.
```