### PR TITLE
package lint issues

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3809,6 +3809,10 @@ Stolen from `org-copy-visible'."
     (while (re-search-forward "^[-]+$" nil t)
       (replace-match ""))
 
+    (goto-char (point-min))
+    (while (re-search-forward "\\\\\_" nil t)
+      (replace-match "\_"))
+
     ;; markdown-mode v2.3 does not yet provide gfm-view-mode
     (if (fboundp 'gfm-view-mode)
         (gfm-view-mode)


### PR DESCRIPTION
Today I ran `package-lint-current-buffer` and got these issues. Not sure if they are all real issues, but I'd like list all here.

CC @yyoncho 

```
24:0: error: Package should have a non-empty ;;; Commentary section.
371:0: error: Customization groups should not end in "-mode" unless that name would conflict with their parent group.
591:41: error: You should depend on (emacs "26.1") if you need `less-css-mode'.
602:41: error: You should depend on (emacs "26.1") if you need `mhtml-mode'.
791:0: error: "seq-first" doesn't start with package's prefix "lsp".
795:0: error: "seq-rest" doesn't start with package's prefix "lsp".
1378:0: error: "when-lsp-workspace" doesn't start with package's prefix "lsp".
1502:3: warning: `with-eval-after-load' is for use in configurations, and should rarely be used in packages.
1534:56: error: You should depend on (emacs "26.1") if you need `flymake-diag-region'.
1546:35: error: You should depend on (emacs "26.1") if you need `flymake-make-diagnostic'.
2100:0: error: Aliases should start with the package's prefix "lsp".
3110:35: error: You should depend on (emacs "26.1") if you need `replace-buffer-contents'.
3138:31: error: You should depend on (emacs "26.1") if you need `undo-amalgamate-change-group'.
4575:1: warning: `with-eval-after-load' is for use in configurations, and should rarely be used in packages.
```