### PR TITLE
lsp-json: update lsp-json-server to new binary name

### DIFF
--- a/lsp-json.el
+++ b/lsp-json.el
@@ -65,7 +65,7 @@
    ("http.proxy" lsp-http-proxy)
    ("http.proxyStrictSSL" lsp-http-proxyStrictSSL)))
 
-(defcustom lsp-json-server "vscode-json-languageserver"
+(defcustom lsp-json-server "json-languageserver"
   "Json language server executable."
   :type 'string
   :group 'lsp-json


### PR DESCRIPTION
Hi,

Json server upstream project has renamed its binary to `json-languageserver` and lsp-mode wont find it.

Snippet from https://github.com/vscode-langservers/vscode-json-languageserver


> Start the language server with the **json-language-server** command. Use a command line argument to specify the prefered communication channel:

This PR fixes it!

`

Thanks!