### PR TITLE
Do not call the server if additionalTextEdits are present

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4065,7 +4065,9 @@ PLIST is the additional data to attach to each candidate."
                          "textEdit" text-edit
                          "insertTextFormat" insert-text-format
                          "additionalTextEdits" additional-text-edits)
-                  (lsp--resolve-completion item)))
+                  (if (gethash "additionalTextEdits" item)
+                      item
+                    (lsp--resolve-completion item))))
            (cond
             (text-edit
              (delete-region (point-at-bol) (point))


### PR DESCRIPTION
- as per spec textEdit/insertTextFormat and insertText are mandatory so we have
to call resolve only if additionalTextEdits are not present.