### PR TITLE
Display signature help regardless of where point is

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -413,13 +413,6 @@ This flag affects only server which do not support incremental update."
   :type 'boolean
   :group 'lsp-mode)
 
-(defcustom lsp-eldoc-skip-whitespace-and-newline t
-  "If non-nil, eldoc will display neither hover nor signature help
-when point is before whitespace or newline."
-  :type 'boolean
-  :group 'lsp-mode
-  :package-version '(lsp-mode . "6.2"))
-
 (defcustom lsp-eldoc-render-all nil
   "Display all of the info returned by document/onHover.
 If this is set to nil, `eldoc' will show only the symbol information."
@@ -3829,44 +3822,45 @@ RENDER-ALL - nil if only the signature should be rendered."
       (lsp--eldoc-message lsp--eldoc-saved-message)
     (setq lsp--hover-saved-bounds nil
           lsp--eldoc-saved-message nil)
-    (let* ((whitespace-or-newline (looking-at "[[:space:]\n]")))
-      (if (and whitespace-or-newline lsp-eldoc-skip-whitespace-and-newline)
+    (let ((request-id (cl-incf lsp-hover-request-id))
+          (pending 0)
+          (whitespace-or-newline (looking-at "[[:space:]\n]")))
+      (if whitespace-or-newline
           (lsp--eldoc-message nil)
-        (let ((request-id (cl-incf lsp-hover-request-id)) (pending 0))
-          (when (and lsp-eldoc-enable-hover (lsp--capability "hoverProvider"))
-            (cl-incf pending)
-            (lsp-request-async
-             "textDocument/hover"
-             (lsp--text-document-position-params)
-             (lambda (hover)
-               (when (and (eq request-id lsp-hover-request-id))
-                 (when hover
-                   (when-let (range (gethash "range" hover))
-                     (setq lsp--hover-saved-bounds (lsp--range-to-region range)))
-                   (-let (((&hash "contents") hover))
-                     (when-let (message
-                                (and contents (lsp--render-on-hover-content contents lsp-eldoc-render-all)))
-                       (when (or (and (not lsp-eldoc-prefer-signature-help) (setq pending 1))
-                                 (not lsp--eldoc-saved-message))
-                         (setq lsp--eldoc-saved-message message)))))
-                 (when (zerop (cl-decf pending))
-                   (lsp--eldoc-message lsp--eldoc-saved-message))
-                 (run-hook-with-args 'lsp-on-hover-hook hover)))
-             :error-handler #'ignore))
-          (when (and lsp-eldoc-enable-signature-help (lsp--capability "signatureHelpProvider"))
-            (cl-incf pending)
-            (lsp-request-async
-             "textDocument/signatureHelp"
-             (lsp--text-document-position-params)
-             (lambda (signature)
-               (when (eq request-id lsp-hover-request-id)
-                 (when-let (message (and signature (lsp--signature->eldoc-message signature)))
-                   (when (or (and lsp-eldoc-prefer-signature-help (setq pending 1))
-                             (not lsp--eldoc-saved-message))
-                     (setq lsp--eldoc-saved-message message)))
-                 (when (zerop (cl-decf pending))
-                   (lsp--eldoc-message lsp--eldoc-saved-message))))
-             :error-handler #'ignore)))))))
+        (when (and lsp-eldoc-enable-hover (lsp--capability "hoverProvider"))
+          (cl-incf pending)
+          (lsp-request-async
+           "textDocument/hover"
+           (lsp--text-document-position-params)
+           (lambda (hover)
+             (when (and (eq request-id lsp-hover-request-id))
+               (when hover
+                 (when-let (range (gethash "range" hover))
+                   (setq lsp--hover-saved-bounds (lsp--range-to-region range)))
+                 (-let (((&hash "contents") hover))
+                   (when-let (message
+                              (and contents (lsp--render-on-hover-content contents lsp-eldoc-render-all)))
+                     (when (or (and (not lsp-eldoc-prefer-signature-help) (setq pending 1))
+                               (not lsp--eldoc-saved-message))
+                       (setq lsp--eldoc-saved-message message)))))
+               (when (zerop (cl-decf pending))
+                 (lsp--eldoc-message lsp--eldoc-saved-message))
+               (run-hook-with-args 'lsp-on-hover-hook hover)))
+           :error-handler #'ignore)))
+      (when (and lsp-eldoc-enable-signature-help (lsp--capability "signatureHelpProvider"))
+        (cl-incf pending)
+        (lsp-request-async
+         "textDocument/signatureHelp"
+         (lsp--text-document-position-params)
+         (lambda (signature)
+           (when (eq request-id lsp-hover-request-id)
+             (when-let (message (and signature (lsp--signature->eldoc-message signature)))
+               (when (or (and lsp-eldoc-prefer-signature-help (setq pending 1))
+                         (not lsp--eldoc-saved-message))
+                 (setq lsp--eldoc-saved-message message)))
+             (when (zerop (cl-decf pending))
+               (lsp--eldoc-message lsp--eldoc-saved-message))))
+         :error-handler #'ignore)))))
 
 (defun lsp--select-action (actions)
   "Select an action to execute from ACTIONS."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -413,6 +413,13 @@ This flag affects only server which do not support incremental update."
   :type 'boolean
   :group 'lsp-mode)
 
+(defcustom lsp-eldoc-skip-whitespace-and-newline t
+  "If non-nil, eldoc will display neither hover nor signature help
+when point is before whitespace or newline."
+  :type 'boolean
+  :group 'lsp-mode
+  :package-version '(lsp-mode . "6.2"))
+
 (defcustom lsp-eldoc-render-all nil
   "Display all of the info returned by document/onHover.
 If this is set to nil, `eldoc' will show only the symbol information."
@@ -3823,7 +3830,7 @@ RENDER-ALL - nil if only the signature should be rendered."
     (setq lsp--hover-saved-bounds nil
           lsp--eldoc-saved-message nil)
     (let* ((whitespace-or-newline (looking-at "[[:space:]\n]")))
-      (if whitespace-or-newline
+      (if (and whitespace-or-newline lsp-eldoc-skip-whitespace-and-newline)
           (lsp--eldoc-message nil)
         (let ((request-id (cl-incf lsp-hover-request-id)) (pending 0))
           (when (and lsp-eldoc-enable-hover (lsp--capability "hoverProvider"))


### PR DESCRIPTION
It should be possible to see signature help when arguments are being split across multiple lines.

For example:
```php
// php
$this->foo(
    $arg1,
    $arg2,
    |
)
```