### PR TITLE
Lsp Terraform

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -44,6 +44,7 @@
 (require 'lsp-haxe)
 (require 'lsp-vhdl)
 (require 'lsp-yaml)
+(require 'lsp-terraform)
 
 ;;; Ada
 (defgroup lsp-ada nil

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -627,7 +627,8 @@ Changes take effect only when a new session is started."
                                         (csharp-mode . "csharp")
                                         (plain-tex-mode . "plaintex")
                                         (latex-mode . "latex")
-                                        (vhdl-mode . "vhdl"))
+                                        (vhdl-mode . "vhdl")
+                                        (terraform-mode . "terraform"))
   "Language id configuration.")
 
 (defvar lsp-method-requirements

--- a/lsp-terraform.el
+++ b/lsp-terraform.el
@@ -49,7 +49,8 @@
 (defun lsp-terraform--make-launch-cmd ()
   (-let [base `(,lsp-terraform-server)]
     (if lsp-terraform-enable-logging
-        (append base "-enable-log-file"))))
+        (push "-enable-log-file" base))
+    base))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection #'lsp-terraform--make-launch-cmd)

--- a/lsp-terraform.el
+++ b/lsp-terraform.el
@@ -29,19 +29,30 @@
 (defgroup lsp-terraform nil
   "LSP support for Terraform, using terraform-lsp"
   :group 'lsp-mode
-  :link '(url-link "https://github.com/juliosueiras/terraform-lsp"))
+  :link '(url-link "https://github.com/juliosueiras/terraform-lsp")
+  :package-version `(lsp-mode . "6.2"))
 
 (defcustom lsp-terraform-server "terraform-lsp"
   "Path to the `terraform-lsp' binary."
   :group 'lsp-terraform
   :risky t
-  :type 'file)
+  :type 'file
+  :package-version `(lsp-mode . "6.2"))
 
-(defun lsp-terraform-server-start ()
-  ())
+(defcustom lsp-terraform-enable-logging nil
+  "If non-nil, enable `terraform-ls''s native logging."
+  :group 'lsp-terraform
+  :risky t
+  :type 'boolean
+  :package-version `(lsp-mode . "6.2"))
+
+(defun lsp-terraform--make-launch-cmd ()
+  (-let [base `(,lsp-terraform-server)]
+    (if lsp-terraform-enable-logging
+        (append base "-enable-log-file"))))
 
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection #'lsp-terraform-server-start)
+ (make-lsp-client :new-connection (lsp-stdio-connection #'lsp-terraform--make-launch-cmd)
                   :major-modes '(terraform-mode)
                   :priority -1
                   :server-id 'tfls))

--- a/lsp-terraform.el
+++ b/lsp-terraform.el
@@ -1,0 +1,50 @@
+;;; lsp-terraform.el --- Terraform Client settings         -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2019 Ross Donaldson
+
+;; Author: Ross Donaldson
+;; Keywords: terraform lsp
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP client for Terraform
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-terraform nil
+  "LSP support for Terraform, using terraform-lsp"
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/juliosueiras/terraform-lsp"))
+
+(defcustom lsp-terraform-server "terraform-lsp"
+  "Path to the `terraform-lsp' binary."
+  :group 'lsp-terraform
+  :risky t
+  :type 'file)
+
+(defun lsp-terraform-server-start ()
+  ())
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection #'lsp-terraform-server-start)
+                  :major-modes '(terraform-mode)
+                  :priority -1
+                  :server-id 'tfls))
+
+(provide 'lsp-terraform)
+;;; lsp-terraform.el ends here


### PR DESCRIPTION
This PR brings in `lsp` configs for working with Terraform configuration files. This configuration is backed by [terraform-lsp](https://github.com/juliosueiras/terraform-lsp). 

`terraform-lsp` is... fairly limited. I've been using this at my day job, and it's still helpful, but it's nowhere near as fully featured as, say, `gopls` or `rls`. 

Also true: I cannot find a good way to auto-install `terraform-lsp`. It requires a fully-functional `go` install toolchain (a modern one, using `go mod`, meaning go version 1.11 or greater). I don't know if there's a typical or correct mechanism for reporting missing language servers, or if it's built in! Do let me know?

Closes #878. 