### PR TITLE
bug: just use symbol prefix and trigger characters for completions

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4277,15 +4277,9 @@ Also, additional data to attached to each candidate can be passed via PLIST."
        :company-require-match 'never
        :company-prefix-length
        (save-excursion
-         (or (and (eq bounds-start (point))
-                  (- bounds-start
-                     (-if-let* ((bol (point-at-bol))
-                                (w-point (re-search-backward (rx whitespace) bol 'noerror)))
-                         (+ 1 w-point)
-                       bol)))
-             (and (goto-char bounds-start)
-                  (lsp--looking-back-trigger-characters-p trigger-chars)
-                  t)))
+         (and (goto-char bounds-start)
+              (lsp--looking-back-trigger-characters-p trigger-chars)
+              t))
        :company-match #'lsp--capf-company-match
        :company-doc-buffer (-compose #'company-doc-buffer
                                      #'lsp--capf-get-documentation)


### PR DESCRIPTION
This should fix #1536 
We revert back to using symbol boundary prefix and trigger characters to trigger completion request.