### PR TITLE
Added support for HDL Checker server to lsp-vhdl

### DIFF
--- a/lsp-vhdl.el
+++ b/lsp-vhdl.el
@@ -34,31 +34,69 @@
 
 (require 'lsp-mode)
 
-(defgroup lsp-vhdl nil
-  "LSP support for VHDL using the server from http://www.vhdltool.com"
-  :group 'lsp-mode
-  :link '(url-link "http://www.vhdltool.com"))
+(defvar vhdl-tool-bin-name "vhdl-tool"
+  "Name of the VHDL Tool binary.")
 
-(defcustom lsp-vhdl-server-path
-  "NOT_SET"
-  "Path to binary server file downloaded from http://www.vhdltool.com/download"
+(defvar vhdl-tool-disp-name "lsp-vhdl-tool"
+  "Display name for VHDL-tool.")
+
+(defvar hdl-checker-bin-name "hdl_checker"
+  "Name of HDL Checker binary.")
+
+(defvar hdl-checker-disp-name "lsp-hdl-checker"
+  "Display name for HDL Checker.")
+
+(defgroup lsp-vhdl nil
+  "LSP support for VHDL. Set lsp-vhdl-server to select server. The default is to use VHDL-tool."
+  :group 'lsp-mode)
+
+(defcustom lsp-vhdl-server 'vhdl-tool
+  "Select which server to use:
+VHDL-tool: A syntax checking, type checking and linting tool (http://vhdltool.com).
+HDL Checker: A wrapper for third party tools such as GHDL, ModelSim, Vivado Simulator (https://github.com/suoto/hdl_checker)."
+  :type '(choice (const :tag "VHDL-tool" vhdl-tool)
+                 (const :tag "HDL Checker" hdl-checker))
+  :group 'lsp-vhdl)
+
+(defcustom lsp-vhdl-server-path nil
+  "Path to binary server file."
   :group 'lsp-vhdl
   :risky t
   :type 'file)
 
 (defun lsp-vhdl--create-connection ()
-  "Returns lsp-stdio-connection or an error if server not found"
+  "Returns lsp-stdio-connection based on the selected server"
+  (cond ((eq lsp-vhdl-server 'hdl-checker) (lsp-vhdl-hdl-checker-server))
+        ((eq lsp-vhdl-server 'vhdl-tool) (lsp-vhdl-vhdl-tool-server))
+        (t (user-error "Server selection \"%s\" not supported" lsp-vhdl-server))))
+
+(defun lsp-vhdl-vhdl-tool-server()
+  "Set up connection for VHDL-tool server."
+  ; If server path is not explicitly set assume it is in PATH
+  (cond ((eq lsp-vhdl-server-path nil) (setq server-path vhdl-tool-bin-name))
+        (t (setq server-path lsp-vhdl-server-path)))
+  ; Check that binary is executable
+  (if (eq (file-executable-p server-path) nil)
+      (user-error "Server \"%s\" does not exist or is not executable" server-path)
+    (lsp-stdio-connection
+     (lambda ()
+       (list server-path "lsp")))))
+
+(defun lsp-vhdl-hdl-checker-server ()
+  "Set up connection for HDL Checker server."
+  ;; If server path is not explicitly set assume it is in PATH
+  (cond ((eq lsp-vhdl-server-path nil) (setq server-path hdl-checker-bin-name))
+        (t (setq server-path lsp-vhdl-server-path)))
   (lsp-stdio-connection
    (lambda ()
-     (list lsp-vhdl-server-path "lsp"))))
+     (list server-path "--lsp"))))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-vhdl--create-connection)
                   :major-modes '(vhdl-mode)
                   :language-id "VHDL"
 		              :priority -1
-                  :server-id 'lsp-vhdl-server)
- )
+                  :server-id 'lsp-vhdl))
 
 (provide 'lsp-vhdl)
 ;;; lsp-vhdl.el ends here


### PR DESCRIPTION
Defaults to use vhdl-tool server but added defcustom to select between the two. Using path to server if explicitly set and assumes it's in PATH otherwise.
Added extra check for hdl_checker binary since it's not automatically executable when downloading a new version.