### PR TITLE
[Rust] Fix unactionable config

### DIFF
--- a/lsp-rust.el
+++ b/lsp-rust.el
@@ -114,26 +114,23 @@ the latest build duration."
   :group 'lsp-rust
   :package-version '(lsp-mode . "6.1"))
 
-(defcustom lsp-rust-crate-blacklist  [
-                                      "cocoa",
-                                      "gleam",
-                                      "glium",
-                                      "idna",
-                                      "libc",
-                                      "openssl",
-                                      "rustc_serialize",
-                                      "serde",
-                                      "serde_json",
-                                      "typenum",
-                                      "unicode_normalization",
-                                      "unicode_segmentation",
+(defcustom lsp-rust-crate-blacklist  '(
+                                      "cocoa"
+                                      "gleam"
+                                      "glium"
+                                      "idna"
+                                      "libc"
+                                      "openssl"
+                                      "rustc_serialize"
+                                      "serde"
+                                      "serde_json"
+                                      "typenum"
+                                      "unicode_normalization"
+                                      "unicode_segmentation"
                                       "winapi"
-                                      ]
+                                      )
   "A list of Cargo crates to blacklist."
-  :type '(restricted-sexp :match-alternatives (lambda (xs)
-                                                (and
-                                                 (vectorp xs)
-                                                 (seq-every-p #'stringp xs))))
+  :type '(repeat string)
   :group 'lsp-rust
   :package-version '(lsp-mode . "6.1"))
 

--- a/lsp-rust.el
+++ b/lsp-rust.el
@@ -114,7 +114,7 @@ the latest build duration."
   :group 'lsp-rust
   :package-version '(lsp-mode . "6.1"))
 
-(defcustom lsp-rust-crate-blacklist  '(
+(defcustom lsp-rust-crate-blacklist  [
                                       "cocoa"
                                       "gleam"
                                       "glium"
@@ -128,12 +128,12 @@ the latest build duration."
                                       "unicode_normalization"
                                       "unicode_segmentation"
                                       "winapi"
-                                      )
+                                      ]
   "A list of Cargo crates to blacklist."
-  :type '(repeat string)
-  :group 'lsp-rust
-  :package-version '(lsp-mode . "6.1"))
-
+  :type '(restricted-sexp :match-alternatives (lambda (xs)
+                                                (and
+                                                 (vectorp xs)
+                                                 (seq-every-p #'stringp xs)))))
 
 (defcustom lsp-rust-build-on-save nil
   "Only index the project when a file is saved and not on


### PR DESCRIPTION
It's possible https://github.com/emacs-lsp/lsp-mode/pull/1063 broke correct LSP initialization with the Rust Language Server.

Among other issues, this resulted in https://github.com/emacs-lsp/lsp-mode/issues/1083

By enabling debugging in the Rust Language Server we can identify the issue:
```
[2019-10-09T21:26:38Z DEBUG rls::server] Language Server starting up. Version: rls 1.39.0 (8dc9ba9 2019-10-01)

[2019-10-09T21:26:41Z WARN  rls::actions::notifications] Received unactionable config:
Object({"rust": Object(
{"all_features": Bool(false),
"all_targets": Bool(true),
"build_bin": Null,
"build_command": Null,
"build_lib": Bool(false),
"build_on_save": Bool(false),
"cfg_test": Bool(false),
"clear_env_rust_log": Bool(true),
"clippy_preference": String("on"),
"crate_blacklist": Array([String("cocoa"), Array([String(","), String("gleam")]), Array([String(","), String("glium")]), Array([String(","), String("idna")]), Array([String(","), String("libc")]), Array([String(","), String("openssl")]), Array([String(","), String("rustc_serialize")]), Array([String(","), String("serde")]), Array([String(","), String("serde_json")]), Array([String(","), String("typenum")]), Array([String(","), String("unicode_normalization")]), Array([String(","), String("unicode_segmentation")]), Array([String(","), String("winapi")])]),
"features": Array([]),
"full_docs": Bool(false),
"jobs": Null,
"no_default_features": Bool(false),
"racer_completion": Bool(true),
"rustflags": Null,
"rustfmt_path": Null,
"show_hover_context": Bool(true),
"show_warnings": Bool(true),
"sysroot": Null,
"target": Null,
"target_dir": Null,
"unstable_features": Bool(false),
"wait_to_build": Null})}) (error: ())
```

Notice the `Received unactionable config` `notification`. This fails because `crate_blacklist` is an `array` of tuples (the separation `,`s are being handled as array items) when it should have been an array of `string`s.

This PR fixes that by changing the `crate_blacklist` field type to a `(repeat string)`. This is the result from the Rust Language Server log after applying this patch:

```
[2019-10-09T21:23:30Z DEBUG rls::server] Language Server starting up. Version: rls 1.39.0 (8dc9ba9 2019-10-01)
[2019-10-09T21:23:34Z DEBUG rls::build::rustc] rustc: analysis read successfully?: true
```