### PR TITLE
Improve wording of the repository file watching warning

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1273,7 +1273,7 @@ Do you want to watch all files in %s? "
         number-of-files
         dir
         dir))
-    (message
+    (lsp--info
      (concat "You can configure this warning with the `lsp-enable-file-watchers' "
              "and `lsp-file-watch-threshold' variables"))))
 


### PR DESCRIPTION
- (lsp--ask-about-watching-repo): New function. Warning message is
shorter to make it less scary for users. The available configuration
variables are presented not as part of the message, but after the user
has answered. Also, per `yes-or-no-p' documentation, the string now ends in
a space.

- (lsp-watch-root-folder): Modify code to
call (lsp--ask-about-watching-repo).