### PR TITLE
Slightly improve handling of HTML entities

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3663,7 +3663,20 @@ MODE is the mode used in the parent frame."
     (add-to-list 'markdown-code-lang-modes (cons mark mode)))
   (setq-local markdown-fontify-code-blocks-natively t)
   (setq-local markdown-fontify-code-block-default-mode mode)
-  (setq-local markdown-hide-markup t))
+  (setq-local markdown-hide-markup t)
+
+  ;; Render some common HTML entities.
+  ;; This should really happen in markdown-mode instead,
+  ;; but it doesn't, so we do it here for now.
+  (setq prettify-symbols-alist
+	(cl-loop for i from 0 to 255
+                 collect (cons (format "&#x%02X;" i) i)))
+  (push '("&lt;" . ?<) prettify-symbols-alist)
+  (push '("&gt;" . ?>) prettify-symbols-alist)
+  (push '("&amp;" . ?&) prettify-symbols-alist)
+  (setq prettify-symbols-compose-predicate
+	(lambda (_start _end _match) t))
+  (prettify-symbols-mode 1))
 
 (defun lsp--buffer-string-visible ()
   "Return visible buffer string.
@@ -3688,18 +3701,8 @@ Stolen from `org-copy-visible'."
   "Render markdown."
 
   (let((markdown-enable-math nil))
-    (goto-char (point-min))
-    (while (re-search-forward "&gt;" nil t)
-      (replace-match ">"))
-
-    (goto-char (point-min))
-
-    (while (re-search-forward "&lt;" nil t)
-      (replace-match "<"))
-
-    (goto-char (point-min))
-
     ;; temporary patch --- since the symbol is not rendered fine in lsp-ui
+    (goto-char (point-min))
     (while (re-search-forward "^[-]+$" nil t)
       (replace-match ""))
 


### PR DESCRIPTION
```
This really should happen in markdown-mode, but it doesn't do that
currently, so do it here for now.

- Handle the numeric hex &#x00; - &#xFF; entities. Encoding
  special (non-alphanumeric) characters as HTML entities is one sure
  way to ensure they don't get interpreted as Markdown or HTML syntax.

- Move handling of &lt; / &gt; to after rendering. This ensures that
  e.g. &lt;b&gt; is never interpreted as <b>.
```

RFC: The `&#x00; - &#xFF;` choice is a bit arbitrary and simply the syntax I chose for escaping in my server. Alternatives would be `&#x00; - &#xff;` or `&#0; - &#255;`. If some server already uses those, would be better to use that; or we could add all of them though that seems wasteful to do unprompted.

Related markdown-mode issue: https://github.com/jrblevin/markdown-mode/issues/377

Related Commonmark thread: https://talk.commonmark.org/t/can-we-have-formal-escaping-rules/2624

Remaining problems:

- Named entities other than `lt` / `gt` / `amp` are still unimplemented
- Unicode numeric entities (above 0xFF) are still unimplemented
- Escaping of entities (i.e. `\&lt;` -> `&lt;`) is unimplemented
- Escapes (<code>\\\`</code> -> <code>`</code>) are still unimplemented
- Ignoring entities in code blocks is unimplemented

All of this should probably happen in `markdown-mode`; for now we probably should only care about inputs emitted by LSP servers in real usage.