### PR TITLE
optimize lsp when it is called multiple times

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7154,7 +7154,9 @@ argument ask the user to select which language server to start. "
   (interactive "P")
 
   (when (and lsp-auto-configure)
-    (seq-do (lambda (package) (require package nil t))
+    (seq-do (lambda (package)
+              ;; loading client is slow and `lsp' can be called repeatedly
+              (unless (featurep package) (require package nil t)))
             lsp-client-packages))
 
   (when (buffer-file-name)


### PR DESCRIPTION
If I use recommend setup `(add-hook 'XXX-mode-hook #'lsp-deferred)` in my javascript project, function `lsp` is called when I load a new js file. So the require statement in below code is always executed,

```lisp
(defun lsp (&optional arg)
   ...
  (when (and lsp-auto-configure)
    (seq-do (lambda (package)
              ;; loading client is slow and `lsp' can be called repeatedly
              (require package nil t))
            lsp-client-packages))
  ...
)
```
and it's better not to load same package multiple times.

The steps to find find the bottle neck of loading js file,
Step 1, define below function `my-connect-lsp`,
```lisp
(defun my-connect-lsp (&optional no-reconnect)
  "Connect lsp server.  If NO-RECONNECT is t, don't shutdown existing lsp connection."
  (interactive "P")
  (when (and (not no-reconnect)
             (fboundp 'lsp-disconnect))
    (lsp-disconnect))
  (when buffer-file-name
    (unless (and (boundp 'lsp-mode) lsp-mode)
      (require 'profiler)
      (require 'lsp-mode)
      (profiler-stop)
      (profiler-cpu-start 1000000)
      (lsp-deferred))))
```
Step 2, patch `lsp-mode.el` with below patch,
```
diff --git a/lsp-mode.el b/lsp-mode.el
index 6f3dcb8..ffc1ee7 100644
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7173,6 +7173,7 @@ argument ask the user to select which language server to start. "
           (lsp-mode 1)
           (when lsp-auto-configure (lsp--auto-configure))
           (setq lsp-buffer-uri (lsp--buffer-uri))
+          (profiler-report-cpu)
           (lsp--info "Connected to %s."
                      (apply 'concat (--map (format "[%s]" (lsp--workspace-print it))
                                            lsp--buffer-workspaces)))))
```
Step 3, open any js file and run `my-connect-lsp`, got below result，

![image](https://user-images.githubusercontent.com/184553/76199740-8cef1b80-6244-11ea-9394-2404ba45a847.png)
