### PR TITLE
Improve edge case library folder detection.

### DIFF
--- a/lsp-go.el
+++ b/lsp-go.el
@@ -147,7 +147,7 @@ defaults to half of your CPU cores."
   :type 'boolean
   :group 'lsp-clients-go)
 
-(defcustom lsp-clients-go-library-directories '("/usr/lib" "usr/local/lib")
+(defcustom lsp-clients-go-library-directories '("/usr")
   "List of directories which will be considered to be libraries."
   :group 'lsp-clients-go
   :risky t

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6491,6 +6491,7 @@ The library folders are defined by each client for each of the active workspace.
                                             (funcall library-folders-fn it)))))))
     (lsp--open-in-workspace workspace)
     (view-mode t)
+    (lsp--info "Opening read-only library file %s." (buffer-file-name))
     (list workspace)))
 
 (defun lsp--persist-session (session)
@@ -6600,7 +6601,10 @@ argument ask the user to select which language server to start. "
       (cond
        (matching-clients
         (when (setq-local lsp--buffer-workspaces
-                          (or (lsp--try-open-in-library-workspace)
+                          (or (and
+                               ;; Don't open as library file if file is part of a project.
+                               (not (lsp-find-session-folder (lsp-session) (buffer-file-name)))
+                               (lsp--try-open-in-library-workspace))
                               (lsp--try-project-root-workspaces (equal arg '(4))
                                                                 (and arg (not (equal arg 1))))))
           (lsp-mode 1)


### PR DESCRIPTION
Don't open a file as a library file if it is within a project root.
This makes things work better if your project root is within a library
folder for some reason.

I also reverted d8e99484ab9bbb211e00f09aff1088ef151f1653 and restored
the Go library paths as just '("/usr"). This fixes standard library
detection on Mac. I don't think we should adjust the default config to
handle the rare case of a user putting their home directory under
/usr. In this case, the user should just customize
lsp-clients-go-library-directories to accommodate their setup.

I also added an info message when opening a library file in read only
mode so it is easy to figure out why your file is in read only mode.
Note that this message is superseded in the minibuffer by the "Connected
to" message, but at least it shows up in *Messages*.

Fixes #1217.