### PR TITLE
Implemented better handling of :mode param

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2752,52 +2752,38 @@ If NO-WAIT is non-nil send the request as notification."
            (t (error (gethash "message" (cl-first resp-error))))))
       (lsp-cancel-request-by-token :sync-request))))
 
-(cl-defun lsp-request-async (method params callback &key mode error-handler no-merge cancel-token)
-  "Send request METHOD with PARAMS."
-  (lsp--send-request-async `(:jsonrpc "2.0" :method ,method :params ,params) callback mode error-handler no-merge cancel-token))
+(defvar lsp--cancelable-requests (ht))
 
-(defun lsp--create-async-callback (count callback mode method no-merge cancel-token)
+(cl-defun lsp-request-async (method params callback
+                                    &key mode error-handler no-merge cancel-token)
+  "Send request METHOD with PARAMS."
+  (lsp--send-request-async `(:jsonrpc "2.0" :method ,method :params ,params)
+                           callback mode error-handler no-merge cancel-token))
+
+(defun lsp--create-request-cancel (id workspaces hook buf method)
+  (lambda (&rest _)
+    (unless (and (equal 'post-command-hook hook)
+                 (equal (current-buffer) buf))
+      (lsp--request-cleanup-hooks id)
+      (with-lsp-workspaces workspaces
+        (lsp--cancel-request id))
+      (lsp-log "Cancelling %s(%s) in hook %s" method id hook))))
+
+(defun lsp--create-async-callback
+    (callback method no-merge workspaces)
   "Create async handler expecting COUNT results, merge them and call CALLBACK.
 MODE determines when the callback will be called depending on the
 condition of the original buffer. METHOD is the invoked method.
-If NO-MERGE is non-nil, don't merge the results but return alist workspace->result."
-  (let ((buf (current-buffer))
-        results)
-    (cl-labels ((handle-result
-                 ()
-                 (when cancel-token
-                   (remhash cancel-token lsp--cancelable-requests))
-                 (funcall callback (if no-merge
-                                       results
-                                     (lsp--merge-results (-map #'cl-rest results) method)))))
-      (pcase mode
-        ('detached (lambda (result)
-                     (push (cons lsp--cur-workspace result) results)
-                     (when (and (eq (length results) count))
-                       (handle-result))))
-        ('alive (lambda (result)
-                  (push (cons lsp--cur-workspace result) results)
-                  (if (and (eq (length results) count)
-                           (buffer-live-p buf))
-                      (with-current-buffer buf
-                        (handle-result))
-                    (lsp-log "Buffer is not alive ignoring response. Method %s." method))))
-        ('tick (let ((tick (buffer-chars-modified-tick)))
-                 (lambda (result)
-                   (when (buffer-live-p buf)
-                     (with-current-buffer buf
-                       (if (and (= tick (buffer-chars-modified-tick)))
-                           (progn
-                             (push (cons lsp--cur-workspace result)  results)
-                             (when (eq (length results) count)
-                               (handle-result)))
-                         (lsp-log "Buffer modified ignoring response. Method %s." method)))))))
-        (_ (lambda (result)
-             (push (cons lsp--cur-workspace result) results)
-             (if (and (eq (length results) count)
-                      (eq buf (current-buffer)))
-                 (handle-result)
-               (lsp-log "Buffer switched - ignoring response. Method %s" method))))))))
+If NO-MERGE is non-nil, don't merge the results but return alist workspace->result.
+ID is the request id. "
+  (let (results)
+    (lambda (result)
+      (push (cons lsp--cur-workspace result) results)
+      (when (eq (length results) (length workspaces))
+        (funcall callback
+                 (if no-merge
+                     results
+                   (lsp--merge-results (-map #'cl-rest results) method)))))))
 
 (defun lsp--create-default-error-handler (method)
   "Default error handler.
@@ -2806,14 +2792,20 @@ METHOD is the executed method."
     (lsp--warn "%s" (or (gethash "message" error)
                         (format "%s Request has failed" method)))))
 
-(defvar lsp--cancelable-requests (ht))
+(defvar lsp--request-cleanup-hooks (ht))
+
+(defun lsp--request-cleanup-hooks (request-id)
+  (when-let (cleanup-function (gethash request-id lsp--request-cleanup-hooks))
+    (funcall cleanup-function)
+    (remhash request-id lsp--request-cleanup-hooks)))
 
 (defun lsp-cancel-request-by-token (cancel-token)
   "Cancel request using CANCEL-TOKEN."
   (-when-let ((request-id . workspaces) (gethash cancel-token lsp--cancelable-requests))
     (with-lsp-workspaces workspaces
       (lsp--cancel-request request-id))
-    (remhash cancel-token lsp--cancelable-requests)))
+    (remhash cancel-token lsp--cancelable-requests)
+    (lsp--request-cleanup-hooks request-id)))
 
 (defun lsp--send-request-async (body callback &optional mode error-callback no-merge cancel-token)
   "Send BODY as a request to the language server.
@@ -2826,50 +2818,88 @@ will be executed only if the buffer from which the call was
 executed is still alive. `current' the callback will be executed
 only if the original buffer is still selected. `tick' - the
 callback will be executed only if the buffer was not modified.
+`unchanged' - the callback will be executed only if the buffer
+hasnt changed and if the buffer is not modified.
 
 ERROR-CALLBACK will be called in case the request has failed.
-If NO-MERGE is non-nil, don't merge the results but return alist workspace->result."
-
+If NO-MERGE is non-nil, don't merge the results but return alist workspace->result.
+"
   (when cancel-token
     (lsp-cancel-request-by-token cancel-token))
 
   (if-let ((target-workspaces (lsp--find-workspaces-for body)))
       (let* ((start-time (current-time))
              (method (plist-get body :method))
-             (workspaces-count (length target-workspaces))
-             (async-callback (lsp--create-async-callback workspaces-count
-                                                         callback
-                                                         mode
-                                                         method
-                                                         no-merge
-                                                         cancel-token))
-             (error-async-callback (lsp--create-async-callback
-                                    workspaces-count
-                                    (or error-callback
-                                        (lsp--create-default-error-handler method))
-                                    mode
-                                    method
-                                    nil
-                                    cancel-token))
              (id (cl-incf lsp-last-id))
+             ;; calculate what are the (hook . local) pairs which will cancel
+             ;; the request
+             (hooks (pcase mode
+                      ('alive     '((kill-buffer-hook . t)))
+                      ('tick      '((kill-buffer-hook . t) (after-change-functions . t)))
+                      ('unchanged '((after-change-functions . t) (post-command-hook . nil)))
+                      ('current   '((post-command-hook . nil)))))
+             (buf (current-buffer))
+             ;; note: lambdas in emacs can be compared but we should make sure
+             ;; that all of the captured arguments are the same - in our case
+             ;; `lsp--create-request-cancel' will return the same lambda when
+             ;; called with the same params.
+             (cleanup-hooks (lambda ()
+                              (when (buffer-live-p buf)
+                                (with-current-buffer buf
+                                  (mapc (-lambda ((hook . local))
+                                          (remove-hook
+                                           hook
+                                           (lsp--create-request-cancel
+                                            id target-workspaces hook buf method)
+                                           local))
+                                        hooks)))
+                              (remhash cancel-token lsp--cancelable-requests)))
+             (callback (lsp--create-async-callback callback
+                                                   method
+                                                   no-merge
+                                                   target-workspaces))
+             (callback (lambda (result)
+                         (lsp--request-cleanup-hooks id)
+                         (funcall callback result)))
+             (error-callback (lsp--create-async-callback
+                              (or error-callback
+                                  (lsp--create-default-error-handler method))
+                              method
+                              nil
+                              target-workspaces))
+             (error-callback (lambda (error)
+                               (lsp--request-cleanup-hooks id)
+                               (funcall error-callback error)))
              (body (plist-put body :id id)))
+
+        ;; cancel request in any of the hooks
+        (when hooks
+          (mapc (-lambda ((hook . local))
+                  (add-hook hook
+                            (lsp--create-request-cancel
+                             id target-workspaces hook buf method)
+                            nil local))
+                hooks)
+          (puthash id cleanup-hooks lsp--request-cleanup-hooks))
+
         (setq lsp--last-active-workspaces target-workspaces)
+
         (when cancel-token
           (puthash cancel-token (cons id target-workspaces) lsp--cancelable-requests))
+
         (seq-doseq (workspace target-workspaces)
-          (with-lsp-workspace workspace
-            (when lsp-print-io
-              (lsp--log-entry-new (lsp--make-log-entry method id
-                                                       (plist-get body :params)
-                                                       'outgoing-req)
-                                  workspace))
-            (let ((message (lsp--make-message body)))
-              (puthash id
-                       (list async-callback error-async-callback method start-time (current-time))
-                       (-> lsp--cur-workspace
-                           lsp--workspace-client
-                           lsp--client-response-handlers))
-              (lsp--send-no-wait message (lsp--workspace-proc workspace)))))
+          (when lsp-log-io
+            (lsp--log-entry-new (lsp--make-log-entry method id
+                                                     (plist-get body :params)
+                                                     'outgoing-req)
+                                workspace))
+          (let ((message (lsp--make-message body)))
+            (puthash id
+                     (list callback error-callback method start-time (current-time))
+                     (-> workspace
+                         (lsp--workspace-client)
+                         (lsp--client-response-handlers)))
+            (lsp--send-no-wait message (lsp--workspace-proc workspace))))
         body)
     (error "The connected server(s) does not support method %s
 To find out what capabilities support your server use `M-x lsp-describe-session' and expand the capabilities section."
@@ -2959,8 +2989,8 @@ disappearing, unset all the variables related to it."
                                            (lineFoldingOnly . ,(or lsp-folding-line-folding-only :json-false)))))
                       (callHierarchy . ((dynamicRegistration . :json-false)))
                       (publishDiagnostics . ((relatedInformation . t)
-	                                           (tagSupport . ((valueSet . [1 2])))
-	                                           (versionSupport . t)))))
+                                             (tagSupport . ((valueSet . [1 2])))
+                                             (versionSupport . t)))))
      (window . ((workDoneProgress . t))))
    custom-capabilities))
 

--- a/test/lsp-integration-test.el
+++ b/test/lsp-integration-test.el
@@ -44,10 +44,11 @@
 (defmacro lsp-test-wait (form)
   `(lsp-test--wait-for '(progn ,form)))
 
-(defun lsp-def-request-async (method params)
+(defun lsp-def-request-async (method params &rest args)
   (--doto (deferred:new #'identity)
-    (lsp-request-async method params (-partial #'deferred:callback-post it)
-                       :error-handler (-partial #'deferred:errorback-post it))))
+    (apply #'lsp-request-async method params (-partial #'deferred:callback-post it)
+           :error-handler (-partial #'deferred:errorback-post it)
+           args)))
 
 (ert-deftest lsp-text-document-hover-request ()
   (lsp-workspace-folders-add (f-join lsp-test-location "fixtures"))
@@ -66,6 +67,97 @@
       (deferred:sync!))
   (kill-buffer)
   (lsp-workspace-folders-remove (f-join lsp-test-location "fixtures")))
+
+(defmacro deferred::nextc (d &rest body)
+  `(deferred:nextc ,d (lambda (result)
+                        ,@body)))
+
+(defmacro lsp-with-pyls (&rest body)
+  `(progn
+     (lsp-workspace-folders-add (f-join lsp-test-location "fixtures"))
+     (find-file (f-join lsp-test-location "fixtures/pyls/test.py"))
+     (lsp)
+     ,@body
+
+     (find-file (f-join lsp-test-location "fixtures/pyls/test.py"))
+     (save-buffer)
+     (kill-buffer)
+     (lsp-workspace-folders-remove (f-join lsp-test-location "fixtures"))))
+
+(ert-deftest lsp-text-document-hover-request-tick ()
+  (lsp-with-pyls
+   (-> (lsp-test-wait
+        (eq 'initialized (lsp--workspace-status
+                          (cl-first (lsp-workspaces)))))
+       (deferred::nextc
+         (goto-char (point-min))
+         (search-forward "fn1")
+         (prog1 (deferred:earlier
+                  (lsp-def-request-async "textDocument/hover"
+                                         (lsp--text-document-position-params)
+                                         :mode 'tick)
+                  (deferred::nextc (deferred:wait 1000) :timeout))
+           (insert "x")
+           (delete-char -1)))
+       (deferred::nextc (should (equal result :timeout)))
+       (deferred:sync!))))
+
+(ert-deftest lsp-test-current-buffer-mode ()
+  (lsp-with-pyls
+   (-> (lsp-test-wait
+        (eq 'initialized (lsp--workspace-status
+                          (cl-first (lsp-workspaces)))))
+       (deferred::nextc
+         (goto-char (point-min))
+         (search-forward "fn1")
+         (prog1 (deferred:earlier
+                  (lsp-def-request-async "textDocument/hover"
+                                         (lsp--text-document-position-params)
+                                         :mode 'current)
+                  (deferred::nextc (deferred:wait 1000) :timeout))
+           (switch-to-buffer "*scratch*")
+           (let ((post-command-hook (->> (f-join lsp-test-location "fixtures/pyls/test.py")
+                                         find-buffer-visiting
+                                         (buffer-local-value 'post-command-hook))))
+             (run-hooks 'post-command-hook))))
+       (deferred::nextc (should (equal result :timeout)))
+       (deferred:sync!))))
+
+(ert-deftest lsp-test-current-buffer-mode ()
+  (lsp-with-pyls
+   (-> (lsp-test-wait
+        (eq 'initialized (lsp--workspace-status
+                          (cl-first (lsp-workspaces)))))
+       (deferred::nextc
+         (goto-char (point-min))
+         (search-forward "fn1")
+         (prog1 (deferred:earlier
+                  (lsp-def-request-async "textDocument/hover"
+                                         (lsp--text-document-position-params)
+                                         :mode 'alive)
+                  (deferred::nextc (deferred:wait 1000) :timeout))
+           (kill-buffer (current-buffer))))
+       (deferred::nextc (should (equal result :timeout)))
+       (deferred:sync!))))
+
+(ert-deftest lsp-test-current-buffer-mode ()
+  (lsp-with-pyls
+   (-> (lsp-test-wait
+        (eq 'initialized (lsp--workspace-status
+                          (cl-first (lsp-workspaces)))))
+       (deferred::nextc
+         (goto-char (point-min))
+         (search-forward "fn1")
+         (prog1 (deferred:earlier
+                  (lsp-def-request-async "textDocument/hover"
+                                         (lsp--text-document-position-params)
+                                         :mode 'alive)
+                  (deferred::nextc (deferred:wait 1000) :timeout))
+           (-> (f-join lsp-test-location "fixtures/pyls/test.py")
+               (find-buffer-visiting)
+               (kill-buffer))))
+       (deferred::nextc (should (equal result :timeout)))
+       (deferred:sync!))))
 
 (provide 'lsp-integration-test)
 ;;; lsp-integration-test.el ends here


### PR DESCRIPTION
- reworked the way :mode works. Now, instead of filtering the results we
register hooks to cancel the request in progress. E. g. if you do 'tick request
lsp-mode will add hook to lsp-on-change and cancel the request right away.

- introduced one more mode 'unchanged which is a combination from tick + current
buffer.