### PR TITLE
Add null processing for "window/workDoneProgress/create".

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5080,6 +5080,10 @@ WORKSPACE is the active workspace."
                              (-map (lambda (folder)
                                      (list :uri (lsp--path-to-uri folder))))
                              (apply #'vector))))
+                     ((string= method "window/workDoneProgress/create")
+                      ;; Ignoring for now
+                      nil
+                      )
                      (t (lsp-warn "Unknown request method: %s" method) nil))))
     ;; Send response to the server.
     (unless (eq response 'delay-response)


### PR DESCRIPTION
This is until LSP Spec version 3.15 is published, and gets rid of an
annoying warning message for servers such as haskell-ide-engine that
already support it.

Closes #1277