### PR TITLE
sending nil pid

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6141,7 +6141,7 @@ SESSION is the active session."
       (lsp-request-async
        "initialize"
        (append
-        (list :processId (emacs-pid)
+        (list :processId nil
               :rootPath (lsp-file-local-name (expand-file-name root))
               :clientInfo (list :name "emacs"
                                 :version (emacs-version))


### PR DESCRIPTION
Language servers who receive a PID check the PID.  If it's no longer running then the language server exits.

Sending the PID works when all language servers are run directly on the host.  However, when using `lsp-docker` sending emacs PID causes certain servers to exit since the emacs PID doesn't exist on the container.

The spec allows for this to be null.