### PR TITLE
Fix lsp-rust-server defcustom type

### DIFF
--- a/lsp-rust.el
+++ b/lsp-rust.el
@@ -36,8 +36,8 @@
 
 (defcustom lsp-rust-server 'rls
   "Choose LSP server."
-  :type '(choice (symbol :tag "rls" rls)
-                 (symbol :tag "rust-analyzer" rust-analyzer))
+  :type '(choice (const :tag "rls" rls)
+                 (const :tag "rust-analyzer" rust-analyzer))
   :group 'lsp-rust
   :package-version '(lsp-mode . "6.2"))
 


### PR DESCRIPTION
Follow-up to my previous PR (https://github.com/emacs-lsp/lsp-mode/pull/1258) which didn't completely fix this. No error was being thrown, but `rls` couldn't be selected, after selecting `rust-analyzer`.