### PR TITLE
Modify declare-function invocations for external plugins.

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -60,11 +60,11 @@
 (require 'ewoc)
 (require 'yasnippet nil t)
 
-(declare-function company-mode "company")
-(declare-function flycheck-mode "flycheck")
-(declare-function lsp-ui-flycheck-enable "lsp-ui")
-(declare-function evil-set-command-property "evil")
-(declare-function projectile-project-root "projectile")
+(declare-function company-mode "ext:company")
+(declare-function flycheck-mode "ext:flycheck")
+(declare-function lsp-ui-flycheck-enable "ext:lsp-ui-flycheck")
+(declare-function evil-set-command-property "ext:evil-common")
+(declare-function projectile-project-root "ext:projectile")
 
 (defconst lsp--message-type-face
   `((1 . ,compilation-error-face)
@@ -6234,8 +6234,8 @@ This avoids overloading the server with many files when starting Emacs."
 
 ;; avy integration
 
-(declare-function avy-process "avy" (candidates overlay-fn cleanup-fn))
-(declare-function avy--key-to-char "avy" (c))
+(declare-function avy-process "ext:avy" (candidates overlay-fn cleanup-fn))
+(declare-function avy--key-to-char "ext:avy" (c))
 (defvar avy-action)
 
 (defun lsp-avy-lens ()


### PR DESCRIPTION
For functions from external packages, we must specify "ext:".