### PR TITLE
Revert lsp--annotate to include candidate kind information

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3680,8 +3680,10 @@ and the position respectively."
 
 (defun lsp--annotate (item)
   "Annotate ITEM detail."
-  (-let (((&hash "detail") (plist-get (text-properties-at 0 item) 'lsp-completion-item)))
-    (concat (when detail (concat " " detail)))))
+  (-let (((&hash "detail" "kind") (plist-get (text-properties-at 0 item) 'lsp-completion-item)))
+    (concat (when detail (concat " " detail))
+            (when-let (kind-name (and kind (aref lsp--completion-item-kind kind)))
+              (format " (%s)" kind-name)))))
 
 (defun lsp--looking-back-trigger-characters-p (trigger-characters)
   "Return non-nil if text before point matches any of the trigger characters."


### PR DESCRIPTION
This should fix #1282. 
Let me know if you want to make candidate kind information to be annotated to be customizable too.