### PR TITLE
lsp-async-start-process: should call error callback when callback fails

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6494,13 +6494,17 @@ When prefix UPDATE? is t force installation even if the server is present."
    update?))
 
 (defun lsp-async-start-process (callback error-callback &rest command)
+  "Start async process COMMAND with CALLBACK and ERROR-CALLBACK."
   (make-process
    :name (cl-first command)
    :command command
    :sentinel (lambda (proc _)
                (when (eq 'exit (process-status proc))
                  (if (zerop (process-exit-status proc))
-                     (funcall callback)
+                     (condition-case err
+                         (funcall callback)
+                       (error
+                        (funcall error-callback (error-message-string err))))
                    (display-buffer " *lsp-install*")
                    (funcall error-callback
                             (format "Async process '%s' failed with exit code %d"


### PR DESCRIPTION
In Windows with server that's using `lsp-async-process-start`, when trying to download new language server via `C-u M-x lsp-install-server` while the old server still running, sometimes the `callback` will fail due to access denied.
The reason is because the old file is still in use and cannot be deleted, that's normal.
However, when the `callback` fails, the `lsp--client-download-in-progress?` will not be cleaned up since the failure happens inside process sentinel and will not trigger and callbacks to cleanup.
When this bug happens, user will not be able to reinstall new language server since the old one is still in downloading state, and it's not easy to clean that.

This change provides a fix by properly catch failure when calling `callbacks` and call error-callback in that case.

An example of this happens is to using `lsp-pwsh` and try to update to newer language server by `C-u M-x lsp-install-server`