### PR TITLE
Add server locations, special-mode for stderr-buf, fix types

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -150,10 +150,10 @@ See instructions at https://marketplace.visualstudio.com/items?itemName=mads-har
 
 ;;; TypeScript/JavaScript
 
-(lsp-dependency javascript-typescript-langserver
-  (:system "javascript-typescript-stdio")
-  (:npm :package "javascript-typescript-langserver"
-        :path "javascript-typescript-stdio"))
+(lsp-dependency 'javascript-typescript-langserver
+                '(:system "javascript-typescript-stdio")
+                '(:npm :package "javascript-typescript-langserver"
+                       :path "javascript-typescript-stdio"))
 
 (defgroup lsp-typescript-javascript nil
   "Support for TypeScript/JavaScript, using Sourcegraph's JavaScript/TypeScript language server."
@@ -221,15 +221,15 @@ directory containing the package. Example:
                                                   (and name location))
                                                 xs)))))
 
-(lsp-dependency typescript-language-server
-  (:system "typescript-language-server")
-  (:npm :package "typescript-language-server"
-        :path "typescript-language-server"))
+(lsp-dependency 'typescript-language-server
+                '(:system "typescript-language-server")
+                '(:npm :package "typescript-language-server"
+                       :path "typescript-language-server"))
 
-(lsp-dependency typescript
-  (:system "tsserver")
-  (:npm :package "typescript"
-        :path "tsserver"))
+(lsp-dependency 'typescript
+                '(:system "tsserver")
+                '  (:npm :package "typescript"
+                         :path "tsserver"))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
@@ -542,7 +542,7 @@ finding the executable with `exec-path'."
 
 (defcustom lsp-kotlin-linting-debounce-time 250
   "[DEBUG] Specifies the debounce time limit. Lower to increase
-responsiveness at the cost of possibile stability issues."
+responsiveness at the cost of possible stability issues."
   :type 'number
   :group 'lsp-kotlin
   :package-version '(lsp-mode . "6.1"))

--- a/lsp-json.el
+++ b/lsp-json.el
@@ -102,10 +102,10 @@
                                                'utf-8-unix)))
                   (list callback))))
 
-(lsp-dependency vscode-json-languageserver
-  (:system "vscode-json-languageserver")
-  (:npm :package "vscode-json-languageserver"
-        :path "vscode-json-languageserver"))
+(lsp-dependency 'vscode-json-languageserver
+                '(:system "vscode-json-languageserver")
+                '(:npm :package "vscode-json-languageserver"
+                       :path "vscode-json-languageserver"))
 
 (lsp-register-client
  (make-lsp-client

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5943,27 +5943,6 @@ SESSION is the active session."
   :type 'directory
   :package-version '(lsp-mode . "6.3"))
 
-(defcustom lsp-server-locations nil
-  "List of server PACKAGE / LOCATION pairs of pre-installed
-server package names and their corresponding executable path
-locations.  The calls to `lsp-dependency' define the PACKAGE name
-key you can use and the corresponding string value should
-location of the executable. For example, if you install the 
-Typescript/JavaScript language servers in a team shared read-only
-Unix location, you can instruct lsp-mode to use the by adding
-the adding two pairs:
-
- key                         string
- ---                         ---------
- typescript-language-server  /net/lsp/typescript-language-server/bin/typescript-language-server
- typescript                  /net/lsp/typescript//lib/node_modules/typescript/lib/tsserver.js
-
-Note, the typescript compiler is invoked by the typescript-language-server and thus we pass
-the path to the tsserver.js file to ensure it works when spawned on Windows."
-  :risky t
-  :type '(alist :value-type (group string))
-  :package-version '(lsp-mode . "6.3"))
-
 (defvar lsp--dependencies (ht))
 
 (defmacro lsp-dependency (name &rest definitions)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6077,7 +6077,7 @@ nil."
   (if (and (f-absolute? path)
            (f-exists? path))
       path
-    (executable-find path))
+    (executable-find path)))
 
 (defun lsp-package-path (dependency)
   "Path to the DEPENDENCY each of the registered providers."


### PR DESCRIPTION
1. Add defcustom lsp-server-locations which lets one specify server locations.
   With this, an organization can install language servers on a central filer
   e.g. npm install -g --prefix /central/location/lsp/SERVER SERVER,
   then Emacs can access them via NFS or Samba which makes Emacs work
   cleanly for all with the desired version language servers.

2. Add a cache for lsp--npm-dependency-path to support lsp-server-locations
   and avoid unnecessary stats after the location to a server has been found.

3. Use special-mode for stderr-buf which makes it readonly, lets one type
   'q' to bury the buffer, etc.

4. Fix a couple typos. Note, one of the typo fixes is in code. The two
   functions
     lsp--cleanup-highlights-if-needed
     lsp--document-highlight
   had typo ":highlihts" which should be ":highlights"
   I suspect this fixes a bug, but wasn't sure what these functions are for.