### PR TITLE
Add vls config `dev` and `experimental`

### DIFF
--- a/lsp-vetur.el
+++ b/lsp-vetur.el
@@ -205,6 +205,32 @@ TypeScript."
   :group 'lsp-vetur
   :package-version '(lsp-mode . "6.1"))
 
+(defcustom lsp-vetur-dev-vls-path ""
+  "The vls path for development"
+  :type 'string
+  :group 'lsp-vetur
+  :package-version '(lsp-mode . "6.1"))
+
+(defcustom lsp-vetur-dev-vls-port -1
+  "The vls port for development"
+  :type 'integer
+  :group 'lsp-vetur
+  :package-version '(lsp-mode . "6.1"))
+
+(defcustom lsp-vetur-dev-log-level "INFO"
+  "The vls log level for development"
+  :type '(choice
+          (const "INFO")
+          (const "DEBUG"))
+  :group 'lsp-vetur
+  :package-version '(lsp-mode . "6.1"))
+
+(defcustom lsp-vetur-experimental-template-interpolation-service nil
+  "Whether to have template interpolation service"
+  :type 'boolean
+  :group 'lsp-vetur
+  :package-version '(lsp-mode . "6.1"))
+
 (defcustom lsp-typescript-tsdk nil
   "Specifies the folder path containing the tsserver and
 lib*.d.ts files to use."
@@ -773,6 +799,10 @@ Code's JavaScript and TypeScript support."
    ("vetur.completion.useScaffoldSnippets" lsp-vetur-completion-use-scaffold-snippets t)
    ("vetur.completion.autoImport" lsp-vetur-completion-auto-import t)
    ("vetur.useWorkspaceDependencies" lsp-vetur-use-workspace-dependencies t)
+   ("vetur.dev.vlsPath" lsp-vetur-dev-vls-path)
+   ("vetur.dev.vlsPort" lsp-vetur-dev-vls-port)
+   ("vetur.dev.logLevel" lsp-vetur-dev-log-level)
+   ("vetur.experimental.templateInterpolationService" lsp-vetur-experimental-template-interpolation-service nil)
    ("emmet.showExpandedAbbreviation" lsp-vetur-emmet)))
 
 (define-obsolete-variable-alias

--- a/lsp-vetur.el
+++ b/lsp-vetur.el
@@ -209,13 +209,13 @@ TypeScript."
   "The vls path for development"
   :type 'string
   :group 'lsp-vetur
-  :package-version '(lsp-mode . "6.1"))
+  :package-version '(lsp-mode . "6.3"))
 
 (defcustom lsp-vetur-dev-vls-port -1
   "The vls port for development"
   :type 'integer
   :group 'lsp-vetur
-  :package-version '(lsp-mode . "6.1"))
+  :package-version '(lsp-mode . "6.3"))
 
 (defcustom lsp-vetur-dev-log-level "INFO"
   "The vls log level for development"
@@ -223,13 +223,13 @@ TypeScript."
           (const "INFO")
           (const "DEBUG"))
   :group 'lsp-vetur
-  :package-version '(lsp-mode . "6.1"))
+  :package-version '(lsp-mode . "6.3"))
 
 (defcustom lsp-vetur-experimental-template-interpolation-service nil
   "Whether to have template interpolation service"
   :type 'boolean
   :group 'lsp-vetur
-  :package-version '(lsp-mode . "6.1"))
+  :package-version '(lsp-mode . "6.3"))
 
 (defcustom lsp-typescript-tsdk nil
   "Specifies the folder path containing the tsserver and


### PR DESCRIPTION
Add all vetur configuration.
In my environment without `vetur.dev` configuration following error occurs when opening `.vue` file.

```
(node:27908) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'logLevel' of undefined
    at VLS.configure (/home/itome/.nvm/versions/node/v12.13.1/lib/node_modules/vls/dist/services/vls.js:164:48)
    at VLS.<anonymous> (/home/itome/.nvm/versions/node/v12.13.1/lib/node_modules/vls/dist/services/vls.js:77:18)
    at Generator.next (<anonymous>)
    at /home/itome/.nvm/versions/node/v12.13.1/lib/node_modules/vls/dist/services/vls.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/home/itome/.nvm/versions/node/v12.13.1/lib/node_modules/vls/dist/services/vls.js:4:12)
    at /home/itome/.nvm/versions/node/v12.13.1/lib/node_modules/vls/dist/services/vls.js:76:71
    at handleNotification (/home/itome/.nvm/versions/node/v12.13.1/lib/node_modules/vls/node_modules/vscode-jsonrpc/lib/main.js:502:43)
    at processMessageQueue (/home/itome/.nvm/versions/node/v12.13.1/lib/node_modules/vls/node_modules/vscode-jsonrpc/lib/main.js:273:17)
    at Immediate.<anonymous> (/home/itome/.nvm/versions/node/v12.13.1/lib/node_modules/vls/node_modules/vscode-jsonrpc/lib/main.js:260:13)

```

This PR fixes it.