### PR TITLE
Load yasnippet as an optional dependency

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -57,6 +57,7 @@
 (require 'tree-widget)
 (require 'markdown-mode)
 (require 'ewoc)
+(require 'yasnippet nil t)
 
 (declare-function company-mode "company")
 (declare-function flycheck-mode "flycheck")
@@ -2522,7 +2523,7 @@ disappearing, unset all the variables related to it."
                                                                                 (featurep 'yasnippet)
                                                                                 (warn (concat
                                                                                        "Yasnippet is not yet loaded, but `lsp-enable-snippet' is set to `t'. "
-                                                                                       "You must either (require 'yasnippet), or disable snippet support."))
+                                                                                       "You must either install yasnippet, or disable snippet support."))
                                                                                 t)
                                                                              :json-false))
                                                         (documentationFormat . ["markdown"])))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2522,7 +2522,7 @@ disappearing, unset all the variables related to it."
                                                                                (or
                                                                                 (featurep 'yasnippet)
                                                                                 (warn (concat
-                                                                                       "Yasnippet is not yet loaded, but `lsp-enable-snippet' is set to `t'. "
+                                                                                       "Yasnippet is not installed, but `lsp-enable-snippet' is set to `t'. "
                                                                                        "You must either install yasnippet, or disable snippet support."))
                                                                                 t)
                                                                              :json-false))


### PR DESCRIPTION
`require` yasnippet with the NOERROR flag so that we can use it if it is installed without the user having to explicitly load it before using lsp-mode.