### PR TITLE
Correct `gopls` defcustom types

### DIFF
--- a/lsp-go.el
+++ b/lsp-go.el
@@ -50,17 +50,17 @@ completing function calls."
 (defcustom lsp-gopls-build-flags ["-tags"]
   "A vector of flags passed on to the build system when invoked,
   applied to queries like `go list'."
-  :type '(repeat string)
+  :type '(vector string)
   :group 'lsp-gopls
   :risky t
   :package-version '(lsp-mode "6.2"))
 
-(defcustom lsp-gopls-env "{}"
+(defcustom lsp-gopls-env (make-hash-table)
   "`gopls' has the unusual ability to set environment variables,
   intended to affect the behavior of commands invoked by `gopls'
-  on the user's behalf. This variable takes a JSON object
-  literal, mapping env var name to value."
-  :type 'string
+  on the user's behalf. This variable takes a hash table of env
+  var names to desired values."
+  :type '(restricted-sexp :match-alternatives (hash-table-p))
   :group 'lsp-gopls
   :risky t
   :package-version '(lsp-mode "6.2"))
@@ -83,9 +83,9 @@ completing function calls."
 ;; official docs:
 ;; https://github.com/golang/tools/blob/master/gopls/doc/settings.md#experimental
 ;; -- @gastove 2019-10-09
-(defcustom lsp-gopls-experimental-disabled-analyses (list)
+(defcustom lsp-gopls-experimental-disabled-analyses []
   "A list of names of analysis passes that should be disabled."
-  :type '(repeat string)
+  :type '(vector string)
   :group 'lsp-gopls
   :risky t
   :package-version '(lsp-mode "6.2"))


### PR DESCRIPTION
Hokay. I've been running this locally for a few hours, and it's looking a lot better. Notes about this:

1. In my testing, using either any kind of list of pairs or a `plist` all resulted in `lsp-mode` serializing an empty data structure as a JSON `null`, which makes `gopls` very angry. It _must_ be sent an empty object (`{}`). An empty `hash-table`, rather than being `nil` (that is, `null`), fills this requirement. I'm open to doing this differently, but it's working for me for now. 

2. I've updated JSON `array` types to use vectors. There was only one I missed before, but I also corrected the `:type` key on `lsp-gopls-build-flags` to clarify. 

Closes #1096 