### PR TITLE
Respect XDG_CACHE_HOME for lsp-server-install-dir

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5969,8 +5969,11 @@ SESSION is the active session."
 
 ;; download server
 
-(defcustom lsp-server-install-dir (expand-file-name
-                                   (locate-user-emacs-file (f-join ".cache" "lsp")))
+(defcustom lsp-server-install-dir (expand-file-name "lsp"
+                                     ;; Using xdg-cache-home for variable name occured package-lint error
+                                     (or (if-let (xdg-cache-home-dir (getenv "XDG_CACHE_HOME"))
+                                             (concat xdg-cache-home-dir "/emacs"))
+                                         (locate-user-emacs-file ".cache")))
   "Directory in which the servers will be installed."
   :risky t
   :type 'directory

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5971,7 +5971,7 @@ SESSION is the active session."
 
 (defcustom lsp-server-install-dir (expand-file-name "lsp"
                                      ;; Using xdg-cache-home for variable name occured package-lint error
-                                     (or (if-let (xdg-cache-home-dir (getenv "XDG_CACHE_HOME"))
+                                     (or (when-let (xdg-cache-home-dir (getenv "XDG_CACHE_HOME"))
                                              (concat xdg-cache-home-dir "/emacs"))
                                          (locate-user-emacs-file ".cache")))
   "Directory in which the servers will be installed."


### PR DESCRIPTION
Hi, The lsp-mode is a very cool package for me.

Emacs will support the XDG convention for init files from 27. So, I migrated configuration file management to the XDG convention.
I want the XDG convention to support lsp-mode.