### PR TITLE
Change docs output

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,7 +4,7 @@ output-dir:
 	mkdir -p output
 
 doc-html: output-dir
-	asciidoctor --safe -b html5 -B ./src/ -D output -o lsp-mode.html ./src/lsp-mode.adoc
+	asciidoctor --safe -b html5 -B ./src/ -D output -o index.html ./src/lsp-mode.adoc
 	cp ./src/output/* ./output/
 
 doc-pdf: output-dir


### PR DESCRIPTION
Change the output of `asciidoctor` to achieve a GitHub pages of https://emacs-lsp.github.io/lsp-mode instead of https://emacs-lsp.github.io/lsp-mode/lsp-mode.html