### PR TITLE
Fix missing arg to lsp-warn, remove confusion with the help system.

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3724,8 +3724,8 @@ point."
         (let ((lsp-help-buf-name "*lsp-help*"))
           (with-current-buffer (get-buffer-create lsp-help-buf-name)
             (with-help-window lsp-help-buf-name
-              (insert (string-trim-right (lsp--render-on-hover-content contents t))))
-          (lsp--info "No content at point."))))))
+              (insert (string-trim-right (lsp--render-on-hover-content contents t))))))
+      (lsp--info "No content at point."))))
 
 (defun lsp--point-in-bounds-p (bounds)
   "Return whether the current point is within BOUNDS."


### PR DESCRIPTION
lsp-describe-thing-at-point now uses it's own *lsp-help* buffer to display content, rather than
using the *Help* buffer. This avoids confusion with the Emacs help system. For example, the prior
revision of this function, used the *Help* buffer and this would show a 'back' button which did not
work.