### PR TITLE
Implement `lsp-string-vector` 

### DIFF
--- a/lsp-go.el
+++ b/lsp-go.el
@@ -50,7 +50,7 @@ completing function calls."
 (defcustom lsp-gopls-build-flags ["-tags"]
   "A vector of flags passed on to the build system when invoked,
   applied to queries like `go list'."
-  :type '(vector string)
+  :type 'lsp-string-vector
   :group 'lsp-gopls
   :risky t
   :package-version '(lsp-mode "6.2"))
@@ -85,7 +85,7 @@ completing function calls."
 ;; -- @gastove 2019-10-09
 (defcustom lsp-gopls-experimental-disabled-analyses []
   "A list of names of analysis passes that should be disabled."
-  :type '(vector string)
+  :type 'lsp-string-vector
   :group 'lsp-gopls
   :risky t
   :package-version '(lsp-mode "6.2"))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -790,6 +790,22 @@ They are added to `markdown-code-lang-modes'")
   "Return t if all elements of SEQUENCE are strings, else nil."
   (not (seq-find (lambda (x) (not (stringp x))) sequence)))
 
+(defun lsp--string-vector-p (candidate)
+  "Returns true if CANDIDATE is a vector data structure and
+every element of it is of type string, else nil."
+  (and
+   (vectorp candidate)
+   (seq-every-p #'stringp candidate)))
+
+(define-widget 'lsp-string-vector 'lazy
+  "A vector of zero or more elements, every element of which is a string.
+Appropriate for any language-specific `defcustom' that needs to
+serialize as a JSON array of strings."
+  :offset 4
+  :tag "Vector"
+  :type '(restricted-sexp
+          :match-alternatives (list #'lsp--string-vector-p)))
+
 (defun lsp--info (format &rest args)
   "Display lsp info message with FORMAT with ARGS."
   (message "%s :: %s" (propertize "LSP" 'face 'success) (apply #'format format args)))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -804,7 +804,7 @@ serialize as a JSON array of strings."
   :offset 4
   :tag "Vector"
   :type '(restricted-sexp
-          :match-alternatives (list #'lsp--string-vector-p)))
+          :match-alternatives (lsp--string-vector-p)))
 
 (defun lsp--info (format &rest args)
   "Display lsp info message with FORMAT with ARGS."

--- a/lsp-pyls.el
+++ b/lsp-pyls.el
@@ -154,7 +154,7 @@ complexity."
 (defcustom lsp-pyls-plugins-pylint-args []
   "Arguments, passed to pylint"
   :risky t
-  :type '(repeat string)
+  :type 'lsp-string-vector
   :group 'lsp-pyls
   :package-version '(lsp-mode . "6.1"))
 

--- a/lsp-rust.el
+++ b/lsp-rust.el
@@ -140,10 +140,7 @@ the latest build duration."
                                       "winapi"
                                       ]
   "A list of Cargo crates to blacklist."
-  :type '(restricted-sexp :match-alternatives (lambda (xs)
-                                                (and
-                                                 (vectorp xs)
-                                                 (seq-every-p #'stringp xs))))
+  :type 'lsp-string-vector
   :group 'lsp-rust
   :package-version '(lsp-mode . "6.1"))
 
@@ -156,10 +153,7 @@ change."
 
 (defcustom lsp-rust-features []
   "A list of Cargo features to enable."
-  :type '(restricted-sexp :match-alternatives (lambda (xs)
-                                                (and
-                                                 (vectorp xs)
-                                                 (seq-every-p #'stringp xs))))
+  :type 'lsp-string-vector
   :group 'lsp-rust
   :package-version '(lsp-mode . "6.1"))
 

--- a/scripts/lsp-generate-settings.el
+++ b/scripts/lsp-generate-settings.el
@@ -41,7 +41,7 @@ ENUM is the value of enum key in vscode manifest."
         ("string" 'string)
         ("number" 'number)
         ("integer" 'number)
-        ("array" '(repeat string))
+        ("array" 'lsp-string-vector)
         (`(,type . ,_rest) `(repeat ,(lsp--convert-type type nil)))))))
 
 (defun lsp-generate-settings (file-name)


### PR DESCRIPTION
This PR creates a new type for use in `defcustom`s that need to represent vectors of strings. 

Very up for debate: what should this new type be _called_. I currently favour `lsp-string-vector`, because I feel it conveys to _users_ of the type what they should use as values for a custom using this type. Putting `json` or `array` in the name are also up for discussion! The name `lsp-json-string-array` certainly reflects what the type _becomes_ much more clearly. 

Closes #1106 