### PR TITLE
Add missing paren to which-key config

### DIFF
--- a/README.org
+++ b/README.org
@@ -131,7 +131,7 @@
        ;; optional if you want which-key integration
        (use-package which-key
          :config
-         (which-key-mode)
+         (which-key-mode))
 
      #+END_SRC
 


### PR DESCRIPTION
The documentation is one paren short in the declaration of use-package for which-key. Users who copy this config will have a parse error in their configuration.