### PR TITLE
Call shutdown method with "params":{}, not "params":null

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2452,7 +2452,7 @@ If NO-MERGE is non-nil, don't merge the results but return alist workspace->resu
   (with-demoted-errors "LSP error: %S"
     (let ((lsp-response-timeout 0.5))
       (condition-case _err
-          (lsp-request "shutdown" nil)
+          (lsp-request "shutdown" (make-hash-table))
         (error (lsp--error "Timeout while sending shutdown request."))))
     (lsp-notify "exit" nil))
   (lsp--uninitialize-workspace))


### PR DESCRIPTION
```
"null" is not a valid JSON value for "params" according to the
JSON-RPC specification.

Do the same thing as for "initialized", and use an empty hash
table to be serialized to {}.
```