### PR TITLE
Be robust to empty uri's returned in textDocument/references response

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3585,26 +3585,24 @@ https://microsoft.github.io/language-server-protocol/specification#textDocument_
     (cl-labels ((get-xrefs-in-file
                  (file-locs location-link)
                  (let ((filename (seq-first file-locs)))
-                   (if (equal filename "")
-                       (ignore (lsp-warn "Failed to process xref entry, unexpected empty filename"))
-                     (condition-case err
-                         (let ((visiting (lsp--buffer-for-file filename))
-                               (fn (lambda (loc)
-                                     (lsp--xref-make-item filename
-                                                          (if location-link (or (gethash "targetSelectionRange" loc)
-                                                                                (gethash "targetRange" loc))
-                                                            (gethash "range" loc))))))
-                           (if visiting
-                               (with-current-buffer visiting
-                                 (seq-map fn (cdr file-locs)))
-                             (when (file-readable-p filename)
-                               (with-temp-buffer
-                                 (insert-file-contents-literally filename)
-                                 (seq-map fn (cdr file-locs))))))
-                       (error (ignore
-                               (lsp-warn "Failed to process xref entry with message: %s" (error-message-string err))))
-                       (file-error (ignore
-                                    (lsp-warn "Failed to process xref entry, file-error, %s: %s" filename (error-message-string err)))))))))
+                   (condition-case err
+                       (let ((visiting (lsp--buffer-for-file filename))
+                             (fn (lambda (loc)
+                                   (lsp--xref-make-item filename
+                                                        (if location-link (or (gethash "targetSelectionRange" loc)
+                                                                              (gethash "targetRange" loc))
+                                                          (gethash "range" loc))))))
+                         (if visiting
+                             (with-current-buffer visiting
+                               (seq-map fn (cdr file-locs)))
+                           (when (file-readable-p filename)
+                             (with-temp-buffer
+                               (insert-file-contents-literally filename)
+                               (seq-map fn (cdr file-locs))))))
+                     (error (ignore
+                             (lsp-warn "Failed to process xref entry for filename '%s': %s" (error-message-string err))))
+                     (file-error (ignore
+                                  (lsp-warn "Failed to process xref entry, file-error, '%s': %s" filename (error-message-string err))))))))
       (apply #'append
              (if (gethash "uri" (seq-first locations))
                  (seq-map


### PR DESCRIPTION
See issue,https://github.com/emacs-lsp/lsp-mode/issues/1113 where ccls is returning an invalid
entry in the response. I plan on also working with the ccls maintainers to fix the root cause.