### PR TITLE
Display the first line of MarkupContent in eldoc

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4719,7 +4719,7 @@ RENDER-ALL - nil if only the signature should be rendered."
     ;; It tends to be long and is not suitable to display fully in the echo area.
     ;; Just display the first line which is typically the signature.
     (let ((rendered (lsp--render-element contents)))
-      (if render-all rendered (car (split-string rendered "\n")))))
+      (if render-all rendered (car (s-lines rendered)))))
    ((and (stringp contents) (not (string-match-p "\n" contents)))
     ;; If the contents is a single string containing a single line,
     ;; render it always.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4715,9 +4715,11 @@ CONTENTS  - MarkedString | MarkedString[] | MarkupContent
 RENDER-ALL - nil if only the signature should be rendered."
   (cond
    ((and (hash-table-p contents) (gethash "kind" contents))
-    ;; MarkupContent, deprecated by LSP but actually very flexible.
-    ;; It tends to be long and is not suitable in echo area.
-    (if render-all (lsp--render-element contents) ""))
+    ;; MarkupContent.
+    ;; It tends to be long and is not suitable to display fully in the echo area.
+    ;; Just display the first line which is typically the signature.
+    (let ((rendered (lsp--render-element contents)))
+      (if render-all rendered (car (split-string rendered "\n")))))
    ((and (stringp contents) (not (string-match-p "\n" contents)))
     ;; If the contents is a single string containing a single line,
     ;; render it always.


### PR DESCRIPTION
Many LSP servers, like gopls, return `document/onHover` as
MarkupContent. This modifies the eldoc behavior to support MarkupContent
by displaying the first rendered line. As the majority of LSP servers
return the signature, this will display the signature as most people expect.

In the future, https://github.com/microsoft/language-server-protocol/issues/772 should make this more reliable.