### PR TITLE
fix markdown escape characters and add multi-root to lsp-json

### DIFF
--- a/lsp-json.el
+++ b/lsp-json.el
@@ -125,6 +125,7 @@
   :major-modes lsp-json--major-modes
   :server-id 'json-ls
   :priority -1
+  :multi-root t
   :completion-in-comments? t
   :initialization-options lsp-json--extra-init-params
   :async-request-handlers (ht ("vscode/content" #'lsp-json--get-content))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -31,6 +31,7 @@
   (require 'project)
   (require 'flymake))
 
+(require 'rx)
 (require 'bindat)
 (require 'cl-lib)
 (require 'compile)
@@ -3874,8 +3875,12 @@ Stolen from `org-copy-visible'."
       (replace-match ""))
 
     (goto-char (point-min))
-    (while (re-search-forward "\\\\\_" nil t)
-      (replace-match "\_"))
+    (while (re-search-forward 
+            (rx (and "\\" (group (or "\\" "`" "*" "_"
+                                     "{" "}" "[" "]" "(" ")"
+                                     "#" "+" "-" "." "!" "|"))))
+            nil t)
+      (replace-match (rx (backref 1))))
 
     ;; markdown-mode v2.3 does not yet provide gfm-view-mode
     (if (fboundp 'gfm-view-mode)

--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -296,6 +296,7 @@ Must not nil.")
   :major-modes lsp-pwsh--major-modes
   :server-id 'pwsh-ls
   :priority -1
+  :multi-root t
   :initialization-options #'lsp-pwsh--extra-init-params
   :notification-handlers (lsp-ht ("powerShell/executionStatusChanged" #'ignore)
                                  ("output" #'ignore))


### PR DESCRIPTION
Per discussion in #1236.
We should properly handling escaped characters in markdown.

Also add `:multiroot t` for `lsp-json` and `lsp-pwsh` since both of their server can work with multiple work spaces.