### PR TITLE
Fix lsp-rust-server defcustom type

### DIFF
--- a/lsp-rust.el
+++ b/lsp-rust.el
@@ -36,8 +36,8 @@
 
 (defcustom lsp-rust-server 'rls
   "Choose LSP server."
-  :type '(choice (symbol :tag 'rls "rls")
-                 (symbol :tag 'rust-analyzer "rust-analyzer"))
+  :type '(choice (symbol :tag "rls" rls)
+                 (symbol :tag "rust-analyzer" rust-analyzer))
   :group 'lsp-mode
   :package-version '(lsp-mode . "6.2"))
 


### PR DESCRIPTION
Trying to customize `lsp-rust-server` currently throws an error.