### PR TITLE
Import new GPG key to download ELPA package on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,15 @@ before_install:
   - make -f emacs-travis.mk install_gnutls install_emacs
   - make -f emacs-travis.mk install_cask
   - docker pull asciidoctor/docker-asciidoctor
+  - |
+    case $EMACS_VERSION in
+    25.*) EMACS_GNUPGHOME=.cask/$EMACS_VERSION/elpa/gnupg ;;
+    *)    EMACS_GNUPGHOME=$HOME/.emacs.d/elpa/gnupg ;;
+    esac
+    mkdir -p "$EMACS_GNUPGHOME"
+    chmod 700 "$EMACS_GNUPGHOME"
+    wget 'https://git.savannah.gnu.org/cgit/emacs.git/plain/etc/package-keyring.gpg'
+    gpg --homedir "$EMACS_GNUPGHOME" --import package-keyring.gpg
 install:
   - cask install
   - sudo pip install python-language-server


### PR DESCRIPTION
This solves `spinner` download error from ELPA.

Emacs 26.1 and 26.2 are failing by other reason.