### PR TITLE
lsp-csharp.el: ability to upgrade server via lsp-csharp-update-server

### DIFF
--- a/lsp-csharp.el
+++ b/lsp-csharp.el
@@ -131,6 +131,8 @@ for installation."
     (lsp-csharp--extract filename target-dir)))
 
 (defun lsp-csharp-update-server ()
+  "Checks if the currently installed version (if any) is lower than then one
+available on github and if so, downloads and installs a newer version."
   (interactive)
   (let ((latest-version (lsp-csharp--latest-available-version))
         (installed-version (lsp-csharp--latest-installed-version)))
@@ -147,8 +149,7 @@ for installation."
       (message "lsp-csharp-update-server: cannot retrieve latest version info"""))))
 
 (defun lsp-csharp--install-server (update-version ask-confirmation)
-  "Checks if the currently installed version (if any) is lower than then one
-available on github and if so, downloads and installs a newer version."
+  "Installs (or updates to UPDATE-VERSION) server binary unless it is already installed."
   (let ((installed-version (lsp-csharp--latest-installed-version))
         (target-version (or update-version (lsp-csharp--latest-available-version))))
     (if (and target-version


### PR DESCRIPTION
This adds ability to update roslyn server binary from github by checking for the latest version and initiating the download/extract procedure.

Server version to use is now determined enumerating and sorting by `version<` subdirectories on:
 - `~/.emacs.d/cache/omnisharp-roslyn`

..instead of referencing a (customizable) variable as we had before.

I think this makes the behaviour more flexible, with possibility to use an old version of the server (downgrade) by just deleting a new version from the cache dir. Also there is now no need to customize variables to update to newer version – just `M-x lsp-csharp-update-server`.

FYI @josteink 