### PR TITLE
add support robot-framework

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -28,6 +28,8 @@
 (require 'dash)
 (require 'dash-functional)
 (require 'rx)
+(require 'cl-lib)
+(require 'em-glob)
 
 ;;; Ada
 (defgroup lsp-ada nil
@@ -827,6 +829,121 @@ responsiveness at the cost of possible stability issues."
                   :major-modes '(cmake-mode)
                   :priority -1
                   :server-id 'cmakels))
+
+;;; Rf
+(defgroup lsp-rf nil
+  "Settings for Robot Framework Language Server."
+  :group 'lsp-mode
+  :tag "Language Server"
+  :link '(url-link "https://github.com/tomi/vscode-rf-language-server.git"))
+
+(defcustom lsp-rf-language-server-main-file "~/.vscode/extensions/tomiturtiainen.rf-intellisense-2.8.0/server/server.js"
+  "Path to the server.js file of the rf-intellisense server. Accepts a string"
+  :type 'string
+  :group 'lsp-rf)
+
+(defcustom lsp-rf-language-server-include-paths []
+  "An array of files that should be included by the parser. Glob patterns as strings are accepted (eg. *.robot between double quotes)"
+  :type 'lsp-string-vector
+  :group 'lsp-rf)
+
+(defcustom lsp-rf-language-server-exclude-paths []
+  "An array of files that should be ignored by the parser. Glob patterns as strings are accepted (eg. *bad.robot between double quotes)"
+  :type 'lsp-string-vector
+  :group 'lsp-rf)
+
+(defcustom lsp-rf-language-server-python-keywords nil
+  "DEPRECATED. Use rfLanguageServer.includePaths instead"
+  :type 'boolean
+  :group 'lsp-rf)
+
+(defcustom lsp-rf-language-server-dir "~/.vscode/extensions/tomiturtiainen.rf-intellisense-2.8.0/server/library-docs/"
+  "Libraries directory for libraries in lsp-rf-language-server-libraries"
+  :type 'string
+  :group 'lsp-rf)
+
+(defcustom lsp-rf-language-server-libraries '("BuiltIn-3.1.1" "Collections-3.0.4")
+  "Libraries whose keywords are suggested with auto-complete"
+  :type '(repeat string)
+  ;; :type 'lsp-string-vector
+  :group 'lsp-rf)
+
+(defcustom lsp-rf-language-server-log-level "debug"
+  "What language server log messages are printed"
+  :type 'string
+  ;; :type '(choice (:tag "off" "errors" "info" "debug"))
+  :group 'lsp-rf)
+
+(defcustom lsp-rf-language-server-trace-server "verbose"
+  "Traces the communication between VSCode and the rfLanguageServer service."
+  :type 'string
+  ;; :type '(choice (:tag "off" "messages" "verbose"))
+  :group 'lsp-rf)
+
+(defun parse-rf-language-server-library-dirs (dirs)
+  "Convert lsp-rf-language-server-libraries list to list with absolute paths"
+  (map 'list
+   (lambda (x)
+     (concat
+      (expand-file-name
+       lsp-rf-language-server-dir)
+      x
+      ".json"))
+   dirs))
+
+(defun parse-rf-language-server-globs-to-regex (vector)
+  "Translates vector of globs to regex (as a group separated by or statements)"
+  (let ((globs (if (eq vector [])
+                        ["*.robot" "*.resource"]
+                      vector)))
+    (concat "\\("(mapconcat 'eshell-glob-regexp globs "\\|") "\\)")))
+
+;; included files are extracted in lsp-register-client function
+;; using the glob-to-regex function above as a third argument in
+;; the directory-files-recursively function
+
+(defun rf-language-server-exclude-paths (seq)
+  "Uses lsp-rf-language-server-exclude-paths vector of globs to
+delete matched files from sequence"
+  (cl-delete-if (lambda (x) (string-match-p
+                             (parse-rf-language-server-globs-to-regex
+                              lsp-rf-language-server-exclude-paths)
+                             x))
+                seq))
+
+(lsp-register-custom-settings
+ '(
+   ("rfLanguageServer.trace.server" lsp-rf-language-server-trace-server)
+   ("rfLanguageServer.logLevel" lsp-rf-language-server-log-level)
+   ("rfLanguageServer.libraries" lsp-rf-language-server-libraries)
+   ("rfLanguageServer.pythonKeywords" lsp-rf-language-server-python-keywords t)
+   ("rfLanguageServer.excludePaths" lsp-rf-language-server-exclude-paths)
+   ("rfLanguageServer.includePaths" lsp-rf-language-server-include-paths)
+   ))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   `("node" ,(expand-file-name
+                                              lsp-rf-language-server-main-file)))
+                  :major-modes '(robot-mode)
+                  :server-id 'rf-intellisense
+                  ;; :library-folders-fn (lambda (_workspace)
+                  ;;                        lsp-rf-language-server-libraries)
+                  :library-folders-fn (lambda (_workspace)
+                                         (parse-rf-language-server-library-dirs
+                                         lsp-rf-language-server-libraries))
+                  :initialized-fn (lambda (workspace)
+                                    (with-lsp-workspace workspace
+                                      (lsp--set-configuration
+                                       (lsp-configuration-section "rfLanguageServer"))
+                                      (lsp-request "buildFromFiles"
+                                                   (list :files
+                                                         (vconcat
+                                                          (rf-language-server-exclude-paths
+                                                           (directory-files-recursively
+                                                            (projectile-project-root)
+                                                            (parse-rf-language-server-globs-to-regex
+                                                             lsp-rf-language-server-include-paths))))))))))
 
 (provide 'lsp-clients)
 ;;; lsp-clients.el ends here

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -838,7 +838,7 @@ responsiveness at the cost of possible stability issues."
   :link '(url-link "https://github.com/tomi/vscode-rf-language-server.git"))
 
 (defcustom lsp-rf-language-server-start-command '("~/.nvm/versions/node/v9.11.2/bin/node" "~/.vscode/extensions/tomiturtiainen.rf-intellisense-2.8.0/server/server.js")
-  "Path to the server.js file of the rf-intellisense server. Accepts a string"
+  "Path to the server.js file of the rf-intellisense server. Accepts a list of strings (path/to/interpreter path/to/server.js)"
   :type 'list
   :group 'lsp-rf)
 

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -936,7 +936,7 @@ responsiveness at the cost of possible stability issues."
                                                          (vconcat
                                                           (parse-rf-language-server-exclude-paths
                                                            (directory-files-recursively
-                                                            (lsp-workspace-root)
+                                                            (lsp--workspace-root workspace)
                                                             (parse-rf-language-server-include-path-regex
                                                              lsp-rf-language-server-include-paths))))))))))
 

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -837,9 +837,9 @@ responsiveness at the cost of possible stability issues."
   :tag "Language Server"
   :link '(url-link "https://github.com/tomi/vscode-rf-language-server.git"))
 
-(defcustom lsp-rf-language-server-main-file "~/.vscode/extensions/tomiturtiainen.rf-intellisense-2.8.0/server/server.js"
+(defcustom lsp-rf-language-server-start-command '("~/.nvm/versions/node/v9.11.2/bin/node" "~/.vscode/extensions/tomiturtiainen.rf-intellisense-2.8.0/server/server.js")
   "Path to the server.js file of the rf-intellisense server. Accepts a string"
-  :type 'string
+  :type 'list
   :group 'lsp-rf)
 
 (defcustom lsp-rf-language-server-include-paths []
@@ -852,17 +852,12 @@ responsiveness at the cost of possible stability issues."
   :type 'lsp-string-vector
   :group 'lsp-rf)
 
-(defcustom lsp-rf-language-server-python-keywords nil
-  "DEPRECATED. Use rfLanguageServer.includePaths instead"
-  :type 'boolean
-  :group 'lsp-rf)
-
 (defcustom lsp-rf-language-server-dir "~/.vscode/extensions/tomiturtiainen.rf-intellisense-2.8.0/server/library-docs/"
   "Libraries directory for libraries in lsp-rf-language-server-libraries"
   :type 'string
   :group 'lsp-rf)
 
-(defcustom lsp-rf-language-server-libraries '("BuiltIn-3.1.1" "Collections-3.0.4")
+(defcustom lsp-rf-language-server-libraries ["BuiltIn-3.1.1" "Collections-3.0.4"]
   "Libraries whose keywords are suggested with auto-complete"
   :type '(repeat string)
   ;; :type 'lsp-string-vector
@@ -881,14 +876,17 @@ responsiveness at the cost of possible stability issues."
   :group 'lsp-rf)
 
 (defun parse-rf-language-server-library-dirs (dirs)
-  (mapcar
+  (vconcat (mapcar
    (lambda (x)
      (concat
       (expand-file-name
        lsp-rf-language-server-dir)
       x
       ".json"))
-   dirs))
+   dirs)))
+
+(defun expand-start-command ()
+  (mapcar 'expand-file-name lsp-rf-language-server-start-command))
 
 (defun parse-rf-language-server-globs-to-regex (vector)
   "Converts vector with globs to regex"
@@ -916,15 +914,12 @@ responsiveness at the cost of possible stability issues."
    ("rfLanguageServer.trace.server" lsp-rf-language-server-trace-server)
    ("rfLanguageServer.logLevel" lsp-rf-language-server-log-level)
    ("rfLanguageServer.libraries" lsp-rf-language-server-libraries)
-   ("rfLanguageServer.pythonKeywords" lsp-rf-language-server-python-keywords t)
    ("rfLanguageServer.excludePaths" lsp-rf-language-server-exclude-paths)
-   ("rfLanguageServer.includePaths" lsp-rf-language-server-include-paths)
-   ))
+   ("rfLanguageServer.includePaths" lsp-rf-language-server-include-paths)))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection
-                                   `("node" ,(expand-file-name
-                                              lsp-rf-language-server-main-file)))
+                                   (expand-start-command))
                   :major-modes '(robot-mode)
                   :server-id 'rf-intellisense
                   ;; :library-folders-fn (lambda (_workspace)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -652,7 +652,8 @@ Changes take effect only when a new session is started."
                                         (cmake-mode . "cmake")
                                         (gdscript-mode . "gdscript")
                                         (d-mode . "d")
-                                        (perl-mode . "perl"))
+                                        (perl-mode . "perl")
+                                        (robot-mode . "robot"))
   "Language id configuration.")
 
 (defvar lsp--last-active-workspaces nil


### PR DESCRIPTION
Here is a rudimentary implementation of the robot-framework lsp-client. It can already be used in a quite straightforward way, so you might agree to merge it already. However, it would be nice to at least implement the right menu's for the log and trace variables. So for now I am sending this PR mainly so you can have a look at it. I can update the documentation too, but I don't know how to instal the server without vscode, I never really worked with npm or javascript. Would be great to get your feedback.

Additionally I could update the spacemacs lsp layer later