### PR TITLE
Change license key configuration for intelephense.

### DIFF
--- a/lsp-intelephense.el
+++ b/lsp-intelephense.el
@@ -153,7 +153,6 @@ language server."
  '(("intelephense.trace.server" lsp-intelephense-trace-server)
    ("intelephense.rename.exclude" lsp-intelephense-rename-exclude)
    ("intelephense.telemetry.enabled" lsp-intelephense-telemetry-enabled t)
-   ("intelephense.licenceKey" lsp-intelephense-licence-key)
    ("intelephense.format.enable" lsp-intelephense-format-enable t)
    ("intelephense.completion.maxItems" lsp-intelephense-completion-max-items)
    ("intelephense.completion.triggerParameterHints" lsp-intelephense-completion-trigger-parameter-hints t)
@@ -185,6 +184,7 @@ language server."
                                              ("indexingEnded" #'ignore))
                   :initialization-options (lambda ()
                                             (list :storagePath lsp-intelephense-storage-path
+                                                  :licenceKey lsp-intelephense-licence-key
                                                   :clearCache lsp-intelephense-clear-cache))
                   :multi-root t
                   :completion-in-comments? t


### PR DESCRIPTION
In the latest versions of intelephense, the license key should be passed in initialization options.

see: https://github.com/bmewburn/intelephense-docs
![image](https://user-images.githubusercontent.com/9398439/75059195-44bec200-54fe-11ea-9cad-9cd59bcf0b8a.png)
