### PR TITLE
lsp-pwsh: properly quote arguments

### DIFF
--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -241,7 +241,7 @@ Must not nil.")
                   "-OutputFormat" "Text"
                   "-File"
                   ,(f-join lsp-pwsh-dir "PowerShellEditorServices/Start-EditorServices.ps1")
-                  "-HostName" "'Emacs Host'"
+                  "-HostName" "\"Emacs Host\""
                   "-HostProfileId" "'Emacs.LSP'"
                   "-HostVersion" "0.1"
                   "-LogPath" ,(f-join lsp-pwsh-log-path "emacs-powershell.log")


### PR DESCRIPTION
Argument with space doesn't correctly quoted in `lsp-pwsh`, and can cause the language server to fail.