### PR TITLE
Fix type argument error when using xref-find-references

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4882,8 +4882,10 @@ perform the request synchronously."
 
 (defun lsp--xref-elements-index (symbols path)
   (-mapcat
-   (-lambda ((&hash "name" "children" "selectionRange" (&hash? "start") "location"))
-     (cons (cons (concat path name) (lsp--position-to-point (or start location)))
+   (-lambda ((&hash "name" "children" "selectionRange" (&hash? "start")
+                    "location" (&hash? "range")))
+     (cons (cons (concat path name)
+                 (lsp--position-to-point (or start (gethash "start" range))))
            (lsp--xref-elements-index children (concat path name " / "))))
    symbols))
 


### PR DESCRIPTION
Hi and thank you for this awesome mode.

I recently had the problem that I was getting `Wrong type argument: number-or-marker-p` when using `xref-find-references` in combination with the Rust Language Server (RLS).

The problem was that the range in the LSP message wasn't parsed correctly. This PR fixes this problem.