### PR TITLE
Remove go-langserver and bingo support, as they're deprecated.

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -146,14 +146,6 @@
     "debugger": "Yes"
   },
   {
-    "name": "bingo",
-    "full-name": "Go",
-    "server-name": "bingo",
-    "server-url": "https://github.com/saibing/bingo",
-    "installation-url": "https://github.com/saibing/bingo/wiki/Install",
-    "debugger": "Yes"
-  },
-  {
     "name": "gdscript",
     "full-name": "GDScript",
     "server-name": "godot",

--- a/lsp-go.el
+++ b/lsp-go.el
@@ -153,25 +153,10 @@ The returned type provides a tri-state that either:
   "Select what codelens should be enabled or not.
 
 The codelens can be found at https://github.com/golang/tools/blob/4d5ea46c79fe3bbb57dd00de9c167e93d94f4710/internal/lsp/source/options.go#L102-L108."
-  :type (lsp-go--defcustom-available-as-alist-type lsp-gopls-available-codelens)
+  :type (lsp-go--defcustom-available-as-alist-type lsp-go-available-codelens)
   :group 'lsp-gopls
   :risky t
   :package-version '(lsp-mode "7.0"))
-
-(lsp-register-custom-settings
- '(("gopls.usePlaceholders" lsp-gopls-use-placeholders t)
-   ("gopls.hoverKind" lsp-gopls-hover-kind)
-   ("gopls.buildFlags" lsp-gopls-build-flags)
-   ("gopls.env" lsp-gopls-env)
-   ("gopls.codelens" lsp-gopls-codelens)))
-
-(lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection
-                                   (lambda () (cons lsp-gopls-server-path lsp-gopls-server-args)))
-                  :major-modes '(go-mode go-dot-mod-mode)
-                  :priority 0
-                  :server-id 'gopls
-                  :library-folders-fn 'lsp-go--library-default-directories))
 
 (define-obsolete-variable-alias
   'lsp-clients-go-library-directories

--- a/lsp-go.el
+++ b/lsp-go.el
@@ -171,17 +171,7 @@ The codelens can be found at https://github.com/golang/tools/blob/4d5ea46c79fe3b
                   :major-modes '(go-mode go-dot-mod-mode)
                   :priority 0
                   :server-id 'gopls
-                  :library-folders-fn 'lsp-clients-go--library-default-directories))
-
-(defgroup lsp-clients-go nil
-  "LSP support for the Go Programming Language."
-  :group 'lsp-mode)
-
-(defcustom lsp-clients-go-server "bingo"
-  "The go language server executable to use."
-  :group 'lsp-clients-go
-  :risky t
-  :type 'file)
+                  :library-folders-fn 'lsp-go--library-default-directories))
 
 (define-obsolete-variable-alias
   'lsp-clients-go-library-directories

--- a/lsp-go.el
+++ b/lsp-go.el
@@ -111,7 +111,7 @@ completing function calls."
 
 (define-obsolete-variable-alias
   'lsp-gopls-available-codelens
-  'lsp-go-available-codelesn
+  'lsp-go-available-codelens
   "lsp-mode 7.0.1")
 
 (defvar lsp-go-available-codelens

--- a/lsp-go.el
+++ b/lsp-go.el
@@ -246,8 +246,9 @@ $GOPATH/pkg/mod along with the value of
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection
-                                   (lambda () (cons lsp-gopls-server-path lsp-gopls-server-args)))
+                                   (lambda () (cons lsp-go-gopls-server-path lsp-go-gopls-server-args)))
                   :major-modes '(go-mode)
+                  :language-id "go"
                   :priority 0
                   :server-id 'gopls
                   :library-folders-fn #'lsp-go--library-default-directories))

--- a/lsp-go.el
+++ b/lsp-go.el
@@ -26,36 +26,62 @@
 
 (require 'lsp-mode)
 
-(defgroup lsp-gopls nil
+(defgroup lsp-go nil
   "LSP support for the Go Programming Language, using the gopls language server."
-  :link '(url-link "https://github.com/golang/go/wiki/gopls")
-  :group 'lsp-mode)
+  :link '(url-link "https://github.com/golang/tools/blob/master/gopls/README.md")
+  :group 'lsp-mode
+  :package-version '(lsp-mode . "6.3.2"))
 
-(defcustom lsp-gopls-use-placeholders t
+(define-obsolete-variable-alias
+  'lsp-gopls-server-path
+  'lsp-go-gopls-server-path
+  "lsp-mode 7.0.1")
+
+(defcustom lsp-go-gopls-server-path "gopls"
+  "Path to gopls server binary."
+  :type 'string
+  :group 'lsp-go)
+
+(define-obsolete-variable-alias
+  'lsp-gopls-server-args
+  'lsp-go-gopls-server-args
+  "lsp-mode 7.0.1")
+
+(defcustom lsp-go-gopls-server-args nil
+  "Extra CLI arguments for gopls."
+  :type '(repeat string)
+  :group 'lsp-go)
+
+(define-obsolete-variable-alias
+  'lsp-gopls-use-placeholders
+  'lsp-go-use-placeholders
+  "lsp-mode 7.0.1")
+
+(defcustom lsp-go-use-placeholders t
   "Cause gopls to provide placeholder parameter snippets when
 completing function calls."
   :type 'boolean
-  :group 'lsp-gopls)
+  :group 'lsp-go)
 
-(defcustom lsp-gopls-server-path "gopls"
-  "Path to gopls server binary."
-  :type 'string
-  :group 'lsp-gopls)
+(define-obsolete-variable-alias
+  'lsp-gopls-build-flags
+  'lsp-go-build-flags
+  "lsp-mode 7.0.1")
 
-(defcustom lsp-gopls-server-args nil
-  "Extra CLI arguments for gopls."
-  :type '(repeat string)
-  :group 'lsp-gopls)
-
-(defcustom lsp-gopls-build-flags []
+(defcustom lsp-go-build-flags []
   "A vector of flags passed on to the build system when invoked,
   applied to queries like `go list'."
   :type 'lsp-string-vector
-  :group 'lsp-gopls
+  :group 'lsp-go
   :risky t
   :package-version '(lsp-mode "6.2"))
 
-(defcustom lsp-gopls-env '()
+(define-obsolete-variable-alias
+  'lsp-gopls-env
+  'lsp-go-env
+  "lsp-mode 7.0.1")
+
+(defcustom lsp-go-env (make-hash-table)
   "`gopls' has the unusual ability to set environment variables,
   intended to affect the behavior of commands invoked by `gopls'
   on the user's behalf. This variable takes a hash table of env
@@ -65,7 +91,12 @@ completing function calls."
   :risky t
   :package-version '(lsp-mode "6.2"))
 
-(defcustom lsp-gopls-hover-kind "SynopsisDocumentation"
+(define-obsolete-variable-alias
+  'lsp-gopls-hover-kind
+  'lsp-go-hover-kind
+  "lsp-mode 7.0.1")
+
+(defcustom lsp-go-hover-kind "SynopsisDocumentation"
   "`gopls' allows the end user to select the desired amount of
   documentation returned during e.g. hover and thing-at-point
   operations."
@@ -74,11 +105,16 @@ completing function calls."
                  (const "FullDocumentation")
                  (const "SingleLine")
                  (const "Structured"))
-  :group 'lsp-gopls
+  :group 'lsp-go
   :risky t
   :package-version '(lsp-mode "6.2"))
 
-(defvar lsp-gopls-available-codelens
+(define-obsolete-variable-alias
+  'lsp-gopls-available-codelens
+  'lsp-go-available-codelesn
+  "lsp-mode 7.0.1")
+
+(defvar lsp-go-available-codelens
   '((generate . "Run `go generate` for a directory")
 	  (test . "Run `go test` for a specific test function")
 	  (tidy . "Run `go mod tidy` for a module")
@@ -87,7 +123,8 @@ completing function calls."
   "Available codelens that can be further enabled or disabled
   through `lsp-gopls-codelens'.")
 
-(defun lsp-gopls--defcustom-available-as-alist-type (alist)
+
+(defun lsp-go--defcustom-available-as-alist-type (alist)
   "Returns a list suitable for the `:type' field in a `defcustom' used to populate an alist.
 
 The input ALIST has the form `((\"name\" . \"documentation sentence\") [...])'
@@ -107,11 +144,16 @@ The returned type provides a tri-state that either:
 	(push 'set list)
 	list))
 
-(defcustom lsp-gopls-codelens '((generate . t) (test . t))
+(define-obsolete-variable-alias
+  'lsp-gopls-codelens
+  'lsp-go-codelens
+  "lsp-mode 7.0.1")
+
+(defcustom lsp-go-codelens '((generate . t) (test . t))
   "Select what codelens should be enabled or not.
 
 The codelens can be found at https://github.com/golang/tools/blob/4d5ea46c79fe3bbb57dd00de9c167e93d94f4710/internal/lsp/source/options.go#L102-L108."
-  :type (lsp-gopls--defcustom-available-as-alist-type lsp-gopls-available-codelens)
+  :type (lsp-go--defcustom-available-as-alist-type lsp-gopls-available-codelens)
   :group 'lsp-gopls
   :risky t
   :package-version '(lsp-mode "7.0"))
@@ -141,71 +183,36 @@ The codelens can be found at https://github.com/golang/tools/blob/4d5ea46c79fe3b
   :risky t
   :type 'file)
 
-(defcustom lsp-clients-go-server-args nil
-  "Extra arguments for the go language server."
-  :type '(repeat string)
-  :group 'lsp-clients-go)
+(define-obsolete-variable-alias
+  'lsp-clients-go-library-directories
+  'lsp-go-library-directories
+  "lsp-mode 7.0.1")
 
-(defcustom lsp-clients-go-func-snippet-enabled t
-  "Enable the returning of argument snippets on `func' completions, eg.
-`func(foo string, arg2 bar)'.  Requires code completion to be enabled."
-  :type 'boolean
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-gocode-completion-enabled t
-  "Enable code completion feature (using gocode)."
-  :type 'boolean
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-format-tool "goimports"
-  "The tool to be used for formatting documents.  Defaults to `goimports' if nil."
-  :type '(choice (const :tag "goimports" "goimports")
-                 (const :tag "gofmt" "gofmt"))
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-imports-local-prefix ""
-  "The local prefix (comma-separated string) that goimports will use."
-  :type 'string
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-max-parallelism nil
-  "The maximum number of goroutines that should be used to fulfill requests.
-This is useful in editor environments where users do not want results ASAP,
-but rather just semi quickly without eating all of their CPU.  When nil,
-defaults to half of your CPU cores."
-  :type '(choice integer (const nil "Half of CPU cores."))
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-use-binary-pkg-cache t
-  "Whether or not $GOPATH/pkg binary .a files should be used."
-  :type 'boolean
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-diagnostics-enabled t
-  "Whether diagnostics are enabled."
-  :type 'boolean
-  :group 'lsp-clients-go)
-
-(defcustom lsp-clients-go-library-directories '("/usr")
+(defcustom lsp-go-library-directories '("/usr")
   "List of directories which will be considered to be libraries."
-  :group 'lsp-clients-go
+  :group 'lsp-go
   :risky t
   :type '(repeat string))
 
-(defcustom lsp-clients-go-library-directories-include-go-modules t
+(define-obsolete-variable-alias
+  'lsp-clients-go-library-directories-include-go-modules
+  'lsp-go-library-directories-include-go-modules
+  "lsp-mode 7.0.1")
+
+(defcustom lsp-go-library-directories-include-go-modules t
   "Whether or not $GOPATH/pkg/mod should be included as a library directory."
   :type 'boolean
-  :group 'lsp-clients-go)
+  :group 'lsp-go)
 
-(defun lsp-clients-go--library-default-directories (_workspace)
+(defun lsp-go--library-default-directories (_workspace)
   "Calculate go library directories.
 
-If `lsp-clients-go-library-directories-include-go-modules' is non-nil
+If `lsp-go-library-directories-include-go-modules' is non-nil
 and the environment variable GOPATH is set this function will return
 $GOPATH/pkg/mod along with the value of
-`lsp-clients-go-library-directories'."
-  (let ((library-dirs lsp-clients-go-library-directories))
-    (when (and lsp-clients-go-library-directories-include-go-modules
+`lsp-go-library-directories'."
+  (let ((library-dirs lsp-go-library-directories))
+    (when (and lsp-go-library-directories-include-go-modules
                (or (and (not (file-remote-p default-directory)) (executable-find "go"))
                    (and (version<= "27.0" emacs-version) (with-no-warnings (executable-find "go" (file-remote-p default-directory))))))
       (with-temp-buffer
@@ -221,38 +228,29 @@ $GOPATH/pkg/mod along with the value of
         (mapcar (lambda (path) (concat (file-remote-p default-directory) path)) library-dirs)
       library-dirs)))
 
-(define-inline lsp-clients-go--bool-to-json (val)
-  (inline-quote (if ,val t :json-false)))
+(defcustom lsp-go-link-target "godoc.org"
+  "Which website to use for displaying Go documentation."
+  :type '(choice (const "godoc.org")
+		 (const "pkg.go.dev")
+		 (string :tag "A custom website"))
+  :group 'lsp-go
+  :package-version '(lsp-mode "7.0.1"))
 
-(defun lsp-clients-go--make-init-options ()
-  "Init options for golang."
-  `(:funcSnippetEnabled ,(lsp-clients-go--bool-to-json lsp-clients-go-func-snippet-enabled)
-                        :disableFuncSnippet ,(lsp-clients-go--bool-to-json (not lsp-clients-go-func-snippet-enabled))
-                        :gocodeCompletionEnabled ,(lsp-clients-go--bool-to-json lsp-clients-go-gocode-completion-enabled)
-                        :formatTool ,lsp-clients-go-format-tool
-                        :goimportsLocalPrefix ,lsp-clients-go-imports-local-prefix
-                        :maxParallelism ,lsp-clients-go-max-parallelism
-                        :useBinaryPkgCache ,lsp-clients-go-use-binary-pkg-cache
-                        :diagnosticsEnabled ,lsp-clients-go-diagnostics-enabled))
-
+(lsp-register-custom-settings
+ '(("gopls.usePlaceholders" lsp-go-use-placeholders t)
+   ("gopls.hoverKind" lsp-go-hover-kind)
+   ("gopls.buildFlags" lsp-gop-build-flags)
+   ("gopls.env" lsp-go-env)
+   ("gopls.linkTarget" lsp-go-link-target)
+   ("gopls.codelens" lsp-go-codelens)))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection
-                                   (lambda () (cons lsp-clients-go-server
-                                                    lsp-clients-go-server-args)))
+                                   (lambda () (cons lsp-gopls-server-path lsp-gopls-server-args)))
                   :major-modes '(go-mode)
-                  :priority -1
-                  :initialization-options 'lsp-clients-go--make-init-options
-                  :server-id 'go-bingo
-                  :library-folders-fn 'lsp-clients-go--library-default-directories))
-
-(lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection "go-langserver")
-                  :major-modes '(go-mode)
-                  :priority -2
-                  :initialization-options 'lsp-clients-go--make-init-options
-                  :server-id 'go-ls
-                  :library-folders-fn 'lsp-clients-go--library-default-directories))
+                  :priority 0
+                  :server-id 'gopls
+                  :library-folders-fn #'lsp-go--library-default-directories))
 
 (provide 'lsp-go)
 ;;; lsp-go.el ends here


### PR DESCRIPTION
This PR also changes gopls defcustoms to use the `lsp-go` prefix, and adds support for the `linkTarget` setting.