### PR TITLE
lsp-vetur add default emmet setting

### DIFF
--- a/lsp-vetur.el
+++ b/lsp-vetur.el
@@ -668,6 +668,15 @@ Code's JavaScript and TypeScript support."
   :type 'boolean
   :package-version '(lsp-mode . "6.1"))
 
+(defcustom lsp-vetur-emmet "never"
+  "Controls the Emmet suggestions that show up in the suggestion/completion list."
+  :type  '(choice
+           (const "never")
+           (const "inMarkupAndStylesheetFilesOnly")
+           (const "always" ))
+  :group 'lsp-vetur
+  :package-version '(lsp-mode . "6.1"))
+
 (lsp-register-custom-settings
  '(("javascript.autoClosingTags" lsp-javascript-auto-closing-tags t)
    ("javascript.format.enable" lsp-javascript-format-enable t)
@@ -763,7 +772,8 @@ Code's JavaScript and TypeScript support."
    ("vetur.completion.tagCasing" lsp-vetur-completion-tag-casing)
    ("vetur.completion.useScaffoldSnippets" lsp-vetur-completion-use-scaffold-snippets t)
    ("vetur.completion.autoImport" lsp-vetur-completion-auto-import t)
-   ("vetur.useWorkspaceDependencies" lsp-vetur-use-workspace-dependencies t)))
+   ("vetur.useWorkspaceDependencies" lsp-vetur-use-workspace-dependencies t)
+   ("emmet.showExpandedAbbreviation" lsp-vetur-emmet)))
 
 (define-obsolete-variable-alias
   'lsp-vetur-server
@@ -795,6 +805,7 @@ Code's JavaScript and TypeScript support."
                                                                (lsp-configuration-section "html")
                                                                (lsp-configuration-section "javascript")
                                                                (lsp-configuration-section "typescript")
+                                                               (lsp-configuration-section "emmet")
                                                                (ht ("globalSnippetDir" lsp-vetur-global-snippets-dir))))
                   :initialized-fn (lambda (workspace)
                                     (with-lsp-workspace workspace
@@ -802,6 +813,7 @@ Code's JavaScript and TypeScript support."
                                        (ht-merge (lsp-configuration-section "vetur")
                                                  (lsp-configuration-section "html")
                                                  (lsp-configuration-section "javascript")
+                                                 (lsp-configuration-section "emmet")
                                                  (lsp-configuration-section "typescript")))))))
 
 (provide 'lsp-vetur)


### PR DESCRIPTION
 vls will throw a error inside style tag:
```
 "Request textDocument/completion failed with message: Cannot read property'showExpandedAbbreviation' of undefined"
```
This should be handled by vls but until they do we need this work around.

