### PR TITLE
Added lsp-after-client-package-hook

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -296,6 +296,11 @@ When nil, all registered clients are considered candidates.")
   :type 'hook
   :group 'lsp-mode)
 
+(defcustom lsp-after-client-packages-hook nil
+  "List of functions to be called after client packages are opened."
+  :type 'hook
+  :group 'lsp-mode)
+
 (defcustom lsp-enable-file-watchers t
   "If non-nil lsp-mode will watch the files in the workspace if
 the server has requested that."
@@ -6982,6 +6987,7 @@ argument ask the user to select which language server to start. "
   (when (and lsp-auto-configure)
     (seq-do (lambda (package) (require package nil t))
             lsp-client-packages))
+  (run-hooks 'lsp-after-client-packages-hook)
 
   (when (buffer-file-name)
     (let (clients

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6985,9 +6985,11 @@ argument ask the user to select which language server to start. "
   (interactive "P")
 
   (when (and lsp-auto-configure)
-    (seq-do (lambda (package) (require package nil t))
-            lsp-client-packages))
-  (run-hooks 'lsp-after-client-packages-hook)
+    (seq-do (lambda (package)
+	      (require package nil t))
+            lsp-client-packages)
+    (run-hooks 'lsp-after-client-packages-hook))
+  
 
   (when (buffer-file-name)
     (let (clients


### PR DESCRIPTION
`lsp-docker` hooked `lsp-clients`.  `lsp-docker` needs a hook after the clients are loaded.  This PR adds a new hook that `lsp-docker` can use.