### PR TITLE
lsp-pwsh: automatically create logs directory

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6469,12 +6469,15 @@ Check `*lsp-install*' and `*lsp-log*' buffer."
                  (setq global-mode-string (-remove-item '(t (:eval (lsp--download-status)))
                                                         global-mode-string))))))
     (lsp--info "Download %s started." (lsp--client-server-id client))
-    (funcall
-     (lsp--client-download-server-fn client)
-     client
-     (lambda () (done t))
-     (lambda (msg) (done nil msg))
-     update?)))
+    (condition-case err
+        (funcall
+         (lsp--client-download-server-fn client)
+         client
+         (lambda () (done t))
+         (lambda (msg) (done nil msg))
+         update?)
+      (error
+       (done nil (error-message-string err))))))
 
 (defun lsp-install-server (update?)
   "Interactively install server.

--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -335,13 +335,15 @@ FORCED if specified with prefix argument."
   (let ((url (format lsp-pwsh-github-asset-url "PowerShell"
                      "PowerShellEditorServices" "PowerShellEditorServices.zip"))
         (temp-file (make-temp-file "ext" nil ".zip")))
-    (unless (and (not update) (file-exists-p lsp-pwsh-dir))
+    (unless (f-exists? lsp-pwsh-log-path)
+      (mkdir lsp-pwsh-log-path 'create-parent))
+    (unless (and (not update) (f-exists? lsp-pwsh-dir))
       ;; since we know it's installed, use powershell to download the file
       ;; (and avoid url.el bugginess or additional libraries)
       (lsp-async-start-process
        (lambda ()
          (lsp--info "lsp-pwsh: Downloading done!")
-         (when (file-exists-p lsp-pwsh-dir) (delete-directory lsp-pwsh-dir 'recursive))
+         (when (f-exists? lsp-pwsh-dir) (delete-directory lsp-pwsh-dir 'recursive))
          (lsp-async-start-process
           callback
           error-callback


### PR DESCRIPTION
As discussed in gitter, we should create logs directory automatically in case the language server is not creating it first.