### PR TITLE
Remember current buffer on lsp--document-links

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2879,6 +2879,11 @@ If NO-MERGE is non-nil, don't merge the results but return alist workspace->resu
                                            local))
                                         hooks)))
                               (remhash cancel-token lsp--cancelable-requests)))
+             (callback (pcase mode
+                         ((or 'alive 'tick) (lambda (&rest args)
+                                              (with-current-buffer buf
+                                                (apply callback args))))
+                         (_ callback)))
              (callback (lsp--create-async-callback callback
                                                    method
                                                    no-merge


### PR DESCRIPTION
The way `lsp--document-links` is currently implemented, it may accidentally generate link highlights in the wrong buffer. This PR should fix that issue by remembering the current buffer and switching back to it once the async request gets resolved