### PR TITLE
Fix deduping in lsp-register-custom-settings

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5535,13 +5535,17 @@ changing the value of `foo'."
 
 (defvar lsp-client-settings nil)
 
+(defun lsp--compare-setting-path (a b)
+  (equal (car a) (car b)))
+
 (defun lsp-register-custom-settings (props)
   "Register PROPS.
 The PROPS is list of triple (path symbol boolean?) Where: path is
 the path to the property, symbol is the defcustom symbol which
 will be used to retrieve the value and boolean determines whether
 the type of the property is boolean?"
-  (setq lsp-client-settings (-uniq (append lsp-client-settings props))))
+  (let ((-compare-fn #'lsp--compare-setting-path))
+    (setq lsp-client-settings (-uniq (append props lsp-client-settings)))))
 
 (defun lsp-region-text (region)
   "Get the text for REGION in current buffer."

--- a/test/lsp-common-test.el
+++ b/test/lsp-common-test.el
@@ -96,6 +96,7 @@
   :risky t
   :type 'list)
 
+(lsp-register-custom-settings '(("section1.prop1" "banana")))
 (lsp-register-custom-settings '(("section1.prop1" lsp-prop1)))
 
 (ert-deftest lsp--custom-settings-test ()


### PR DESCRIPTION
Dedupe by the setting's path rather than the entire tuple. This avoids
ending up with duplicating settings that end up in the wrong order so
the newer value doesn't actually take effect. I swapped the arg order
to "append" so that the new setting in "props" replaces any existing
setting.