### PR TITLE
Use non-versioned TextDocumentIdentifier in didClose

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3380,7 +3380,7 @@ if it's closing the last buffer in the workspace."
          (with-demoted-errors "Error sending didClose notification in ‘lsp--text-document-did-close’: %S"
            (lsp-notify
             "textDocument/didClose"
-            `(:textDocument ,(lsp--versioned-text-document-identifier))))
+            `(:textDocument ,(lsp--text-document-identifier))))
          (when (and (not lsp-keep-workspace-alive)
                     (not keep-workspace-alive)
                     (not (lsp--workspace-buffers lsp--cur-workspace)))


### PR DESCRIPTION
According to [the specification](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_didClose), the `textDocument` parameter for `textDocument/didClose` is `TextDocumentIdentifier`, not `VersionedTextDocumentIdentifier`.

RFC, maybe some servers rely on this information? I had a look at the git history and it was there since the beginning, I'm guessing not intentionally.

Eglot seems to be correctly sending just a `TextDocumentIdentifier`.