### PR TITLE
default lsp-gopls-build-flags to an empty list

### DIFF
--- a/lsp-go.el
+++ b/lsp-go.el
@@ -47,7 +47,7 @@ completing function calls."
   :type '(repeat string)
   :group 'lsp-gopls)
 
-(defcustom lsp-gopls-build-flags ["-tags"]
+(defcustom lsp-gopls-build-flags []
   "A vector of flags passed on to the build system when invoked,
   applied to queries like `go list'."
   :type 'lsp-string-vector


### PR DESCRIPTION
With the `['-tags']` default and a non-default GOPACKAGESDRIVER for gopls,  I was getting errors like "invalid options syntax -tags" because `-tags` isn't a legit option for the build system that driver integrates with.