### PR TITLE
lsp--render-element: allow to handle nil

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4568,6 +4568,7 @@ When language is nil render as markup if `markdown-mode' is loaded."
        (lsp--render-string value kind)))
     ;; plain string
     ((stringp content) (lsp--render-string content "markdown"))
+    ((null content) "")
     (t (error "Failed to handle %s" content)))
    ""))
 


### PR DESCRIPTION
When there's empty signature, error will be thrown since `lsp--render-element` cannot handle nil.
Fix: allow it to handle `nil`.