### PR TITLE
Fix rust-analyzer inlay hints flickering

### DIFF
--- a/lsp-rust.el
+++ b/lsp-rust.el
@@ -451,7 +451,8 @@ PARAMS progress report notification data."
                                (overlay-put overlay 'lsp-rust-analyzer-inlay-hint t)
                                (overlay-put overlay 'evaporate t)
                                (overlay-put overlay 'after-string (propertize (concat ": " label)
-                                                                              'font-lock-face 'font-lock-comment-face)))))))
+                                                                              'font-lock-face 'font-lock-comment-face)))))
+                         :mode 'tick))
   nil)
 
 (defun lsp-rust-analyzer-initialized? ()


### PR DESCRIPTION
Apparently the `'tick` mode got lost when copying the code for the rust-analyzer inlay hints, which causes them to flicker while editing.