### PR TITLE
dls: configurable server path and args

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -828,17 +828,5 @@ responsiveness at the cost of possible stability issues."
                   :priority -1
                   :server-id 'cmakels))
 
-;; D
-(defgroup lsp-d nil
-  "LSP support for D, using dls."
-  :group 'lsp-mode
-  :link '(url-link "https://github.com/d-language-server/dls"))
-
-(lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection "~/.dub/packages/.bin/dls-latest/dls")
-                  :major-modes '(d-mode)
-                  :priority -1
-                  :server-id 'dls))
-
 (provide 'lsp-clients)
 ;;; lsp-clients.el ends here

--- a/lsp-dls.el
+++ b/lsp-dls.el
@@ -31,7 +31,7 @@
   :group 'lsp-mode
   :link '(url-link "https://github.com/d-language-server/dls"))
 
-(defcustom lsp-dls-path "~/.dub/packages/.bin/dls-latest/dls"
+(defcustom lsp-dls-path "dls"
   "Path to dls server binary."
   :type 'string
   :group 'lsp-dls)

--- a/lsp-dls.el
+++ b/lsp-dls.el
@@ -1,0 +1,56 @@
+;;; lsp-dls.el --- dls configuration               -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 lsp-mode developers
+
+;; Author: Hiroki Noda <kubo39@gmail.com>
+;; Keywords:
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; dls client configuration
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-dls nil
+  "LSP support for D, using https://github.com/d-language-server/dls."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/d-language-server/dls"))
+
+(defcustom lsp-dls-path "~/.dub/packages/.bin/dls-latest/dls"
+  "Path to dls server binary."
+  :type 'string
+  :group 'lsp-dls)
+
+(defcustom lsp-dls-args nil
+  "Add server initialization options for dls."
+  :type '(repeat string)
+  :group 'lsp-dls)
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   (lambda () (cons lsp-dls-path lsp-dls-args)))
+                  :major-modes '(d-mode)
+                  :priority -1
+                  :server-id 'dls))
+
+(provide 'lsp-dls)
+;;; lsp-dls.el ends here
+
+;; Local Variables:
+;; flycheck-disabled-checkers: (emacs-lisp-checkdoc)
+;; End:

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -189,7 +189,7 @@ occasionally break as language servers are updated."
   :package-version '(lsp-mode . "6.1"))
 
 (defcustom lsp-client-packages
-  '(ccls cquery lsp-clients lsp-clojure lsp-csharp lsp-css lsp-dart lsp-elm
+  '(ccls cquery lsp-clients lsp-clojure lsp-csharp lsp-css lsp-dart lsp-dls lsp-elm
     lsp-erlang lsp-eslint lsp-fsharp lsp-gdscript lsp-go lsp-haskell lsp-haxe
     lsp-intelephense lsp-java lsp-json lsp-metals lsp-pwsh lsp-pyls
     lsp-python-ms lsp-rust lsp-solargraph lsp-terraform lsp-verilog lsp-vetur


### PR DESCRIPTION
This commit allows to custom server's path and arguments by using
`lsp-dls-path` or `lsp-dls-args`.