### PR TITLE
Cache completion candidates in lsp-capf

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3709,6 +3709,10 @@ and the position respectively."
   "Cached candidates for completion at point function.
 In the form of (prefix items args).")
 
+(defun lsp--capf-clear-cache (&rest _)
+  "Clear completion caches."
+  (setq lsp--capf-cache nil))
+
 (defun lsp--capf-filter-candidates (pred string items &rest plist)
   "List the possible completion of STRING in candidates ITEMS.
 Only the elements that satisfy predicate PRED are considered.
@@ -3854,15 +3858,17 @@ PLIST is the additional data to attach to each candidate."
                                  (point)))
            (when additional-text-edits
              (lsp--apply-text-edits additional-text-edits)))
-         (setq lsp--capf-cache nil)
+         (lsp--capf-clear-cache)
          (when lsp-signature-auto-activate
            (lsp-signature-activate))
          (when (lsp--looking-back-trigger-characters-p trigger-chars)
            (setq this-command 'self-insert-command)))))))
 
 (with-eval-after-load 'company
-  (add-hook 'company-completion-finished-hook (lambda (&rest _) (setq lsp--capf-cache nil)))
-  (add-hook 'company-completion-cancelled-hook (lambda (&rest _) (setq lsp--capf-cache nil))))
+  (add-hook 'company-completion-finished-hook #'lsp--capf-clear-cache)
+  (add-hook 'company-completion-cancelled-hook #'lsp--capf-clear-cache))
+
+(advice-add #'completion-at-point :before #'lsp--capf-clear-cache)
 
 (defun lsp--to-yasnippet-snippet (text)
   "Convert VS code snippet TEXT to yasnippet snippet."


### PR DESCRIPTION
This finish fixing #1305.
Caching candidates from language server when language server said they're completed (`isIncomplete == nil`).

The cache is a list that contains `(cache-prefix cache-items additional-args)`.
It will be applied when `cache-prefix` is prefix of currently input string. And will be invalidated/updated immediately otherwise.

Pairing with `completion-styles` we can archive flex matching for `lsp-mode` completion at point function.
![a2d69604-18a8-430e-a99d-cea0740e985f](https://user-images.githubusercontent.com/2631472/72684763-ad450880-3b26-11ea-9da4-8db62db6a337.gif)




