### PR TITLE
Setting to disable adding company-lsp automatically

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -275,6 +275,13 @@ links, and so on. For finer granularity you may use `lsp-enable-*' properties."
   :type 'boolean
   :package-version '(lsp-mode . "6.1"))
 
+(defcustom lsp-auto-configure-company-backends t
+  "When auto-configuring `lsp-mode', 
+  `company-lsp' is pushed at the top of the `company-backends'.
+  If that is not desirable, set this variable to nil"
+  :group 'lsp-mode
+  :type 'boolean)
+
 (defcustom lsp-disabled-clients nil
   "A list of disabled/blacklisted clients.
 Each entry in the list can be either:
@@ -6522,7 +6529,8 @@ returns the command to execute."
          (not lsp-prefer-capf))
     (progn
       (company-mode 1)
-      (add-to-list 'company-backends 'company-lsp)
+      (when lsp-auto-configure-company-backends
+        (add-to-list 'company-backends 'company-lsp))
       (setq-local company-backends (remove 'company-capf company-backends))))
 
    ((and (fboundp 'company-mode))


### PR DESCRIPTION
Hello,

I was trying to setup company-backends to have a merged list for simplicity as I use few backends. For clarity and as an example, I want to keep my backends set up like so:

```lisp
(setq company-backends '((company-lsp company-keywords company-yasnippet company-files)
                         company-dabbrev))
```

When trying to set it up, I kept having `company-lsp` pushed at the top of `company-backends` whenever lsp was activated.

After a long time going through people's configurations I finally set to read _lsp-mode.el_, and I found that line:

https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-mode.el#L6525

Locally commenting it out proved that it was the culprit.

I then naturally set out to disable that line, browsing for lsp options. But there is no option to do so.

Hence this PR :)