### PR TITLE
Check that the environment variable is not nil

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5308,7 +5308,7 @@ Ignore non-boolean keys whose value is nil."
                          (funcall environment-fn)
                        nil)))
     (-flatten (cons (cl-loop for (key . value) in environment
-                             if (or value
+                             if (or (eval value)
                                     (eq (get value 'custom-type) 'boolean))
                              collect (concat key "=" (lsp--value-to-string
                                                       (eval value))))


### PR DESCRIPTION
Fixes https://github.com/syl20bnr/spacemacs/issues/12997

* lsp-mode.el (lsp--compute-process-environment): Check if the
evaluation of the LSP environment variable is nil. If it is, it
shouldn't be part of the language server environment.