### PR TITLE
bug: canonical file name shouldn't follow symlink and expand properly with TRAMP path

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1440,9 +1440,9 @@ already have been created."
            (indent 1))
   `(when-let (lsp--cur-workspace ,workspace) ,@body))
 
-(defun lsp-canonical-file-name  (file-name)
-  "Return the canonical FILE-NAME."
-  (f-canonical (directory-file-name (f-expand file-name))))
+(defun lsp-canonical-file-name (file-name)
+  "Return the canonical, without trailing slash FILE-NAME."
+  (directory-file-name (expand-file-name file-name)))
 
 (defun lsp--window-show-message (_workspace params)
   "Send the server's messages to log.


### PR DESCRIPTION
Fix #1300 and #1523 
We should not use `f-canonical` since it will return file true name path and can break symlink.
We also should not expand with `f-expand` since it ignore `file-name-handler-alist` and make TRAMP path not expand properly  on Windows