### PR TITLE
Use `*${name}::stderr*` template for tcp-connection process stderr buffer

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6264,7 +6264,7 @@ process listening for TCP connections on the provided port."
                      (process-environment
                       (lsp--compute-process-environment environment-fn))
                      (proc (make-process :name name :connection-type 'pipe :coding 'no-conversion
-                                         :command final-command :sentinel sentinel :stderr name :noquery t))
+                                         :command final-command :sentinel sentinel :stderr (format "*%s::stderr*" name) :noquery t))
                      (tcp-proc (lsp--open-network-stream host port (concat name "::tcp"))))
 
                 ;; TODO: Same :noquery issue (see above)


### PR DESCRIPTION
Right now when server uses TCP transport (eg, erlang_ls), we launch a server process and this creates a new buffer for process's stderr with the name of the language server (eg, `erlang-ls`).

But "stdio" transport uses "*${name}::stderr*" template for subprocess stderr output.

I think it's better fit, because, according to https://www.emacswiki.org/emacs/Buffer, buffers that are not associated with files are usually have names enclosed with asterisks.

With this PR both stderr buffers for both TCP and stdio transports will look uniform.