### PR TITLE
Implement automatic downloading facilities

### DIFF
--- a/lsp-eslint.el
+++ b/lsp-eslint.el
@@ -198,16 +198,14 @@
   (interactive)
   (lsp-send-execute-command "eslint.applyAllFixes" (vector (lsp--versioned-text-document-identifier))))
 
-
-
 (lsp-register-client
  (make-lsp-client
   :new-connection
-  (plist-put (lsp-stdio-connection
-              (lambda () lsp-eslint-server-command))
-             :test? (lambda ()
-                      (and (cl-second lsp-eslint-server-command)
-                           (file-exists-p (cl-second lsp-eslint-server-command)))))
+  (lsp-stdio-connection
+   (lambda () lsp-eslint-server-command)
+   (lambda ()
+     (and (cl-second lsp-eslint-server-command)
+          (file-exists-p (cl-second lsp-eslint-server-command)))))
   :activation-fn (lambda (filename &optional _)
                    (or (string-match-p (rx (one-or-more anything) "."
                                            (or "ts" "js" "jsx" "tsx" "html" "vue"))

--- a/lsp-vhdl.el
+++ b/lsp-vhdl.el
@@ -76,9 +76,9 @@ HDL Checker: A wrapper for third party tools such as GHDL, ModelSim, Vivado Simu
   "Returns lsp-stdio-connection based on the selected server"
   (lsp-vhdl--set-server-path)
   (lsp-vhdl--set-server-args)
-  (plist-put
-   (lsp-stdio-connection (lambda () (list (plist-get lsp-vhdl--params 'server-path) (plist-get lsp-vhdl--params 'server-args))))
-   :test? (lambda () (f-executable? (plist-get lsp-vhdl--params 'server-path)))))
+  (lsp-stdio-connection
+    (lambda () (list (plist-get lsp-vhdl--params 'server-path) (plist-get lsp-vhdl--params 'server-args)))
+    (lambda () (f-executable? (plist-get lsp-vhdl--params 'server-path)))))
 
 (defun lsp-vhdl--set-server-path()
   "Set path to server binary based on selection in lsp-vhdl-server."

--- a/lsp-xml.el
+++ b/lsp-xml.el
@@ -197,11 +197,9 @@ Newlines and excess whitespace are removed."
   :package-version '(lsp-mode . "6.1"))
 
 (defun lsp-xml--create-connection ()
-  (plist-put
-   (lsp-stdio-connection
-    (lambda () lsp-xml-server-command))
-   :test? (lambda ()
-            (f-exists? lsp-xml-jar-file))))
+  (lsp-stdio-connection
+   (lambda () lsp-xml-server-command)
+   (lambda () (f-exists? lsp-xml-jar-file))))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-xml--create-connection)


### PR DESCRIPTION
- Fixes #506

- Implemented base facilities for downloading and installing language servers
- added new field :download-server-fn in lsp--client structure which will be
called with (client callback update?).
- Implemented automatic installation via npm for jsts-ls and ts-ls.
- All servers(when feasible) should be installed under `lsp-server-install-dir`.

@akirak - check the cl-defgenerics in lsp-mode - let me know if they are
sufficient to implement the nix variands.

@razzmatazz - I have ported CSharp implementation but I havent converted it into
async.

@seagle0128 - lsp-python-ms is not ported. In general, it will work as it is but
it will ask to install the server even if you are about to start language server not being in python file. 

@TOTBWF - F# same as C#.

@kiennq powershell installation is converted to async one.