### PR TITLE
add lsp-rust-select-and-apply-source-change-command for auto imports

### DIFF
--- a/lsp-rust.el
+++ b/lsp-rust.el
@@ -408,10 +408,12 @@ PARAMS progress report notification data."
 
 (defconst lsp-rust-action-handlers
   '(("rust-analyzer.applySourceChange" .
-     (lambda (p) (lsp-rust-apply-source-change-command p)))))
+     (lambda (p) (lsp-rust-apply-source-change-command p)))
+    ("rust-analyzer.selectAndApplySourceChange" .
+     (lambda (p) (lsp-rust-select-and-apply-source-change-command p)))))
 
 (defun lsp-rust-apply-source-change-command (p)
-  (let ((data (lsp-seq-first (ht-get p "arguments"))))
+  (let ((data (-> p (ht-get "arguments") (lsp-seq-first))))
     (lsp-rust-apply-source-change data)))
 
 (defun lsp-rust-uri-filename (text-document)
@@ -425,6 +427,12 @@ PARAMS progress report notification data."
           (position (ht-get cursor-position "position")))
       (find-file filename)
       (goto-char (lsp--position-to-point position)))))
+
+(defun lsp-rust-select-and-apply-source-change-command (p)
+  (let* ((options (-> p (ht-get "arguments") (lsp-seq-first)))
+         (chosen-option (lsp--completing-read "Select option:" options
+                                              (-lambda ((&hash "label")) label))))
+    (lsp-rust-apply-source-change chosen-option)))
 
 (define-derived-mode lsp-rust-analyzer-syntax-tree-mode special-mode "Rust-Analyzer-Syntax-Tree"
   "Mode for the rust-analyzer syntax tree buffer.")


### PR DESCRIPTION
I get this error when I apply the changes from @flodiebold. I will take another look at it when I'm home, but maybe it's obvious and I just don't see the problem.

```
Debugger entered--Lisp error: (wrong-type-argument hash-table-p nil)
  gethash("workspaceEdit" nil nil)
  lsp-rust-apply-source-change(nil)
  lsp-rust-apply-source-change-command(#<hash-table equal 3/3 0x1560bd2d16bd>)
  lsp-rust-select-and-apply-source-change-command(#<hash-table equal 3/3 0x1560bd12f441>)
  (lambda (p) (lsp-rust-select-and-apply-source-change-command p))(#<hash-table equal 3/3 0x1560bd12f441>)
  lsp--execute-command(#<hash-table equal 3/3 0x1560bd12f441>)
  lsp-execute-code-action(#<hash-table equal 2/2 0x1560bd12f47d>)
  funcall-interactively(lsp-execute-code-action #<hash-table equal 2/2 0x1560bd12f47d>)
  call-interactively(lsp-execute-code-action record nil)
  command-execute(lsp-execute-code-action record)
  helm-M-x-execute-command(lsp-execute-code-action)
```
