### PR TITLE
lsp-completion-at-point: fix prefix psedo-bounds

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4024,14 +4024,15 @@ PLIST is the additional data to attach to each candidate."
   (when (or (--some (lsp--client-completion-in-comments? (lsp--workspace-client it))
                     (lsp-workspaces))
             (not (nth 4 (syntax-ppss))))
-    (let* ((bounds-start (or (car (bounds-of-thing-at-point 'symbol)) (point)))
-           (trigger-chars (->> (lsp--server-capabilities)
-                               (gethash "completionProvider")
-                               (gethash "triggerCharacters")))
-           result done?)
+    (-let* (((bounds-start . bounds-end) (or (bounds-of-thing-at-point 'symbol)
+                                             (cons (point) (point))))
+            (trigger-chars (->> (lsp--server-capabilities)
+                                (gethash "completionProvider")
+                                (gethash "triggerCharacters")))
+            result done?)
       (list
        bounds-start
-       (point)
+       bounds-end
        (lambda (_probe pred action)
          (cond
           ((eq action 'metadata)


### PR DESCRIPTION
This should fix #1447.
However it causes a regression of not be able to show suggestions when cursor in middle of symbols as by design (which's very Emacs way).
Please reject this if we need to be able to show suggestions when cursor in middle of symbols.