### PR TITLE
Fix ts-ls with correct tsServerPath

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -237,8 +237,10 @@ directory containing the package. Example:
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
-                                                          (cons (lsp-package-path 'typescript-language-server)
-                                                                lsp-clients-typescript-server-args)))
+                                                          `(,(lsp-package-path 'typescript-language-server)
+                                                            "--tsserver-path"
+                                                            ,(lsp-package-path 'typescript)
+                                                            ,@lsp-clients-typescript-server-args)))
                   :activation-fn 'lsp-typescript-javascript-tsx-jsx-activate-p
                   :priority -2
                   :completion-in-comments? t

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6012,11 +6012,13 @@ Check `*lsp-install*' and `*lsp-log*' buffer."
 
 ;; https://docs.npmjs.com/files/folders#executables
 (cl-defun lsp--npm-dependency-path (&key package path &allow-other-keys)
-  (let ((path (f-join lsp-server-install-dir "npm" package
-                      (cond ((eq system-type 'windows-nt) "")
-                            (t "bin"))
-                      path)))
-    (unless (f-exists? path)
+  "Return npm dependency PATH for PACKAGE."
+  (let ((path (executable-find
+               (f-join lsp-server-install-dir "npm" package
+                       (cond ((eq system-type 'windows-nt) "")
+                             (t "bin"))
+                       path))))
+    (unless (and path (f-exists? path))
       (error "The package %s is not installed.  Unable to find %s" package path))
     path))
 


### PR DESCRIPTION
The `initialization-options` of `ts-ls` is doing nothing with passing `tsServerPath`.
From https://github.com/theia-ide/typescript-language-server, it seems that we actually need to pass the path via command line options.

Also, fix `lsp--npm-dependency-path` to return full executable name, else the `ts-ls` will crash in Windows.