### PR TITLE
Protect against a missing progress reporter

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1536,8 +1536,8 @@ WORKSPACE is the workspace that contains the progress token."
        ("end"
         (let ((reporter (lsp-workspace-get-work-done-token token workspace)))
           (when reporter
-            ((progress-reporter-done reporter)
-             (lsp-workspace-rem-work-done-token token workspace))))))))
+            (progn (progress-reporter-done reporter)
+                   (lsp-workspace-rem-work-done-token token workspace))))))))
 
 (defun lsp-diagnostics (&optional current-workspace?)
   "Return the diagnostics from all workspaces."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1530,12 +1530,14 @@ WORKSPACE is the workspace that contains the progress token."
 
        ("report"
         (let ((reporter (lsp-workspace-get-work-done-token token workspace)))
-          (progress-reporter-update reporter (gethash "percentage" value nil))))
+          (when reporter
+            (progress-reporter-update reporter (gethash "percentage" value nil)))))
 
        ("end"
         (let ((reporter (lsp-workspace-get-work-done-token token workspace)))
-          (progress-reporter-done reporter)
-          (lsp-workspace-rem-work-done-token token workspace))))))
+          (when reporter
+            ((progress-reporter-done reporter)
+             (lsp-workspace-rem-work-done-token token workspace))))))))
 
 (defun lsp-diagnostics (&optional current-workspace?)
   "Return the diagnostics from all workspaces."


### PR DESCRIPTION
If we receive unexpected progress messages, make sure we actually have
a progress reporter before using it.

Closes #1601