### PR TITLE
lsp-capf: prevent double filtering

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4168,11 +4168,7 @@ Also, additional data to attached to each candidate can be passed via PLIST."
          (cond
           ((eq action 'metadata)
            `(metadata ((category . lsp-capf)
-                       (display-sort-function . (lambda (candidates)
-                                                  (--sort (string-lessp
-                                                           (get-text-property 0 'lsp-sort-text it)
-                                                           (get-text-property 0 'lsp-sort-text other))
-                                                          candidates))))))
+                       (display-sort-function . #'identity))))
           ((eq (car-safe action) 'boundaries) nil)
           ;; retrieve candidates
           (done? result)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -745,7 +745,7 @@ Set to nil to disable the warning."
 
 (defcustom lsp-completion-styles (if (version<= "27.0" emacs-version)
                                      `(flex)
-                                   completion-styles)
+                                   `(substring))
   "List of completion styles to use for filtering completion items."
   :group 'lsp-mode
   :type completion--styles-type)


### PR DESCRIPTION
Prevent double filtering by:
- Define new category for `lsp-capf` which will always have style `basic`. This will prevent `company-capf` from performing additional filtering.
- Define `lsp-completion-styles` to allow user to customize completion styles to use when filtering candidates.