### PR TITLE
fix: make-progress-reporter exception caused by nil log--info

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3072,7 +3072,7 @@ This method is used if we do not have `buffer-replace-content'."
                              (prepare-change-group)))
              (howmany (length edits))
              (reporter (make-progress-reporter
-                        (lsp--info "Applying %s edits to `%s'..."
+                        (lsp--info "Applying %s edits to %s ..."
                                    howmany (current-buffer))
                         0 howmany))
              (done 0)


### PR DESCRIPTION
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  string-match("[[:alnum:]]\\'" nil)
  make-progress-reporter(nil 0 1)
  lsp--apply-text-edits((#<hash-table equal 2/65 0x41ec94a9>))
  lsp--apply-formatting((#<hash-table equal 2/65 0x41ec94a9>))