### PR TITLE
Support yaml-language-server

### DIFF
--- a/README.org
+++ b/README.org
@@ -175,6 +175,7 @@
    | VHDL                  | [[http://www.vhdltool.com][VHDL Tool]]                                 | Yes            | Download from http://www.vhdltool.com/download                                                          | No                           |
    | Vue                   | [[https://github.com/vuejs/vetur/tree/master/server][vue-language-server]]                       | Yes            | npm install -g vue-language-server                                                                      | Yes (Firefox/Chrome)         |
    | XML                   | [[https://github.com/angelozerr/lsp4xml][lsp4xml]]                                   | Yes            | Download from [[https://github.com/angelozerr/lsp4xml/releases][lsp4xml releases]]                                                                          |                              |
+   | YAML                  | [[https://github.com/redhat-developer/yaml-language-server][yaml]]                                      | Yes            | npm install -g yaml-language-server                                                                     |                              |
 ** Commands
    - ~lsp-describe-session~ - Display session folders and running servers.
    - ~lsp-describe-thing-at-point~ - Display help for the thing at point.

--- a/doc/src/doc.el
+++ b/doc/src/doc.el
@@ -5,7 +5,7 @@
 
 (defconst lsp-doc--client-groups
   (sort
-   '(lsp-clojure lsp-css lsp-html lsp-intelephense lsp-pyls lsp-rust lsp-solargraph lsp-vetur lsp-xml lsp-groovy lsp-typescript-javascript lsp-typescript lsp-flow lsp-php lsp-ocaml lsp-clangd lsp-dart lsp-elixir lsp-fortran lsp-kotlin lsp-hack lsp-metals lsp-fsharp lsp-erlang)
+   '(lsp-clojure lsp-css lsp-html lsp-intelephense lsp-pyls lsp-rust lsp-solargraph lsp-vetur lsp-xml lsp-groovy lsp-typescript-javascript lsp-typescript lsp-flow lsp-php lsp-ocaml lsp-clangd lsp-dart lsp-elixir lsp-fortran lsp-kotlin lsp-hack lsp-metals lsp-fsharp lsp-erlang lsp-yaml)
    (lambda (s1 s2)
      (string< (symbol-name s1) (symbol-name s2)))))
 

--- a/doc/src/lang-support.adoc
+++ b/doc/src/lang-support.adoc
@@ -221,4 +221,10 @@
 |Download from https://github.com/angelozerr/lsp4xml/releases[lsp4xml releases]
 |
 
+|YAML
+|https://github.com/redhat-developer/yaml-language-server[yaml-language-server]
+|<<lsp-yaml,Built-in>>
+|`npm install -g yaml-language-server`
+|
+
 |===

--- a/doc/src/lsp-langs.adoc
+++ b/doc/src/lsp-langs.adoc
@@ -45,3 +45,5 @@ include::lsp-typescript-javascript/index.adoc[]
 include::lsp-vetur/index.adoc[]
 
 include::lsp-xml/index.adoc[]
+
+include::lsp-yaml/index.adoc[]

--- a/doc/src/lsp-yaml/index.adoc
+++ b/doc/src/lsp-yaml/index.adoc
@@ -1,0 +1,5 @@
+[id="lsp-yaml"]
+=== YAML support: `lsp-yaml`
+`lsp-yaml` provides support for YAML using https://github.com/redhat-developer/yaml-language-server[yaml-language-server]
+
+include::lsp-yaml-vars.adoc[]

--- a/doc/src/lsp-yaml/lsp-yaml-vars.adoc
+++ b/doc/src/lsp-yaml/lsp-yaml-vars.adoc
@@ -1,0 +1,96 @@
+[id="lsp-yaml-vars"]
+==== `lsp-yaml` settings
+
+[id="lsp-yaml-format-enable"]
+- lsp-yaml-format-enable
+____
+Default value: `pass:[t]`
+
+Enable/disable default YAML formatter.
+____
+[id="lsp-yaml-single-quote"]
+- lsp-yaml-single-quote
+____
+Default value: `pass:[nil]`
+
+Use single quote instead of double quotes.
+____
+[id="lsp-yaml-bracket-spacing"]
+- lsp-yaml-bracket-spacing
+____
+Default value: `pass:[t]`
+
+Print spaces between brackets in objects.
+____
+[id="lsp-yaml-prose-wrap"]
+- lsp-yaml-prose-wrap
+____
+Default value: `pass:["preserve"]`
+
+Options for prose-wrap.
+Always: wrap prose if it exeeds the print width.
+Never: never wrap the prose.
+Preserve: wrap prose as-is.
+____
+[id="lsp-yaml-print-width"]
+- lsp-yaml-print-width
+____
+Default value: `pass:[80]`
+
+Specify the line length that the printer will wrap on.
+____
+[id="lsp-yaml-validate"]
+- lsp-yaml-validate
+____
+Default value: `pass:[t]`
+
+Enable/disable validation feature.
+____
+[id="lsp-yaml-hover"]
+- lsp-yaml-hover
+____
+Default value: `pass:[t]`
+
+Enable/disable hover feature.
+____
+[id="lsp-yaml-completion"]
+- lsp-yaml-completion
+____
+Default value: `pass:[t]`
+
+Enable/disable completion feature.
+____
+[id="lsp-yaml-schemas"]
+- lsp-yaml-schemas
+____
+Default value: `pass:[nil]`
+
+Associate schemas to YAML files in a glob pattern.
+lsp-yaml-schemas allows you to specify json schemas that you want to validate against the yaml that you write.
+Kubernetes is an optional field. It does not require a url as the language server will provide that.
+You just need the keyword kubernetes and a glob pattern.
+
+Example: `(setq lsp-yaml-schemas '(:kubernetes "*"))`
+____
+[id="lsp-yaml-lsp-yaml-schema-store-enable"]
+- lsp-yaml-lsp-yaml-schema-store-enable
+____
+Default value: `pass:[t]`
+
+Enable/disable JSON Schema store. When set to true, available YAML schemas will be automatically pulled from the store.
+____
+[id="lsp-yaml-custom-tags"]
+- lsp-yaml-custom-tags
+____
+Default value: `pass:[nil]`
+
+Custom tags for the parser to use.
+Example: `(setq lsp-yaml-custom-tags '("!Scalar-example scalar" "!Seq-example sequence" "!Mapping-example mapping"))`
+____
+[id="lsp-yaml-server-command"]
+- lsp-yaml-server-command
+____
+Default value: `pass:['("yaml-language-server" "--stdio")]`
+
+Command to start yaml-language-server.
+____

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -43,6 +43,7 @@
 (require 'lsp-erlang)
 (require 'lsp-haxe)
 (require 'lsp-vhdl)
+(require 'lsp-yaml)
 
 ;;; Ada
 (defgroup lsp-ada nil

--- a/lsp-yaml.el
+++ b/lsp-yaml.el
@@ -1,0 +1,143 @@
+;;; lsp-yaml.el --- LSP YAML server integration        -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2019  Aya Igarashi
+
+;; Author: Aya Igarashi <ladiclexxx@gmail.com>
+;; Keywords:
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-yaml nil
+  "LSP support for YAML, using yaml-language-server."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/redhat-developer/yaml-language-server")
+  :package-version '(lsp-mode . "6.2"))
+
+(defcustom lsp-yaml-format-enable t
+  "Enable/disable default YAML formatter."
+  :type 'boolean
+  :group 'lsp-yaml
+  :package-version '(lsp-mode . "6.2"))
+
+(defcustom lsp-yaml-single-quote nil
+  "Use single quote instead of double quotes."
+  :type 'boolean
+  :group 'lsp-yaml
+  :package-version '(lsp-mode . "6.2"))
+
+(defcustom lsp-yaml-bracket-spacing t
+  "Print spaces between brackets in objects."
+  :type 'boolean
+  :group 'lsp-yaml
+  :package-version '(lsp-mode . "6.2"))
+
+(defcustom lsp-yaml-prose-wrap "preserve"
+  "Options for prose-wrap.
+   Always: wrap prose if it exeeds the print width.
+   Never: never wrap the prose.
+   Preserve: wrap prose as-is."
+  :type '(choice
+          (const "always")
+          (const "never")
+          (const "preserve"))
+  :group 'lsp-yaml
+  :package-version '(lsp-mode . "6.2"))
+
+(defcustom lsp-yaml-print-width 80
+  "Specify the line length that the printer will wrap on."
+  :type 'number
+  :group 'lsp-yaml
+  :package-version '(lsp-mode . "6.2"))
+
+(defcustom lsp-yaml-validate t
+  "Enable/disable validation feature."
+  :type 'boolean
+  :group 'lsp-yaml
+  :package-version '(lsp-mode . "6.2"))
+
+(defcustom lsp-yaml-hover t
+  "Enable/disable hover feature."
+  :type 'boolean
+  :group 'lsp-yaml
+  :package-version '(lsp-mode . "6.2"))
+
+(defcustom lsp-yaml-completion t
+  "Enable/disable completion feature."
+  :type 'boolean
+  :group 'lsp-yaml
+  :package-version '(lsp-mode . "6.2"))
+
+(defcustom lsp-yaml-schemas (make-hash-table)
+  "Associate schemas to YAML files in a glob pattern."
+  :type '(restricted-sexp :match-alternatives (hash-table-p))
+  :group 'lsp-yaml
+  :package-version '(lsp-mode . "6.2"))
+
+(defcustom lsp-yaml-schema-store-enable t
+  "Enable/disable JSON Schema store. When set to true, available YAML
+   schemas will be automatically pulled from the store."
+  :type 'boolean
+  :group 'lsp-yaml
+  :package-version '(lsp-mode . "6.2"))
+
+(defcustom lsp-yaml-custom-tags nil
+  "Custom tags for the parser to use."
+  :type '(repeat string)
+  :group 'lsp-yaml
+  :package-version '(lsp-mode . "6.2"))
+
+(lsp-register-custom-settings
+ '(("yaml.format.enable" lsp-yaml-format-enable t)
+   ("yaml.format.singleQuote" lsp-yaml-single-quote t)
+   ("yaml.format.bracketSpacing" lsp-yaml-bracket-spacing)
+   ("yaml.format.proseWrap" lsp-yaml-prose-wrap)
+   ("yaml.format.printWidth" lsp-yaml-print-width)
+   ("yaml.validate" lsp-yaml-validate t)
+   ("yaml.hover" lsp-yaml-hover t)
+   ("yaml.completion" lsp-yaml-completion t)
+   ("yaml.schemas" lsp-yaml-schemas)
+   ("yaml.schemaStore.enable" lsp-yaml-schema-store-enable t)
+   ("yaml.customTags" lsp-yaml-custom-tags)))
+
+(defcustom lsp-yaml-server-command '("yaml-language-server" "--stdio")
+  "Command to start yaml-languageserver."
+  :type '(repeat string)
+  :group 'lsp-yaml
+  :package-version '(lsp-mode . "6.2"))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   (lambda () lsp-yaml-server-command))
+                  :major-modes '(yaml-mode)
+                  :priority 0
+                  :server-id 'yamlls
+                  :initialized-fn (lambda (workspace)
+                                    (with-lsp-workspace workspace
+                                      (lsp--set-configuration
+                                       (lsp-configuration-section "yaml"))))))
+
+(provide 'lsp-yaml)
+;;; lsp-yaml.el ends here
+
+;; Local Variables:
+;; flycheck-disabled-checkers: (emacs-lisp-checkdoc)
+;; End:


### PR DESCRIPTION
I've added a new client for [yaml-language-server](https://github.com/redhat-developer/yaml-language-server). The server provides a built-in Kubernetes JSON Schema, so it's an excellent tool for Kubernetes YAML engineers.