### PR TITLE
Adding code action handlers for `lsp-pwsh`.

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -752,8 +752,11 @@ They are added to `markdown-code-lang-modes'")
 
 (defun lsp-elt (sequence n)
   "Return Nth element of SEQUENCE or nil if N is out of range."
-  (if (listp sequence) (elt sequence n)
-    (and (> (length sequence) n) (elt sequence n))))
+  (cond
+   ((listp sequence) (elt sequence n))
+   ((arrayp sequence) 
+    (and (> (length sequence) n) (aref sequence n)))
+   (t (and (> (length sequence) n) (elt sequence n)))))
 
 ;; define seq-first and seq-rest for older emacs
 (defun lsp-seq-first (sequence)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1496,7 +1496,7 @@ WORKSPACE is the workspace that contains the diagnostics."
       "Report new diagnostics to flymake."
       (funcall lsp--flymake-report-fn
                (-some->> (lsp-diagnostics)
-                 (gethash buffer-file-name)
+                 (gethash (lsp--fix-path-casing buffer-file-name))
                  (--map (-let* (((&hash "message" "severity" "range") (lsp-diagnostic-original it))
                                 ((start . end) (lsp--range-to-region range)))
                           (when (= start end)
@@ -3584,7 +3584,8 @@ and the position respectively."
                            (lambda (diag)
                              (let ((line (lsp-diagnostic-line diag)))
                                (and (>= line start) (<= line end))))
-                           (gethash buffer-file-name (lsp-diagnostics) nil))))
+                           (gethash (lsp--fix-path-casing buffer-file-name)
+                                    (lsp-diagnostics) nil))))
     (cl-coerce (seq-map #'lsp-diagnostic-original diags-in-range) 'vector)))
 
 (defalias 'lsp--cur-line-diagnotics 'lsp-cur-line-diagnostics)

--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -234,6 +234,9 @@ Must not nil.")
 
 (defun lsp-pwsh--command ()
   "Return the command to start server."
+  (unless (and lsp-pwsh-exe (file-executable-p lsp-pwsh-exe))
+    (user-error "Use `lsp-pwsh-exe' with the value of `%s' is not a valid powershell binary"
+                lsp-pwsh-exe))
   ;; Download extension
   (lsp-pwsh-setup)
   `(,lsp-pwsh-exe "-NoProfile" "-NonInteractive" "-NoLogo"

--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -266,7 +266,8 @@ Must not nil.")
   :server-id 'pwsh-ls
   :priority 1
   :initialization-options #'lsp-pwsh--extra-init-params
-  :notification-handlers (lsp-ht ("powerShell/executionStatusChanged" 'ignore))
+  :notification-handlers (lsp-ht ("powerShell/executionStatusChanged" #'ignore)
+                                 ("output" #'ignore))
   :initialized-fn (lambda (w)
                     (with-lsp-workspace w
                       (lsp--set-configuration


### PR DESCRIPTION
This fix #1205 and some other issues:
- `lsp-mode` crash with unhelpful error when `powershell` is not found
- `codeAction` is not working in Windows
- `lsp-pwsh` sometimes warn about `output` is not handled.