### PR TITLE
[lsp-dart] Add more variables to initializationOptions

### DIFF
--- a/lsp-dart.el
+++ b/lsp-dart.el
@@ -94,20 +94,21 @@ PARAMS closing labels notification data sent from WORKSPACE."
   (-let* (((&hash "uri" "labels") params)
           (buffer (lsp--buffer-for-file (lsp--uri-to-path uri))))
     (remove-overlays (point-min) (point-max) 'lsp-dart-closing-labels t)
-    (seq-doseq (label-ht labels)
-      (save-excursion
-        (-let* ((label (gethash "label" label-ht))
-                (range (gethash "range" label-ht))
-                ((beg . end) (lsp--range-to-region range))
-                (end-line (progn
-                            (goto-char end)
-                            (line-end-position)))
-                (overlay (make-overlay beg end-line buffer)))
-          (overlay-put overlay 'lsp-dart-closing-labels t)
-          (overlay-put overlay 'after-string (propertize (concat lsp-dart-closing-labels-prefix " " label)
-                                                         'display `((height ,lsp-dart-closing-labels-size))
-                                                         'cursor t
-                                                         'font-lock-face 'font-lock-comment-face)))))))
+    (when buffer
+      (seq-doseq (label-ht labels)
+        (save-excursion
+          (-let* ((label (gethash "label" label-ht))
+                  (range (gethash "range" label-ht))
+                  ((beg . end) (lsp--range-to-region range))
+                  (end-line (progn
+                              (goto-char end)
+                              (line-end-position)))
+                  (overlay (make-overlay beg end-line buffer)))
+            (overlay-put overlay 'lsp-dart-closing-labels t)
+            (overlay-put overlay 'after-string (propertize (concat lsp-dart-closing-labels-prefix " " label)
+                                                           'display `((height ,lsp-dart-closing-labels-size))
+                                                           'cursor t
+                                                           'font-lock-face 'font-lock-comment-face))))))))
 
 (lsp-register-client
  (make-lsp-client :new-connection

--- a/lsp-dart.el
+++ b/lsp-dart.el
@@ -105,6 +105,7 @@ PARAMS closing labels notification data sent from WORKSPACE."
           (overlay-put overlay 'lsp-dart-closing-labels t)
           (overlay-put overlay 'after-string (propertize (concat lsp-dart-closing-labels-prefix " " label)
                                                          'display `((height ,lsp-dart-closing-labels-size))
+                                                         'cursor t
                                                          'font-lock-face 'font-lock-comment-face)))))))
 
 (lsp-register-client

--- a/lsp-dart.el
+++ b/lsp-dart.el
@@ -57,6 +57,27 @@ imported into the current file. Defaults to true"
   :group 'lsp-dart
   :package-version '(lsp-mode . "6.2"))
 
+(defcustom lsp-dart-closing-labels nil
+  "When set to non-nil, dart/textDocument/publishClosingLabel notifications will
+be sent with information to render editor closing labels. Defaults to nil"
+  :type 'boolean
+  :group 'lsp-dart
+  :package-version '(lsp-mode . "6.2"))
+
+(defcustom lsp-dart-outline nil
+  "When set to non-nil, dart/textDocument/publishOutline notifications will be
+sent with outline information for open files. Defaults to nil"
+  :type 'boolean
+  :group 'lsp-dart
+  :package-version '(lsp-mode . "6.2"))
+
+(defcustom lsp-dart-flutter-outline nil
+  "When set to non-nil, dart/textDocument/publishFlutterOutline notifications will
+be sent with Flutter outline information for open files. Defaults to nil"
+  :type 'boolean
+  :group 'lsp-dart
+  :package-version '(lsp-mode . "6.2"))
+
 (defun lsp-dart--server-command ()
   "Generate LSP startup command."
   (or
@@ -73,7 +94,10 @@ imported into the current file. Defaults to true"
                   :priority -1
                   :initialization-options
                   `((onlyAnalyzeProjectsWithOpenFiles . ,lsp-dart-only-analyze-projects-with-open-files)
-                    (suggestFromUnimportedLibraries . ,lsp-dart-suggest-from-unimported-libraries))
+                    (suggestFromUnimportedLibraries . ,lsp-dart-suggest-from-unimported-libraries)
+                    (closingLabels . ,lsp-dart-closing-labels)
+                    (outline . ,lsp-dart-outline)
+                    (flutterOutline . ,lsp-dart-flutter-outline))
                   :server-id 'dart_analysis_server))
 
 (provide 'lsp-dart)

--- a/lsp-dart.el
+++ b/lsp-dart.el
@@ -93,22 +93,23 @@ Defaults to 0.9"
 PARAMS closing labels notification data sent from WORKSPACE."
   (-let* (((&hash "uri" "labels") params)
           (buffer (lsp--buffer-for-file (lsp--uri-to-path uri))))
-    (remove-overlays (point-min) (point-max) 'lsp-dart-closing-labels t)
     (when buffer
-      (seq-doseq (label-ht labels)
-        (save-excursion
-          (-let* ((label (gethash "label" label-ht))
-                  (range (gethash "range" label-ht))
-                  ((beg . end) (lsp--range-to-region range))
-                  (end-line (progn
-                              (goto-char end)
-                              (line-end-position)))
-                  (overlay (make-overlay beg end-line buffer)))
-            (overlay-put overlay 'lsp-dart-closing-labels t)
-            (overlay-put overlay 'after-string (propertize (concat lsp-dart-closing-labels-prefix " " label)
-                                                           'display `((height ,lsp-dart-closing-labels-size))
-                                                           'cursor t
-                                                           'font-lock-face 'font-lock-comment-face))))))))
+      (with-current-buffer buffer
+        (remove-overlays (point-min) (point-max) 'lsp-dart-closing-labels t)
+        (seq-doseq (label-ht labels)
+          (save-excursion
+            (-let* ((label (gethash "label" label-ht))
+                    (range (gethash "range" label-ht))
+                    ((beg . end) (lsp--range-to-region range))
+                    (end-line (progn
+                                (goto-char end)
+                                (line-end-position)))
+                    (overlay (make-overlay beg end-line buffer)))
+              (overlay-put overlay 'lsp-dart-closing-labels t)
+              (overlay-put overlay 'after-string (propertize (concat lsp-dart-closing-labels-prefix " " label)
+                                                             'display `((height ,lsp-dart-closing-labels-size))
+                                                             'cursor t
+                                                             'font-lock-face 'font-lock-comment-face)))))))))
 
 (lsp-register-client
  (make-lsp-client :new-connection

--- a/lsp-dart.el
+++ b/lsp-dart.el
@@ -92,7 +92,7 @@ Defaults to 0.9"
   "Closing labels notification handling.
 PARAMS closing labels notification data sent from WORKSPACE."
   (-let* (((&hash "uri" "labels") params)
-          (buffer (get-file-buffer (string-remove-prefix "file://" uri))))
+          (buffer (lsp--buffer-for-file (lsp--uri-to-path uri))))
     (remove-overlays (point-min) (point-max) 'lsp-dart-closing-labels t)
     (seq-doseq (label-ht labels)
       (save-excursion

--- a/lsp-dart.el
+++ b/lsp-dart.el
@@ -91,7 +91,8 @@ Defaults to 0.9"
 (defun lsp-dart--handle-closing-labels (_workspace params)
   "Closing labels notification handling.
 PARAMS closing labels notification data sent from WORKSPACE."
-  (-let (((&hash "labels") params))
+  (-let* (((&hash "uri" "labels") params)
+          (buffer (get-file-buffer (string-remove-prefix "file://" uri))))
     (remove-overlays (point-min) (point-max) 'lsp-dart-closing-labels t)
     (seq-doseq (label-ht labels)
       (save-excursion
@@ -101,7 +102,7 @@ PARAMS closing labels notification data sent from WORKSPACE."
                 (end-line (progn
                             (goto-char end)
                             (line-end-position)))
-                (overlay (make-overlay beg end-line)))
+                (overlay (make-overlay beg end-line buffer)))
           (overlay-put overlay 'lsp-dart-closing-labels t)
           (overlay-put overlay 'after-string (propertize (concat lsp-dart-closing-labels-prefix " " label)
                                                          'display `((height ,lsp-dart-closing-labels-size))

--- a/lsp-dart.el
+++ b/lsp-dart.el
@@ -24,6 +24,8 @@
 
 ;;; Code:
 
+(require 'ht)
+
 (defgroup lsp-dart nil
   "LSP support for Dart, using dart analysis server."
   :group 'lsp-mode
@@ -57,26 +59,26 @@ imported into the current file. Defaults to true"
   :group 'lsp-dart
   :package-version '(lsp-mode . "6.2"))
 
-(defcustom lsp-dart-closing-labels nil
+(defcustom lsp-dart-closing-labels t
   "When set to non-nil, dart/textDocument/publishClosingLabel notifications will
 be sent with information to render editor closing labels. Defaults to nil"
   :type 'boolean
   :group 'lsp-dart
-  :package-version '(lsp-mode . "6.2"))
+  :package-version '(lsp-mode . "6.3"))
 
-(defcustom lsp-dart-outline nil
-  "When set to non-nil, dart/textDocument/publishOutline notifications will be
-sent with outline information for open files. Defaults to nil"
-  :type 'boolean
+(defcustom lsp-dart-closing-labels-prefix " "
+  "The prefix string to be concatened with the closing label.
+Defaults to a single space"
+  :type 'string
   :group 'lsp-dart
-  :package-version '(lsp-mode . "6.2"))
+  :package-version '(lsp-mode . "6.3"))
 
-(defcustom lsp-dart-flutter-outline nil
-  "When set to non-nil, dart/textDocument/publishFlutterOutline notifications will
-be sent with Flutter outline information for open files. Defaults to nil"
-  :type 'boolean
+(defcustom lsp-dart-closing-labels-size 0.9
+  "The font size factor to be multiplied by the closing labels font size.
+Defaults to 0.9"
+  :type 'float
   :group 'lsp-dart
-  :package-version '(lsp-mode . "6.2"))
+  :package-version '(lsp-mode . "6.3"))
 
 (defun lsp-dart--server-command ()
   "Generate LSP startup command."
@@ -85,6 +87,25 @@ be sent with Flutter outline information for open files. Defaults to nil"
    `(,(expand-file-name (f-join lsp-dart-sdk-dir "bin/dart"))
      ,(expand-file-name (f-join lsp-dart-sdk-dir "bin/snapshots/analysis_server.dart.snapshot"))
      "--lsp")))
+
+(defun lsp-dart--handle-closing-labels (_workspace params)
+  "Closing labels notification handling.
+PARAMS closing labels notification data sent from WORKSPACE."
+  (-let (((&hash "labels") params))
+    (remove-overlays (point-min) (point-max) 'lsp-dart-closing-labels t)
+    (seq-doseq (label-ht labels)
+      (save-excursion
+        (-let* ((label (gethash "label" label-ht))
+                (range (gethash "range" label-ht))
+                ((beg . end) (lsp--range-to-region range))
+                (end-line (progn
+                            (goto-char end)
+                            (line-end-position)))
+                (overlay (make-overlay beg end-line)))
+          (overlay-put overlay 'lsp-dart-closing-labels t)
+          (overlay-put overlay 'after-string (propertize (concat lsp-dart-closing-labels-prefix " " label)
+                                                         'display `((height ,lsp-dart-closing-labels-size))
+                                                         'font-lock-face 'font-lock-comment-face)))))))
 
 (lsp-register-client
  (make-lsp-client :new-connection
@@ -95,9 +116,8 @@ be sent with Flutter outline information for open files. Defaults to nil"
                   :initialization-options
                   `((onlyAnalyzeProjectsWithOpenFiles . ,lsp-dart-only-analyze-projects-with-open-files)
                     (suggestFromUnimportedLibraries . ,lsp-dart-suggest-from-unimported-libraries)
-                    (closingLabels . ,lsp-dart-closing-labels)
-                    (outline . ,lsp-dart-outline)
-                    (flutterOutline . ,lsp-dart-flutter-outline))
+                    (closingLabels . ,lsp-dart-closing-labels))
+                  :notification-handlers (ht ("dart/textDocument/publishClosingLabels" 'lsp-dart--handle-closing-labels))
                   :server-id 'dart_analysis_server))
 
 (provide 'lsp-dart)


### PR DESCRIPTION
Add support for the [closingLabels initializationOptions](https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md#initialization-options).
![image](https://user-images.githubusercontent.com/7820865/78463995-5927da00-76ba-11ea-8816-7c6d33f08a4f.png)


Fixes #https://github.com/emacs-lsp/lsp-mode/issues/1560