### PR TITLE
Update `gopls` initialization options

### DIFF
--- a/lsp-go.el
+++ b/lsp-go.el
@@ -47,13 +47,13 @@ completing function calls."
   :type '(repeat string)
   :group 'lsp-gopls)
 
-(defcustom lsp-gopls-build-flags '("-tags")
-  "A set of flags passed on to the build system when invoked,
+(defcustom lsp-gopls-build-flags ["-tags"]
+  "A vector of flags passed on to the build system when invoked,
   applied to queries like `go list'."
   :type '(repeat string)
   :group 'lsp-gopls
   :risky t
-  :package-version '(lsp-mode "6.3"))
+  :package-version '(lsp-mode "6.2"))
 
 (defcustom lsp-gopls-env "{}"
   "`gopls' has the unusual ability to set environment variables,
@@ -63,7 +63,7 @@ completing function calls."
   :type 'string
   :group 'lsp-gopls
   :risky t
-  :package-version '(lsp-mode "6.3"))
+  :package-version '(lsp-mode "6.2"))
 
 (defcustom lsp-gopls-hover-kind "SynopsisDocumentation"
   "`gopls' allows the end user to select the desired amount of
@@ -76,7 +76,7 @@ completing function calls."
                  (const "Structured"))
   :group 'lsp-gopls
   :risky t
-  :package-version '(lsp-mode "6.3"))
+  :package-version '(lsp-mode "6.2"))
 
 ;; EXPERIMENTAL! ヽ(⌐■_■)ノ♪♬ At time of writing, these options are considered
 ;; experimental, and might either change or become durable. For more, see the
@@ -88,7 +88,7 @@ completing function calls."
   :type '(repeat string)
   :group 'lsp-gopls
   :risky t
-  :package-version '(lsp-mode "6.3"))
+  :package-version '(lsp-mode "6.2"))
 
 (defcustom lsp-gopls-experimental-staticcheck nil
   "If true, enables the use of staticcheck.io analyzers. Note
@@ -97,14 +97,14 @@ completing function calls."
   :type 'bool
   :group 'lsp-gopls
   :risky t
-  :package-version '(lsp-mode "6.3"))
+  :package-version '(lsp-mode "6.2"))
 
 (defcustom lsp-gopls-experimental-completion-documentation nil
   "If true, documentation is returned alongside completion candidates"
   :type 'bool
   :group 'lsp-gopls
   :risky t
-  :package-version '(lsp-mode "6.3"))
+  :package-version '(lsp-mode "6.2"))
 
 (defcustom lsp-gopls-experimental-complete-unimported nil
   "If true, the completion engine is allowed to make suggestions
@@ -112,7 +112,7 @@ completing function calls."
   :type 'bool
   :group 'lsp-gopls
   :risky t
-  :package-version '(lsp-mode "6.3"))
+  :package-version '(lsp-mode "6.2"))
 
 (defcustom lsp-gopls-experimental-deep-completion nil
   "If true, turns on the completion engine's ability to return
@@ -122,7 +122,7 @@ completing function calls."
   :type 'bool
   :group 'lsp-gopls
   :risky t
-  :package-version '(lsp-mode "6.3"))
+  :package-version '(lsp-mode "6.2"))
 
 (lsp-register-custom-settings
  '(("gopls.usePlaceholders" lsp-gopls-use-placeholders t)
@@ -251,7 +251,7 @@ $GOPATH/pkg/mod along with the value of
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection
                                    (lambda () (cons lsp-clients-go-server
-                                               lsp-clients-go-server-args)))
+                                                    lsp-clients-go-server-args)))
                   :major-modes '(go-mode)
                   :priority -1
                   :initialization-options 'lsp-clients-go--make-init-options

--- a/lsp-go.el
+++ b/lsp-go.el
@@ -47,8 +47,93 @@ completing function calls."
   :type '(repeat string)
   :group 'lsp-gopls)
 
+(defcustom lsp-gopls-build-flags '("-tags")
+  "A set of flags passed on to the build system when invoked,
+  applied to queries like `go list'."
+  :type '(repeat string)
+  :group 'lsp-gopls
+  :risky t
+  :package-version '(lsp-mode "6.3"))
+
+(defcustom lsp-gopls-env "{}"
+  "`gopls' has the unusual ability to set environment variables,
+  intended to affect the behavior of commands invoked by `gopls'
+  on the user's behalf. This variable takes a JSON object
+  literal, mapping env var name to value."
+  :type 'string
+  :group 'lsp-gopls
+  :risky t
+  :package-version '(lsp-mode "6.3"))
+
+(defcustom lsp-gopls-hover-kind "SynopsisDocumentation"
+  "`gopls' allows the end user to select the desired amount of
+  documentation returned during e.g. hover and thing-at-point
+  operations."
+  :type '(choice (const "SynopsisDocumentation")
+                 (const "NoDocumentation")
+                 (const "FullDocumentation")
+                 (const "SingleLine")
+                 (const "Structured"))
+  :group 'lsp-gopls
+  :risky t
+  :package-version '(lsp-mode "6.3"))
+
+;; EXPERIMENTAL! ヽ(⌐■_■)ノ♪♬ At time of writing, these options are considered
+;; experimental, and might either change or become durable. For more, see the
+;; official docs:
+;; https://github.com/golang/tools/blob/master/gopls/doc/settings.md#experimental
+;; -- @gastove 2019-10-09
+(defcustom lsp-gopls-experimental-disabled-analyses (list)
+  "A list of names of analysis passes that should be disabled."
+  :type '(repeat string)
+  :group 'lsp-gopls
+  :risky t
+  :package-version '(lsp-mode "6.3"))
+
+(defcustom lsp-gopls-experimental-staticcheck nil
+  "If true, enables the use of staticcheck.io analyzers. Note
+  that users also have the option of using staticheck.io
+  analyzers through flycheck."
+  :type 'bool
+  :group 'lsp-gopls
+  :risky t
+  :package-version '(lsp-mode "6.3"))
+
+(defcustom lsp-gopls-experimental-completion-documentation nil
+  "If true, documentation is returned alongside completion candidates"
+  :type 'bool
+  :group 'lsp-gopls
+  :risky t
+  :package-version '(lsp-mode "6.3"))
+
+(defcustom lsp-gopls-experimental-complete-unimported nil
+  "If true, the completion engine is allowed to make suggestions
+  for packages not currently imported."
+  :type 'bool
+  :group 'lsp-gopls
+  :risky t
+  :package-version '(lsp-mode "6.3"))
+
+(defcustom lsp-gopls-experimental-deep-completion nil
+  "If true, turns on the completion engine's ability to return
+  completions from deep inside relevant entities. For an example, see:
+
+  https://github.com/golang/tools/blob/master/gopls/doc/settings.md#deepcompletion-boolean"
+  :type 'bool
+  :group 'lsp-gopls
+  :risky t
+  :package-version '(lsp-mode "6.3"))
+
 (lsp-register-custom-settings
- '(("gopls.usePlaceholders" lsp-gopls-use-placeholders t)))
+ '(("gopls.usePlaceholders" lsp-gopls-use-placeholders t)
+   ("gopls.hoverKind" lsp-gopls-hover-kind)
+   ("gopls.buildFlags" lsp-gopls-build-flags)
+   ("gopls.env" lsp-gopls-env)
+   ("gopls.experimentalDisabledAnalyses" lsp-gopls-experimental-disabled-analyses)
+   ("gopls.staticcheck" lsp-gopls-experimental-staticcheck t)
+   ("gopls.completionDocumentation" lsp-gopls-experimental-completion-documentation t)
+   ("gopls.completeUnimported" lsp-gopls-experimental-complete-unimported t)
+   ("gopls.deepCompletion" lsp-gopls-experimental-deep-completion t)))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection
@@ -135,15 +220,15 @@ $GOPATH/pkg/mod along with the value of
     (when (and lsp-clients-go-library-directories-include-go-modules
                (or (and (not (file-remote-p default-directory)) (executable-find "go"))
                    (and (version<= "27.0" emacs-version) (with-no-warnings (executable-find "go" (file-remote-p default-directory))))))
-              (with-temp-buffer
-                (when (zerop (process-file "go" nil t nil "env" "GOPATH"))
-                  (setq library-dirs
-                        (append
-                         library-dirs
-                         (list
-                         (concat
-                          (string-trim-right (buffer-substring (point-min) (point-max)))
-                          "/pkg/mod")))))))
+      (with-temp-buffer
+        (when (zerop (process-file "go" nil t nil "env" "GOPATH"))
+          (setq library-dirs
+                (append
+                 library-dirs
+                 (list
+                  (concat
+                   (string-trim-right (buffer-substring (point-min) (point-max)))
+                   "/pkg/mod")))))))
     (if (file-remote-p default-directory)
         (mapcar (lambda (path) (concat (file-remote-p default-directory) path)) library-dirs)
       library-dirs)))
@@ -166,7 +251,7 @@ $GOPATH/pkg/mod along with the value of
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection
                                    (lambda () (cons lsp-clients-go-server
-                                                    lsp-clients-go-server-args)))
+                                               lsp-clients-go-server-args)))
                   :major-modes '(go-mode)
                   :priority -1
                   :initialization-options 'lsp-clients-go--make-init-options


### PR DESCRIPTION
`gopls`, wrapped by `lsp-go`, supports a variety of settings not currently
exposed as `defcustom`s. This commit adds them. For full docs, see:

https://github.com/golang/tools/blob/master/gopls/doc/settings.md

Note that a set of these are marked experimental in the doc, and so I've
included the word `experimental` in the corresponding `defcustom`.