### PR TITLE
Fix #1138

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3076,8 +3076,7 @@ The method uses `replace-buffer-contents'."
                                     length)))))))))
 
 (defun lsp--apply-text-edits (edits)
-  "Apply the edits described in the TextEdit[] object.
-This method is used if we do not have `buffer-replace-content'."
+  "Apply the edits described in the TextEdit[] object."
   (unless (seq-empty-p edits)
     (atomic-change-group
       (run-hooks 'lsp-before-apply-edits-hook)


### PR DESCRIPTION
this PR should fix #1138 by flushing delayed changes if the server sync method had temporarily been changed to `'full`. Issue #1138 contains a small test script that can be used to verify the efficacy of this change (tested on a trunk build of clangd-10)