### PR TITLE
lsp--line-character-to-point: `character`  'nil?

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1144,7 +1144,7 @@ INHERIT-INPUT-METHOD will be proxied to `completing-read' without changes."
       ;; server may send character position beyond the current line and we
       ;; should fallback to line end.
       (let ((line-end (line-end-position)))
-        (if (and (not (equal nil character)) (> character (- line-end (point))))
+        (if (and character (> character (- line-end (point))))
             line-end
           (forward-char character)
           (point))))))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1144,7 +1144,7 @@ INHERIT-INPUT-METHOD will be proxied to `completing-read' without changes."
       ;; server may send character position beyond the current line and we
       ;; should fallback to line end.
       (let ((line-end (line-end-position)))
-        (if (and character (> character (- line-end (point))))
+        (if (or (not character) (> character (- line-end (point))))
             line-end
           (forward-char character)
           (point))))))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1144,7 +1144,7 @@ INHERIT-INPUT-METHOD will be proxied to `completing-read' without changes."
       ;; server may send character position beyond the current line and we
       ;; should fallback to line end.
       (let ((line-end (line-end-position)))
-        (if (> character (- line-end (point)))
+        (if (and (not (equal nil character)) (> character (- line-end (point))))
             line-end
           (forward-char character)
           (point))))))


### PR DESCRIPTION
Fixes https://github.com/emacs-lsp/lsp-origami/issues/5, but I don't know what this might implicate in other places.
In certain, but not all, php-files, ```lsp--line-character-to-point``` is called with ```character``` passed as ```nil```, don't use numerical comparison in this case.  Simply check that character is not nil prior to the comparison