### PR TITLE
Rename lsp-clients-rust-progress-string to lsp-rust-progress-string.

### DIFF
--- a/lsp-rust.el
+++ b/lsp-rust.el
@@ -282,20 +282,15 @@ is often the type local variable declaration."
    ("rust.target" lsp-rust-target)
    ("rust.sysroot" lsp-rust-sysroot)))
 
-(defvar lsp-clients-rust-progress-string ""
-  "Rust progress status as reported by the RLS server.")
-
-(put 'lsp-rust-progress-string 'risky-local-variable t)
-(add-to-list 'global-mode-string (list '(t lsp-clients-rust-progress-string)))
-
-(defun lsp-clients--rust-window-progress (_workspace params)
+(defun lsp-rust--window-progress (workspace params)
   "Progress report handling.
 PARAMS progress report notification data."
   (-let (((&hash "done" "message" "title") params))
     (if (or done (s-blank-str? message))
-        (setq lsp-clients-rust-progress-string nil)
-      (setq lsp-clients-rust-progress-string (format "%s - %s" title (or message "")))
-      (lsp-log lsp-clients-rust-progress-string))))
+      (lsp-workspace-status nil workspace)
+      (let ((status-string (format "%s - %s" title (or message ""))))
+        (lsp-workspace-status status-string workspace)
+        (lsp-log status-string)))))
 
 (cl-defmethod lsp-execute-command
   (_server (_command (eql rls.run)) params)


### PR DESCRIPTION
The variable is called `lsp-clients-rust-progress-string` but then `lsp-rust-progress-string` is made risky:
https://github.com/emacs-lsp/lsp-mode/blob/efca9d5c70d8340ebf0640a6d3af7451d13109f5/lsp-rust.el#L288

So I decided to remove `clients` part as it seems it's a leftover of moving things out of `lsp-clients.el`.