### PR TITLE
Uri is not correctly translated to path in Windows and also the tramp path is not correctly expanded

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1238,8 +1238,10 @@ DELETE when `lsp-mode.el' is deleted.")
 
 (defun lsp--path-to-uri-1 (path)
   (concat lsp--uri-file-prefix
-          (url-hexify-string (expand-file-name (or (file-remote-p path 'localname t) path))
-                             url-path-allowed-chars)))
+          (--> path
+               (expand-file-name it)
+               (or (file-remote-p it 'localname t) it)
+               (url-hexify-string it url-path-allowed-chars))))
 
 (defun lsp--path-to-uri (path)
   "Convert PATH to a uri."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1215,7 +1215,7 @@ On other systems, returns path without change."
          (file-name (if (and type (not (string= type "file")))
                         (if-let ((handler (lsp--get-uri-handler type)))
                             (funcall handler uri)
-                          (signal 'lsp-file-scheme-not-supported (list uri)))
+                          uri)
                       ;; `url-generic-parse-url' is buggy on windows:
                       ;; https://github.com/emacs-lsp/lsp-mode/pull/265
                       (or (and (eq system-type 'windows-nt)

--- a/test/lsp-common-test.el
+++ b/test/lsp-common-test.el
@@ -39,8 +39,8 @@
     (should (equal (lsp--uri-to-path "custom://file-path") "file-path"))))
 
 (ert-deftest lsp-common-test--unexpected-scheme ()
-  (should-error (lsp--uri-to-path "will-fail://file-path")
-                :type 'lsp-file-scheme-not-supported))
+  (should (equal (lsp--uri-to-path "will-fail://file-path")
+                 "will-fail://file-path")))
 
 (ert-deftest lsp--uri-to-path--handle-utf8 ()
   (let ((lsp--uri-file-prefix "file:///")


### PR DESCRIPTION
There're 2 problems:
- `lsp--path-to-uri` is not working correctly for remote path that has path, for example `$HOME`, different from local.
The example if remote machine has `$HOME` set to `/home/user1` and local machine has `$HOME` set to `/home/user2`, `lsp--path-to-uri` should expand `/ssh:host:bar/~/foo` to `/home/user1/foo` instead of `/home/user2/foo`.
- `lsp--uri-to-path` is not working correct for Windows path, since it recognizes driver path as file handling scheme and throw. We should just return the raw uri path in that case. emacs-lsp/dap-mode#159