### PR TITLE
Correct npm installing commands and path for Windows

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -157,7 +157,7 @@ This directory shoud contain a file matching groovy-language-server-*.jar"
 (lsp-dependency javascript-typescript-langserver
   (:system "javascript-typescript-stdio")
   (:npm :package "javascript-typescript-langserver"
-        :path ".bin/javascript-typescript-stdio"))
+        :path "javascript-typescript-stdio"))
 
 (defgroup lsp-typescript-javascript nil
   "Support for TypeScript/JavaScript, using Sourcegraph's JavaScript/TypeScript language server."
@@ -228,12 +228,12 @@ directory containing the package. Example:
 (lsp-dependency typescript-language-server
   (:system "typescript-language-server")
   (:npm :package "typescript-language-server"
-        :path ".bin/typescript-language-server"))
+        :path "typescript-language-server"))
 
 (lsp-dependency typescript
   (:system "tsserver")
   (:npm :package "typescript"
-        :path ".bin/tsserver"))
+        :path "tsserver"))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()

--- a/lsp-json.el
+++ b/lsp-json.el
@@ -104,7 +104,7 @@
 (lsp-dependency vscode-json-languageserver
   (:system "vscode-json-languageserver")
   (:npm :package "vscode-json-languageserver"
-        :path ".bin/vscode-json-languageserver"))
+        :path "vscode-json-languageserver"))
 
 (lsp-register-client
  (make-lsp-client

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5982,10 +5982,14 @@ Check `*lsp-install*' and `*lsp-log*' buffer."
 
 ;; npm handling
 
+;; https://docs.npmjs.com/files/folders#executables
 (cl-defun lsp--npm-dependency-path (&key package path &allow-other-keys)
-  (let ((path (f-join lsp-server-install-dir "npm" package "node_modules" path)))
+  (let ((path (f-join lsp-server-install-dir "npm" package
+                      (cond ((eq system-type 'windows-nt) "")
+                            (t "bin"))
+                      path)))
     (unless (f-exists? path)
-      (error "The package %s is not installed. Unable to find %s." package path))
+      (error "The package %s is not installed.  Unable to find %s" package path))
     path))
 
 (cl-defun lsp--npm-dependency-download  (callback error-callback &key package &allow-other-keys)
@@ -5993,6 +5997,7 @@ Check `*lsp-install*' and `*lsp-log*' buffer."
       (lsp-async-start-process callback
                                error-callback
                                npm-binary
+                               "-g"
                                "--prefix"
                                (f-join lsp-server-install-dir "npm" package)
                                "install"


### PR DESCRIPTION
According to https://docs.npmjs.com/files/folders#executables, we should install using global opyion with prefix and correct the path to have support for Windows