### PR TITLE
Better implementation of displaying textDocument/signatureHelp

### DIFF
--- a/README.org
+++ b/README.org
@@ -202,6 +202,10 @@
    - ~lsp-lens-hide~ - Hide lenses in the current file
    - ~lsp-lens-mode~  - Turn on/off lenses in the current file.
    - ~lsp-avy-lens~ - Click lens using ~avy~
+   - ~lsp-signature-activate~ - activate signature help. Bound to ~C-M-SPC~ by default.
+   - ~lsp-signature-next~ - show next signature. Bound to ~M-n~ when signature help is activated.
+   - ~lsp-signature-previous~ - show previous signature. Bound to ~M-p~ when signature help is activated.
+   - ~lsp-signature-stop~ - cancel signature help. Bound to ~C-c C-k~ when signature help is activated.
 ** Settings
    - ~lsp-log-io~ - If non-nil, print all messages to and from the language server to ~*lsp-log*~.
    - ~lsp-print-performance~ - If non-nil, print performance info. to ~*lsp-log*~.
@@ -216,7 +220,6 @@
    - ~lsp-document-sync-method~ - How to sync the document with the language server.
    - ~lsp-auto-execute-action~ - Auto-execute single action.
    - ~lsp-eldoc-render-all~ - Display all of the info returned by ~document/onHover~. If this is nil, ~eldoc~ will show only the symbol information.
-   - ~lsp-signature-render-all~ - Display all of the info returned by ~textDocument/signatureHelp~. If this is nil, ~eldoc~ will show only the active signature.
    - ~lsp-enable-completion-at-point~ - Enable ~completion-at-point~ integration.
    - ~lsp-enable-xref~ - Enable xref integration.
    - ~lsp-prefer-flymake~ - If you prefer flycheck and ~lsp-ui-flycheck~ is available, ~(setq lsp-prefer-flymake nil)~. If set to ~:none~ neither of two will be enabled.
@@ -231,6 +234,8 @@
    - ~lsp-server-trace~ - Request trace mode on the language server.
    - ~lsp-enable-semantic-highlighting~ - Enable experimental semantic highlighting support
    - ~lsp-enable-imenu~ - If non-nil, automatically enable imenu integration when server provides ~textDocument/documentSymbol~.
+   - ~lsp-signature-auto-activate~ - Auto activate signature when trigger char is pressed.
+   - ~lsp-signature-render-documentation~ - Include signature documentation in signature help.
 ** Screenshots
    - RUST Completion with company-lsp
      [[file:examples/completion.png]]

--- a/lsp-go.el
+++ b/lsp-go.el
@@ -78,11 +78,57 @@ completing function calls."
   :risky t
   :package-version '(lsp-mode "6.2"))
 
+(defcustom lsp-gopls-experimental-disabled-analyses []
+  "A list of the names of analysis passes that should be disabled. You can use
+ this to turn off analyses that you feel are not useful in the editor."
+  :type 'lsp-string-vector
+  :group 'lsp-gopls
+  :package-version '(lsp-mode "6.2"))
+
+(defcustom lsp-gopls-staticcheck nil
+  "If non-nil, enables the use of staticcheck.io analyzers."
+  :type 'boolean
+  :group 'lsp-gopls
+  :package-version '(lsp-mode "6.2"))
+
+(defcustom lsp-gopls-completion-documentation t
+  "If nil, indicates that the user does not want documentation with completion
+ results."
+  :type 'boolean
+  :group 'lsp-gopls
+  :package-version '(lsp-mode "6.2"))
+
+(defcustom lsp-gopls-complete-unimported nil
+  "If true, the completion engine is allowed to make suggestions for packages
+ that you do not currently import."
+  :type 'boolean
+  :group 'lsp-gopls
+  :package-version '(lsp-mode "6.2"))
+
+(defcustom lsp-gopls-deep-completion t
+  "If true, this turns on the ability to return completions from deep inside
+ relevant entities, rather than just the locally accessible ones."
+  :type 'boolean
+  :group 'lsp-gopls
+  :package-version '(lsp-mode "6.2"))
+
+(defcustom lsp-gopls-fuzzy-matching t
+  "If true, this enables server side fuzzy matching of completion candidates."
+  :type 'boolean
+  :group 'lsp-gopls
+  :package-version '(lsp-mode "6.2"))
+
 (lsp-register-custom-settings
  '(("gopls.usePlaceholders" lsp-gopls-use-placeholders t)
    ("gopls.hoverKind" lsp-gopls-hover-kind)
    ("gopls.buildFlags" lsp-gopls-build-flags)
-   ("gopls.env" lsp-gopls-env)))
+   ("gopls.env" lsp-gopls-env)
+   ("gopls.experimentalDisabledAnalyses" lsp-gopls-experimental-disabled-analyses)
+   ("gopls.staticcheck" lsp-gopls-staticcheck)
+   ("gopls.completionDocumentation" lsp-gopls-complete-unimported)
+   ("gopls.completeUnimported" lsp-gopls-complete-unimported)
+   ("gopls.deepCompletion" lsp-gopls-deep-completion)
+   ("gopls.fuzzyMatching" lsp-gopls-fuzzy-matching)))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection

--- a/test/lsp-io-test.el
+++ b/test/lsp-io-test.el
@@ -32,8 +32,8 @@
   (let ((fn (lsp--create-filter-function nil)))
     (lambda (input)
       (flet ((lsp--parser-on-message (msg _workspace))
-             (lsp--read-json (msg)
-                             (push msg lsp--test-results)))
+             (json-read-from-string (msg)
+                                    (push msg lsp--test-results)))
         (funcall fn nil input)
         (prog1 lsp--test-results
           (setq lsp--test-results nil))))))


### PR DESCRIPTION
This implementation is more accurate and closer to the lsp protocol idea.

- the signatures could be browsed using `M-n`/`M-p` and `C-c C-k` to switch back
to hover info

- the signatureHelp is triggered when

- added two new variables: `lsp-signature-render-documentation` - to control
whether to include signature documentation and `lsp-signature-auto-activate`.
When `lsp-signature-auto-activate` is true the signatureHelp will be displayed
when you press the signature trigger char(e. g. `(` in java).

``` elisp
(add-hook 'company-completion-finished-hook (lambda (&rest _) (lsp-signature-activate)))
```
