### PR TITLE
lsp-metals: Support `/**` completion

### DIFF
--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -275,7 +275,8 @@ server via `window/logMessage'."
                                       (lsp--set-configuration
                                        (lsp-configuration-section "metals"))))
                   :after-open-fn (lambda ()
-                                   (add-hook 'lsp-on-idle-hook #'lsp-metals--did-focus nil t))))
+                                   (add-hook 'lsp-on-idle-hook #'lsp-metals--did-focus nil t))
+                  :completion-in-comments? t))
 
 (provide 'lsp-metals)
 ;;; lsp-metals.el ends here

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4252,8 +4252,15 @@ Also, additional data to attached to each candidate can be passed via PLIST."
        :company-require-match 'never
        :company-prefix-length
        (save-excursion
-         (goto-char bounds-start)
-         (lsp--looking-back-trigger-characters-p trigger-chars))
+         (or (and (eq bounds-start (point))
+                  (- bounds-start
+                     (-if-let* ((bol (point-at-bol))
+                                (w-point (re-search-backward (rx whitespace) bol 'noerror)))
+                         (+ 1 w-point)
+                       bol)))
+             (and (goto-char bounds-start)
+                  (lsp--looking-back-trigger-characters-p trigger-chars)
+                  t)))
        :company-match #'lsp--capf-company-match
        :company-doc-buffer (-compose #'company-doc-buffer
                                      #'lsp--capf-get-documentation)


### PR DESCRIPTION
This fix #1525 
There're two issues:
- The prefix length is `nil` due to symbol boundary is `nil` in this case. This the completion request is not triggered.
  We should always calculate `company-prefix-length` so it will automatically trigger completion even if the current position is not belong to a symbol.
  We new approach, the prefix length will be decided as the length to closest previous whitespace boundary.
- `lsp-metals` doesn't support `completion-in-comments`, thus make completion is not triggered while inside comment. We should fix that too.
