### PR TITLE
Add go-dot-mod-mode support.

### DIFF
--- a/lsp-go.el
+++ b/lsp-go.el
@@ -87,7 +87,7 @@ completing function calls."
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection
                                    (lambda () (cons lsp-gopls-server-path lsp-gopls-server-args)))
-                  :major-modes '(go-mode)
+                  :major-modes '(go-mode go-dot-mod-mode)
                   :priority 0
                   :server-id 'gopls
                   :library-folders-fn 'lsp-clients-go--library-default-directories))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -190,7 +190,7 @@ occasionally break as language servers are updated."
 
 (defcustom lsp-client-packages
   '(ccls cquery lsp-clients lsp-clojure lsp-csharp lsp-css lsp-dart lsp-elm
-    lsp-erlang lsp-eslint lsp-fsharp lsp-gdscript lsp-go lsp-haskell lsp-haxe
+    lsp-erlang lsp-eslint lsp-fsharp lsp-gdscript lsp-haskell lsp-haxe
     lsp-intelephense lsp-java lsp-json lsp-metals lsp-pwsh lsp-pyls
     lsp-python-ms lsp-rust lsp-solargraph lsp-terraform lsp-verilog lsp-vetur
     lsp-vhdl lsp-xml lsp-yaml)
@@ -611,6 +611,7 @@ Changes take effect only when a new session is started."
                                         (html-mode . "html")
                                         (sgml-mode . "html")
                                         (mhtml-mode . "html")
+                                        (go-dot-mod-mode . "go")
                                         (go-mode . "go")
                                         (haskell-mode . "haskell")
                                         (hack-mode . "hack")


### PR DESCRIPTION
go-dot-mod-mode is a major mode for go.mod files. Gopls supports some
go.mod features, so add go-dot-mod-mode support to lsp-mode.

Also, remove the deprecated lsp-go from lsp-client-packages. I think
this was breaking things for people who still accidentally have lsp-go
installed.