### PR TITLE
lsp--uri-to-path: use utf-8 when locale-coding-system unset

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1212,7 +1212,8 @@ On other systems, returns path without change."
   "Convert URI to a file path."
   (let* ((url (url-generic-parse-url (url-unhex-string uri)))
          (type (url-type url))
-         (file (decode-coding-string (url-filename url) locale-coding-system))
+         (encoding (or locale-coding-system 'utf-8))
+         (file (decode-coding-string (url-filename url) encoding))
          (file-name (if (and type (not (string= type "file")))
                         (if-let ((handler (lsp--get-uri-handler type)))
                             (funcall handler uri)


### PR DESCRIPTION
Try to fix https://github.com/emacs-lsp/lsp-mode/issues/1280