### PR TITLE
Display image on lsp--render-string.

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4662,7 +4662,7 @@ Stolen from `org-copy-visible'."
 (defvar lsp--display-inline-image-alist
   '((lsp--render-markdown
      (:regexp
-      "!\\[.*?\\](data:image/png;base64,\\([A-Za-z0-9+/\n]+?=*?\\)\\(|[^)]+\\)?)"
+      "!\\[.*?\\](data:image/[a-zA-Z]+;base64,\\([A-Za-z0-9+/\n]+?=*?\\)\\(|[^)]+\\)?)"
       :sexp
       (create-image
        (base64-decode-string

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4689,10 +4689,16 @@ Inaddition, Each can have property:
                  If omitted, interpreted as index 0.
 ")
 
+(defcustom lsp-display-inline-image t
+  "Showing inline image or not.
+If nil, inline image are displayed as link."
+  :group 'lsp-mode
+  :type 'boolean)
+
 (defun lsp--display-inline-image (mode)
   "Add image property if available."
-    (when (display-images-p)
   (let ((plist-list (cdr (assq mode lsp--display-inline-image-alist))))
+    (when (and (display-images-p) lsp-display-inline-image)
       (cl-loop
        for plist in plist-list
        with regexp with replaced-index

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4690,8 +4690,7 @@ In addition, each can have property:
 ")
 
 (defcustom lsp-display-inline-image t
-  "Showing inline image or not.
-If nil, inline image are displayed as link."
+  "Showing inline image or not."
   :group 'lsp-mode
   :type 'boolean)
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4683,7 +4683,7 @@ Each PROPERTY-LIST should have properties:
 :sexp    Return image when evaluated. You can use infomation of regexp
          by using (match-beggining N), (match-end N) or (match-substring N).
 
-Inaddition, Each can have property:
+In addition, each can have property:
 :replaced-index  Determine index which is used to replace regexp to image.
                  The value means first argument of `match-beggining' and `match-end'.
                  If omitted, interpreted as index 0.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4659,6 +4659,59 @@ Stolen from `org-copy-visible'."
 
     (lsp--setup-markdown major-mode)))
 
+(defvar lsp--display-image-alist
+  '((lsp--render-markdown
+     (:regexp
+      "!\\[.*?\\](data:image/png;base64,\\([A-Za-z0-9+/\n]+?=*?\\)\\(|[^)]+\\)?)"
+      :sexp
+      (create-image
+       (base64-decode-string
+        (buffer-substring-no-properties (match-beginning 1) (match-end 1)))
+       nil t))))
+  "Replaced string regexp and function returning image.
+Each element should be:
+(MODE . (PROPERTY-LIST...))
+MODE (car) is function which is defined in `lsp-language-id-configuration'.
+Cdr should be list of PROPERTY-LIST.
+
+Each PROPERTY-LIST should have properties:
+:regexp  Regexp which determines what string is relpaced to image.
+         You should also get infomation of image, by parenthesis constructs.
+         By deafult, all matched string is replaced to image, but you can change
+         index of replaced string by keyword :replaced-index.
+
+:sexp    Return image when evaluated. You can use infomation of regexp
+         by using (match-beggining N), (match-end N) or (match-substring N).
+
+Inaddition, Each can have property:
+:replaced-index  Determine index which is used to replace regexp to image.
+                 The value means first argument of `match-beggining' and `match-end'.
+                 If omitted, interpreted as index 0.
+")
+
+(defun lsp--display-image (mode)
+  "Add image property if available."
+  (let ((plist-list (cdr (assq mode lsp--display-image-alist))))
+    (when (display-images-p)
+      (cl-loop
+       for plist in plist-list
+       with regexp with replaced-index
+       do
+       (setq regexp (plist-get plist :regexp))
+       (setq replaced-index (or (plist-get plist :replaced-index) 0))
+
+       (font-lock-remove-keywords nil (list regexp replaced-index))
+       (let ((inhibit-read-only t))
+         (save-excursion
+           (goto-char (point-min))
+           (while (re-search-forward regexp nil t)
+             (set-text-properties
+              (match-beginning replaced-index) (match-end replaced-index)
+              nil)
+             (add-text-properties
+              (match-beginning replaced-index) (match-end replaced-index)
+              `(display ,(eval (plist-get plist :sexp)))))))))))
+
 (defun lsp--fontlock-with-mode (str mode)
   "Fontlock STR with MODE."
   (condition-case nil
@@ -4666,7 +4719,8 @@ Stolen from `org-copy-visible'."
         (insert str)
         (delay-mode-hooks (funcall mode))
         (cl-flet ((window-body-width () lsp-window-body-width))
-          (font-lock-ensure))
+          (font-lock-ensure)
+          (lsp--display-image mode))
         (lsp--buffer-string-visible))
     (error str)))
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4659,7 +4659,7 @@ Stolen from `org-copy-visible'."
 
     (lsp--setup-markdown major-mode)))
 
-(defvar lsp--display-image-alist
+(defvar lsp--display-inline-image-alist
   '((lsp--render-markdown
      (:regexp
       "!\\[.*?\\](data:image/png;base64,\\([A-Za-z0-9+/\n]+?=*?\\)\\(|[^)]+\\)?)"
@@ -4689,10 +4689,10 @@ Inaddition, Each can have property:
                  If omitted, interpreted as index 0.
 ")
 
-(defun lsp--display-image (mode)
+(defun lsp--display-inline-image (mode)
   "Add image property if available."
-  (let ((plist-list (cdr (assq mode lsp--display-image-alist))))
     (when (display-images-p)
+  (let ((plist-list (cdr (assq mode lsp--display-inline-image-alist))))
       (cl-loop
        for plist in plist-list
        with regexp with replaced-index
@@ -4720,7 +4720,7 @@ Inaddition, Each can have property:
         (delay-mode-hooks (funcall mode))
         (cl-flet ((window-body-width () lsp-window-body-width))
           (font-lock-ensure)
-          (lsp--display-image mode))
+          (lsp--display-inline-image mode))
         (lsp--buffer-string-visible))
     (error str)))
 


### PR DESCRIPTION
Hi! Thanks for awesome package!

By this commit, base64 png in markdown are displayed.
In addition, anyone can add image displayer by adding list to `lsp--display-image-alist`.

For example, on my package [lsp-latex](https://github.com/ROCKTAKEY/lsp-latex), document showed by lsp-ui-doc is improved like below.

I hesitated over whether I deal with this in lsp-latex or lsp-mode, but displaying image can be used on all lsp-client, so I made this PR. 

Origin is this [issue](https://github.com/ROCKTAKEY/lsp-latex/issues/9).

Thanks!

# example
before:
![before](https://user-images.githubusercontent.com/20369462/80275191-93fdba80-871a-11ea-8e14-faa4c641f0bd.PNG)
after:
![after](https://user-images.githubusercontent.com/20369462/80275195-9e1fb900-871a-11ea-8257-e7d17d8e1c83.PNG)
