### PR TITLE
Show function prototype in the echo area when Clangd is active

### DIFF
--- a/test/lsp-clients-test.el
+++ b/test/lsp-clients-test.el
@@ -93,4 +93,32 @@
   (should (not (lsp-typescript-javascript-tsx-jsx-activate-p "abc.tsxx")))
   (should (not (lsp-typescript-javascript-tsx-jsx-activate-p "abc.jss"))))
 
+(ert-deftest lsp-clients-extract-signature-from-clangd-on-hover ()
+  (should (string= (lsp-clients-extract-signature-on-hover
+                         #s(hash-table size 30 test equal data ("value" "Sample\n ```cpp\n// In Function.hpp\nvoid function(int n);\n```")) 'clangd) "void function(int n);"))
+  (should (string= (lsp-clients-extract-signature-on-hover
+                         #s(hash-table size 30 test equal data ("value" "Sample\n ```cpp\nvoid function(int n);\n```")) 'clangd) "void function(int n);"))
+  (should (string= (lsp-clients-extract-signature-on-hover
+                         #s(hash-table size 30 test equal data ("value" "Sample\n ```cpp\n   void function(int n);\n```")) 'clangd) "void function(int n);"))
+  (should-error (lsp-clients-extract-signature-on-hover
+                 #s(hash-table size 30 test equal data ("value" "Wrong")) 'clangd)))
+
+(ert-deftest lsp-clients-join-region ()
+  (with-temp-buffer
+    (insert "void function(int n);")
+    (should (string= (lsp-join-region (point-min) (point-max)) "void function(int n);"))
+    (erase-buffer)
+    (insert "    void function(int n);")
+    (should (string= (lsp-join-region (point-min) (point-max)) "void function(int n);"))
+    (erase-buffer)
+    (insert "void foo(int n,
+                      int p,
+                      int k);")
+    (should (string= (lsp-join-region (point-min) (point-max)) "void foo(int n, int p, int k);"))
+    (erase-buffer)
+    (insert "void foo(int n,
+                  int p,
+                  int k);")
+    (should (string= (lsp-join-region (point-min) (point-max)) "void foo(int n, int p, int k);"))))
+
 ;;; lsp-clients-test.el ends here


### PR DESCRIPTION
Since https://github.com/emacs-lsp/lsp-mode/pull/1607, we show the first line of MarkupContent `onHover` in the echo area. For Clangd, in particular, the first line is not very representative.

This patch improves the experience using Clangd by extracting the part of the doc that corresponds to the type signature and showing that instead. The information is always condensed in one line to avoid the echo area growing uncomfortably.

This is in part a limitation of LSP and the protocol should offer this flexibility by default. Until the protocol is revised, I think it's OK we handle this client-side.

**Screenshots:**

Clangd showing the signature of a function from a call site:

<img width="741" alt="Screenshot 2020-05-02 at 1 10 16 AM" src="https://user-images.githubusercontent.com/1573717/80848258-f4a55f80-8c12-11ea-9fb8-dcf80b8a163f.png">

Clangd showing the type of an auto variable:

<img width="744" alt="Screenshot 2020-05-02 at 1 11 01 AM" src="https://user-images.githubusercontent.com/1573717/80848264-fa9b4080-8c12-11ea-830b-fdbeb50f7714.png">
