### PR TITLE
change url allowed chars to default, which is url-unreserved-chars

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1196,8 +1196,7 @@ DELETE when `lsp-mode.el' is deleted.")
 
 (defun lsp--path-to-uri-1 (path)
   (concat lsp--uri-file-prefix
-          (url-hexify-string (expand-file-name (or (file-remote-p path 'localname t) path))
-                             url-path-allowed-chars)))
+          (url-hexify-string (expand-file-name (or (file-remote-p path 'localname t) path)))))
 
 (defun lsp--path-to-uri (path)
   "Convert PATH to a uri."


### PR DESCRIPTION
I encountered "Unable to find file" problem when using cquery as language server, I did some search and find that it's because the "+" in my file path didn't get hexified. Changing "+" to a letter solves my problem.