### PR TITLE
Fix  $schema insertion in lsp-json

### DIFF
--- a/lsp-json.el
+++ b/lsp-json.el
@@ -92,14 +92,15 @@
 
 (defun lsp-json--get-content (_workspace uri callback)
   "Get content from URI."
-  (url-retrieve uri (lambda (_status callback)
-                      (goto-char (point-min))
-                      (re-search-forward "\n\n" nil 'noerror)
-                      (funcall
-                       callback
-                       (decode-coding-string (buffer-substring (point) (point-max))
-                                             'utf-8-unix)))
-                (list callback)))
+  (ignore-errors
+    (url-retrieve uri (lambda (_status callback)
+                        (goto-char (point-min))
+                        (re-search-forward "\n\n" nil 'noerror)
+                        (funcall
+                         callback
+                         (decode-coding-string (buffer-substring (point) (point-max))
+                                               'utf-8-unix)))
+                  (list callback))))
 
 (lsp-dependency vscode-json-languageserver
   (:system "vscode-json-languageserver")


### PR DESCRIPTION
In `lsp-json` when we try to select candidate and insert `$schema` into json file, with lsp-capf, `\$schema` will be insert.
This is due to `start-point` is not correctly calculated (it can be changed when lambda block is invoked so it's may not correct).
We may need to use text edit range as `start-point` and fallback to `(point)` if needed.

Since we will reverting text in `textEdit` range anyway, this change is actually safe and works better for snippet expanding.