### PR TITLE
Ignore .ccls-cache for file watching

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -317,6 +317,7 @@ the server has requested that."
                                     "[/\\\\]\\.bloop$"
                                     "[/\\\\]\\.metals$"
                                     "[/\\\\]target$"
+                                    "[/\\\\]\\.ccls-cache$"
                                     ;; Autotools output
                                     "[/\\\\]\\.deps$"
                                     "[/\\\\]build-aux$"


### PR DESCRIPTION
.ccls-cache is an internal directory created by the ccls lang server.