### PR TITLE
lsp-capf: sort candidate after filtering

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4101,6 +4101,9 @@ Also, additional data to attached to each candidate can be passed via PLIST."
                                  (if (consp tail) (setcdr tail nil))
                                  it))))
                   (-flatten-n 1)
+                  (-sort (-on #'> (lambda (o)
+                                    (or (get-text-property 0 'completion-score o)
+                                        0))))
                   ;; TODO: pass additional function to sort the candidates
                   (-map (-partial #'get-text-property 0 'lsp-completion-item)))
            lsp-items)))
@@ -4168,8 +4171,8 @@ Also, additional data to attached to each candidate can be passed via PLIST."
        (lambda (_probe _pred action)
          (cond
           ((eq action 'metadata)
-           `(metadata ((category . lsp-capf)
-                       (display-sort-function . #'identity))))
+           `(metadata (category . lsp-capf)
+                      (display-sort-function . identity)))
           ((eq (car-safe action) 'boundaries) nil)
           ;; retrieve candidates
           (done? result)


### PR DESCRIPTION
We need to sort candidates based on filtering score.
Fix issue mention in [#1445(comment)](https://github.com/emacs-lsp/lsp-mode/pull/1475#issuecomment-595884077)