### PR TITLE
Metals refresh lens only if lsp-lens-mode is enabled

### DIFF
--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -217,7 +217,8 @@ Should be ignored if there is no open doctor window."
        (lsp--workspace-buffers)
        (mapc (lambda (buffer)
                (with-current-buffer buffer
-                 (lsp--lens-schedule-refresh t))))))
+                 (when (bound-and-true-p lsp-lens-mode)
+                   (lsp--lens-schedule-refresh t)))))))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection 'lsp-metals--server-command)


### PR DESCRIPTION
The code lens should not be rendered when `lsp-lens-mode` is disabled.