### PR TITLE
Change typescript activation function

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -166,17 +166,17 @@ See instructions at https://marketplace.visualstudio.com/items?itemName=mads-har
   :risky t
   :type '(repeat string))
 
-(defun lsp-typescript-javascript-tsx-jsx-activate-p (filename &optional _)
+(defun lsp-typescript-javascript-jsx-activate-p (filename &optional _)
   "Check if the javascript-typescript language server should be enabled based on FILENAME."
-  (or (string-match-p (rx (one-or-more anything) "." (or "ts" "js") (opt "x") string-end) filename)
-      (and (derived-mode-p 'js-mode 'js2-mode 'typescript-mode)
+  (or (string-match-p ".*\.jsx?$" filename)
+      (and (derived-mode-p 'js-mode 'js2-mode)
            (not (derived-mode-p 'json-mode)))))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
                                                           (cons (lsp-package-path 'javascript-typescript-langserver)
                                                                 lsp-clients-typescript-javascript-server-args)))
-                  :activation-fn 'lsp-typescript-javascript-tsx-jsx-activate-p
+                  :activation-fn 'lsp-typescript-javascript-jsx-activate-p
                   :priority -3
                   :completion-in-comments? t
                   :server-id 'jsts-ls
@@ -231,13 +231,19 @@ directory containing the package. Example:
                 '  (:npm :package "typescript"
                          :path "tsserver"))
 
+(defun lsp-typescript-javascript-tsx-activate-p (filename &optional _)
+  "Check if the javascript-typescript language server should be enabled based on FILENAME."
+  (or (string-match-p ".*\.tsx?$" filename)
+      (and (derived-mode-p 'typescript-mode)
+           (not (derived-mode-p 'json-mode)))))
+
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
                                                           `(,(lsp-package-path 'typescript-language-server)
                                                             "--tsserver-path"
                                                             ,(lsp-package-path 'typescript)
                                                             ,@lsp-clients-typescript-server-args)))
-                  :activation-fn 'lsp-typescript-javascript-tsx-jsx-activate-p
+                  :activation-fn 'lsp-typescript-javascript-tsx-activate-p
                   :priority -2
                   :completion-in-comments? t
                   :initialization-options (lambda ()

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -168,7 +168,7 @@ See instructions at https://marketplace.visualstudio.com/items?itemName=mads-har
 
 (defun lsp-typescript-javascript-jsx-activate-p (filename &optional _)
   "Check if the javascript-typescript language server should be enabled based on FILENAME."
-  (or (string-match-p ".*\.jsx?$" filename)
+  (or (string-match-p (rx (one-or-more anything) ".js" (opt "x") string-end) filename)
       (and (derived-mode-p 'js-mode 'js2-mode)
            (not (derived-mode-p 'json-mode)))))
 
@@ -233,7 +233,7 @@ directory containing the package. Example:
 
 (defun lsp-typescript-javascript-tsx-activate-p (filename &optional _)
   "Check if the javascript-typescript language server should be enabled based on FILENAME."
-  (or (string-match-p ".*\.tsx?$" filename)
+  (or (string-match-p (rx (one-or-more anything) ".ts" (opt "x") string-end) filename)
       (and (derived-mode-p 'typescript-mode)
            (not (derived-mode-p 'json-mode)))))
 

--- a/test/lsp-clients-test.el
+++ b/test/lsp-clients-test.el
@@ -76,13 +76,15 @@
     (should (not (lsp-clients-flow-activate-p (concat test-location "fixtures/SampleTypeScriptProject/src/sample.ts") nil)))))
 
 (ert-deftest lsp-typescript-javascript-activates-based-on-file-extension ()
-  (should (lsp-typescript-javascript-tsx-jsx-activate-p "abc.js"))
-  (should (lsp-typescript-javascript-tsx-jsx-activate-p "abc.jsx"))
-  (should (lsp-typescript-javascript-tsx-jsx-activate-p "abc.ts"))
-  (should (lsp-typescript-javascript-tsx-jsx-activate-p "abc.tsx"))
-  (should (lsp-typescript-javascript-tsx-jsx-activate-p "a1.ts"))
-  (should (lsp-typescript-javascript-tsx-jsx-activate-p "a1.d.ts"))
-  (should (not (lsp-typescript-javascript-tsx-jsx-activate-p "abc.tsxx")))
-  (should (not (lsp-typescript-javascript-tsx-jsx-activate-p "abc.jss"))))
+  (should (lsp-typescript-javascript-jsx-activate-p "abc.js"))
+  (should (lsp-typescript-javascript-jsx-activate-p "abc.jsx"))
+  (should (lsp-typescript-javascript-tsx-activate-p "abc.ts"))
+  (should (lsp-typescript-javascript-tsx-activate-p "abc.tsx"))
+  (should (lsp-typescript-javascript-tsx-activate-p "a1.ts"))
+  (should (lsp-typescript-javascript-tsx-activate-p "a1.d.ts"))
+  (should (not (and (lsp-typescript-javascript-jsx-activate-p "abc.tsxx")
+		    (lsp-typescript-javascript-tsx-activate-p "abc.tsxx"))))
+  (should (not (and (lsp-typescript-javascript-jsx-activate-p "abc.jss")
+		    (lsp-typescript-javascript-tsx-activate-p "abc.jss")))))
 
 ;;; lsp-clients-test.el ends here


### PR DESCRIPTION
Because javascript and typescript used the same activation function it would only activate the javascript language server. 

This differentiates typescript and javascript activation functions.