### PR TITLE
Add some missing markdown escapes

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4612,6 +4612,7 @@ MODE is the mode used in the parent frame."
   (push '("&lt;" . ?<) prettify-symbols-alist)
   (push '("&gt;" . ?>) prettify-symbols-alist)
   (push '("&amp;" . ?&) prettify-symbols-alist)
+  (push '("&nbsp;" . ? ) prettify-symbols-alist)
   (setq prettify-symbols-compose-predicate
         (lambda (_start _end _match) t))
   (prettify-symbols-mode 1))
@@ -4646,7 +4647,7 @@ Stolen from `org-copy-visible'."
 
     (goto-char (point-min))
     (while (re-search-forward
-            (rx (and "\\" (group (or "\\" "`" "*" "_"
+            (rx (and "\\" (group (or "\\" "`" "*" "_" ":" "/"
                                      "{" "}" "[" "]" "(" ")"
                                      "#" "+" "-" "." "!" "|"))))
             nil t)


### PR DESCRIPTION
These show up a lot in gopls MarkupContent.

This is what gopls `FullDocumentation` currently renders as:

![image](https://user-images.githubusercontent.com/522123/80286391-138f8780-8723-11ea-8993-72bb437c1397.png)

After this change:

![image](https://user-images.githubusercontent.com/522123/80286423-46d21680-8723-11ea-8042-e0aa779c2af1.png)
