### PR TITLE
Fix npm instructions in documentation

### DIFF
--- a/lsp-elm.el
+++ b/lsp-elm.el
@@ -34,7 +34,7 @@
 (defcustom lsp-elm-elm-language-server-path
   "elm-language-server"
   "Path for elm-language-server.
-Can be installed globally with npm -i -g @elm-tooling/elm-language-server,
+Can be installed globally with: npm i -g @elm-tooling/elm-language-server,
 or manually by cloning the repo and following the installing instructions."
   :group 'lsp-elm
   :risky t


### PR DESCRIPTION
installing with npm is done with `npm i` or `npm install` (not `npm -i`)