### PR TITLE
incorrect format in docs

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3809,6 +3809,10 @@ Stolen from `org-copy-visible'."
     (while (re-search-forward "^[-]+$" nil t)
       (replace-match ""))
 
+    (goto-char (point-min))
+    (while (re-search-forward "\\\\\_" nil t)
+      (replace-match "\_"))
+
     ;; markdown-mode v2.3 does not yet provide gfm-view-mode
     (if (fboundp 'gfm-view-mode)
         (gfm-view-mode)


### PR DESCRIPTION
As the screenshot below, `last_type` is displayed as `last\_type`.

`lsp-python-ms` + Emacs 27.0.50 + macOS Catalina

I believe the issue is common.

![image](https://user-images.githubusercontent.com/140797/68074993-ff567780-fddc-11e9-8b5d-2a3763deb575.png)

