### PR TITLE
Hide code lenses before revert-buffer

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2036,14 +2036,14 @@ CALLBACK - callback for the lenses."
     (add-hook 'lsp-on-idle-hook #'lsp--lens-idle-function nil t)
     (add-hook 'lsp-on-change-hook (lambda () (lsp--lens-schedule-refresh t)) nil t)
     (add-hook 'after-save-hook (lambda () (lsp--lens-schedule-refresh t)) nil t)
-    (add-hook 'before-revert-hook (lambda () (lsp-lens-hide)) nil t)
+    (add-hook 'before-revert-hook #'lsp-lens-hide nil t)
     (lsp-lens-refresh t))
    (t
     (lsp-lens-hide)
     (remove-hook 'lsp-on-idle-hook #'lsp--lens-idle-function t)
     (remove-hook 'lsp-on-change-hook (lambda () (lsp--lens-schedule-refresh nil)) t)
     (remove-hook 'after-save-hook (lambda () (lsp--lens-schedule-refresh t)) t)
-    (remove-hook 'before-revert-hook (lambda () (lsp-lens-hide)) nil t)
+    (remove-hook 'before-revert-hook #'lsp-lens-hide t)
     (setq lsp--lens-last-count nil)
     (setq lsp--lens-backend-cache nil))))
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2036,12 +2036,14 @@ CALLBACK - callback for the lenses."
     (add-hook 'lsp-on-idle-hook #'lsp--lens-idle-function nil t)
     (add-hook 'lsp-on-change-hook (lambda () (lsp--lens-schedule-refresh t)) nil t)
     (add-hook 'after-save-hook (lambda () (lsp--lens-schedule-refresh t)) nil t)
+    (add-hook 'before-revert-hook (lambda () (lsp-lens-hide)) nil t)
     (lsp-lens-refresh t))
    (t
     (lsp-lens-hide)
     (remove-hook 'lsp-on-idle-hook #'lsp--lens-idle-function t)
     (remove-hook 'lsp-on-change-hook (lambda () (lsp--lens-schedule-refresh nil)) t)
     (remove-hook 'after-save-hook (lambda () (lsp--lens-schedule-refresh t)) t)
+    (remove-hook 'before-revert-hook (lambda () (lsp-lens-hide)) nil t)
     (setq lsp--lens-last-count nil)
     (setq lsp--lens-backend-cache nil))))
 


### PR DESCRIPTION
Firstly, thank you for adding code lens support :slightly_smiling_face: 

I've found that the code lens overlays aren't removed when `revert-buffer` is called.  This results in the following odd behaviour : https://drive.google.com/file/d/1-kl5Cbi6ie2WBg7GoW0gCy2RkVwScMM7/view

When a buffer is reverted with `revert-buffer`, the `lsp--lens-overlays` variable is reset to it's default value of `nil`.  However, the code lens overlays it previously referred to still exist.  This PR calls `lsp-lens-hide` before a buffer is reverted, deleting any code lens overlays.

I'm not well versed in overlays, so am not sure if this is the best possible solution.  Please let me know if you think of a better approach.  I'm also not too sure where or how to add tests to this project - please feel free to point me to a place to do so.