### PR TITLE
lsp-json: Enable formatter provider

### DIFF
--- a/README.org
+++ b/README.org
@@ -507,8 +507,6 @@
    - I am getting "Package ‘spinner-1.7.3’ is unavailable" when trying to install =lsp-mode=.
      - This is caused by GPG keys used by the ELPA package manager not being up
        to date. You may fix by installing: [[https://elpa.gnu.org/packages/gnu-elpa-keyring-update.html][gnu-elpa-keyring-update]]
-   - Json completion doesn't seem working?
-     - The latest [[https://www.npmjs.com/package/vscode-json-languageserver/v/1.2.2][vscode-json-languageserver]] is broken. You will need to install the earlier version of it ~npm i vscode-json-languageserver@1.2.1~
    - The flycheck does not work in =typescript=, =html= and =javascript= blocks in =vue-mode=. How to fix that?
      - This is caused by the fact that =vue-mode= uses multiple major modes in
        single file and the =lsp-ui= checker may not associated with the major mode

--- a/lsp-json.el
+++ b/lsp-json.el
@@ -41,12 +41,6 @@
   :group 'lsp-json
   :package-version '(lsp-mode . "6.3"))
 
-(defcustom lsp-json-format-enable t
-  "Enable/disable default JSON formatter"
-  :type 'boolean
-  :group 'lsp-json
-  :package-version '(lsp-mode . "6.3"))
-
 (defcustom lsp-http-proxy nil
   "The URL of the proxy server to use when fetching schema."
   :type 'string
@@ -60,13 +54,13 @@
   :package-version '(lsp-mode . "6.3"))
 
 (lsp-register-custom-settings
- '(("json.format.enable" lsp-json-format-enable t)
-   ("json.schemas" lsp-json-schemas)
+ '(("json.schemas" lsp-json-schemas)
    ("http.proxy" lsp-http-proxy)
    ("http.proxyStrictSSL" lsp-http-proxyStrictSSL)))
 
 (defvar lsp-json--extra-init-params
-  `(:handledSchemaProtocols ["file" "http" "https"]))
+  `(:provideFormatter t
+    :handledSchemaProtocols ["file" "http" "https"]))
 
 (defvar lsp-json--major-modes '(json-mode jsonc-mode))
 
@@ -121,7 +115,9 @@
   :async-request-handlers (ht ("vscode/content" #'lsp-json--get-content))
   :initialized-fn (lambda (w)
                     (with-lsp-workspace w
-                      (lsp--set-configuration (lsp-configuration-section "json"))
+                      (lsp--set-configuration
+                       (ht-merge (lsp-configuration-section "json")
+                                 (lsp-configuration-section "http")))
                       (lsp-notify "json/schemaAssociations" lsp-json--schema-associations)))
   :download-server-fn (lambda (_client callback error-callback _update?)
                         (lsp-package-ensure 'vscode-json-languageserver callback error-callback))))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -113,6 +113,8 @@
    "Operator"
    "TypeParameter"])
 
+(defconst lsp--empty-ht (make-hash-table))
+
 (define-obsolete-variable-alias 'lsp-print-io 'lsp-log-io "lsp-mode 6.1")
 
 (defcustom lsp-log-io nil
@@ -503,7 +505,7 @@ The hook will receive two parameters list of added and removed folders."
 (defcustom lsp-imenu-sort-methods '(kind name)
   "How to sort the imenu items.
 
-The value is a list of `kind' `name' or `position'. Priorities
+The value is a list of `kind' `name' or `position'.  Priorities
 are determined by the index of the element."
   :type '(repeat (choice (const name)
                          (const position)
@@ -529,7 +531,7 @@ are determined by the index of the element."
 METHOD is one of the symbols accepted by
 `lsp-imenu-sort-methods'.
 
-FUNCTION takes two hash tables representing DocumentSymbol. It
+FUNCTION takes two hash tables representing DocumentSymbol.  It
 returns a negative number, 0, or a positive number indicating
 whether the first parameter is less than, equal to, or greater
 than the second parameter.")
@@ -2816,8 +2818,8 @@ To find out what capabilities support your server use `M-x lsp-describe-session'
   (with-demoted-errors "LSP error: %S"
     (let ((lsp-response-timeout 0.5))
       (condition-case _err
-          (lsp-request "shutdown" (make-hash-table))
-        (error (lsp--error "Timeout while sending shutdown request."))))
+          (lsp-request "shutdown" lsp--empty-ht)
+        (error (lsp--error "Timeout while sending shutdown request"))))
     (lsp-notify "exit" nil))
   (setf (lsp--workspace-shutdown-action lsp--cur-workspace) (or (and restart 'restart) 'shutdown))
   (lsp--uninitialize-workspace))
@@ -3491,7 +3493,7 @@ The method uses `replace-buffer-contents'."
   "Get the value of capability CAP.  If CAPABILITIES is non-nil, use them instead."
   (gethash cap (or capabilities
                    (lsp--server-capabilities)
-                   (make-hash-table))))
+                   lsp--empty-ht)))
 
 (defun lsp--registered-capability (method)
   "Check whether there is workspace providing METHOD."
@@ -6184,7 +6186,7 @@ SESSION is the active session."
                (lsp--workspace-status workspace) 'initialized)
 
          (with-lsp-workspace workspace
-           (lsp-notify "initialized" (make-hash-table)))
+           (lsp-notify "initialized" lsp--empty-ht))
 
          (when-let (initialize-fn (lsp--client-initialized-fn client))
            (funcall initialize-fn workspace))


### PR DESCRIPTION
Enable `lsp-json` formatter provider via initialization options instead of dynamic registration.
Also remove FAQ about json language server not working since the latest version is working alright.