### PR TITLE
lsp-pwsh: support code formatting

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3129,6 +3129,8 @@ The method uses `replace-buffer-contents'."
                                     beg (+ beg (length newText))
                                     length)))))))))
 
+(defvar-local lsp--filter-cr? t)
+
 (defun lsp--apply-text-edits (edits)
   "Apply the edits described in the TextEdit[] object."
   (unless (seq-empty-p edits)
@@ -3146,6 +3148,11 @@ The method uses `replace-buffer-contents'."
                            'lsp--apply-text-edit)))
         (unwind-protect
             (->> edits
+                 (mapc (lambda (edit)
+                         (when lsp--filter-cr?
+                           ;; filter \r out of text since it's mostly useless
+                           (ht-set edit "newText"
+                                   (s-replace "\r" "" (ht-get edit "newText" ""))))))
                  (nreverse)
                  (seq-sort #'lsp--text-edit-sort-predicate)
                  (mapc (lambda (edit)

--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -307,7 +307,10 @@ Must not nil.")
   :initialized-fn (lambda (w)
                     (with-lsp-workspace w
                       (lsp--set-configuration
-                       (lsp-configuration-section "powershell"))))
+                       (lsp-configuration-section "powershell")))
+                    (let ((caps (lsp--workspace-server-capabilities w)))
+                      (ht-set caps "documentRangeFormattingProvider" t)
+                      (ht-set caps "documentFormattingProvider" t)))
   ))
 
 ;; Compatibility


### PR DESCRIPTION
Fix #1212:
- force enable `formattingProvider` capability of PSES since it already supports that.
- filter `\r` out of edit text since they're annoying and logically should never used as replaced text.

I'm not really happy with the hack of removing `\r`, @yyoncho, do you have any suggestion?