### PR TITLE
[csharp] Use lsp-seq-first instead of seq-first

### DIFF
--- a/lsp-csharp.el
+++ b/lsp-csharp.el
@@ -52,7 +52,7 @@ Set this if you have the binary installed or have it built yourself."
                  (lambda (x) (substring x 1))
                  (lambda (a b) (not (version<= a b)))
                  lst)))
-    (when sorted (seq-first sorted))))
+    (when sorted (lsp-seq-first sorted))))
 
 (defun lsp-csharp--latest-installed-version ()
   "Returns latest version of the server installed on the machine (if any)."


### PR DESCRIPTION
Prevent errors on emacs 26