### PR TITLE
lsp-solargraph: use bundler per project

### DIFF
--- a/lsp-solargraph.el
+++ b/lsp-solargraph.el
@@ -115,6 +115,13 @@
   :group 'lsp-solargraph
   :package-version '(lsp-mode . "6.3"))
 
+(defun lsp-solargraph--build-command ()
+  "Build solargraph command"
+  (let ((lsp-command '("solargraph" "stdio")))
+    (if lsp-solargraph-use-bundler
+              (append '("bundle" "exec") lsp-command)
+            lsp-command)))
+
 (lsp-register-custom-settings
  '(("solargraph.logLevel" lsp-solargraph-log-level)
    ("solargraph.folding" lsp-solargraph-folding t)
@@ -131,20 +138,17 @@
 
 ;; Ruby
 (lsp-register-client
- (let ((lsp-command '("solargraph" "stdio")))
-   (make-lsp-client
-    :new-connection (lsp-stdio-connection
-                     (if lsp-solargraph-use-bundler
-                         (append '("bundle" "exec") lsp-command)
-                       lsp-command))
-    :major-modes '(ruby-mode enh-ruby-mode)
-    :priority -1
-    :multi-root lsp-solargraph-multi-root
-    :server-id 'ruby-ls
-    :initialized-fn (lambda (workspace)
-                      (with-lsp-workspace workspace
-                        (lsp--set-configuration
-                         (lsp-configuration-section "solargraph")))))))
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection
+                   #'lsp-solargraph--build-command)
+  :major-modes '(ruby-mode enh-ruby-mode)
+  :priority -1
+  :multi-root lsp-solargraph-multi-root
+  :server-id 'ruby-ls
+  :initialized-fn (lambda (workspace)
+                    (with-lsp-workspace workspace
+                      (lsp--set-configuration
+                       (lsp-configuration-section "solargraph"))))))
 
 (provide 'lsp-solargraph)
 ;;; lsp-solargraph.el ends here

--- a/lsp-solargraph.el
+++ b/lsp-solargraph.el
@@ -112,6 +112,7 @@
 (defcustom lsp-solargraph-multi-root t
   "If non nil, `solargraph' will be started in multi-root mode."
   :type 'boolean
+  :safe #'booleanp
   :group 'lsp-solargraph
   :package-version '(lsp-mode . "6.3"))
 


### PR DESCRIPTION
This is a follow up to [this discussion](https://www.reddit.com/r/emacs/comments/g2ayzc/lspmode_and_ruby/fnn6ike/).

I would like to be able to use lsp-solargraph with bundler on a per-project basis, e.g. via a dir-locals file.

This PR extracts the solargraph launch command building into a separate function so that overriding `lsp-solargraph-use-bundler` can take effect.

In addition it sets `lsp-solargraph-use-bundler` to "safe" if it is a boolean. I don't think this should be a security risk, but I also note that almost no `lsp-*` variables are marked as "safe" so if it's against policy then please let me know.

Also I don't know how this does or should affect the value of `"solargraph.useBundler"` passed to `lsp-register-custom-settings`. In my testing things worked fine, despite this value being potentially out of sync depending on the project.