### PR TITLE
Case-insensitive completion for code actions

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4773,11 +4773,12 @@ When language is nil render as markup if `markdown-mode' is loaded."
    ((seq-empty-p actions) (signal 'lsp-no-code-actions nil))
    ((and (eq (seq-length actions) 1) lsp-auto-execute-action)
     (lsp-seq-first actions))
-   (t (lsp--completing-read "Select code action: "
-                            (seq-into actions 'list)
-                            (-lambda ((&hash "title" "command"))
-                              (or title command))
-                            nil t))))
+   (t (let ((completion-ignore-case t))
+        (lsp--completing-read "Select code action: "
+                              (seq-into actions 'list)
+                              (-lambda ((&hash "title" "command"))
+                                (or title command))
+                              nil t)))))
 
 (defun lsp--render-on-hover-content (contents render-all)
   "Render the content received from 'document/onHover' request.


### PR DESCRIPTION
Since code actions are not usually dependent on case, it would be more convenient to have their completion case-insensitive. If somehow there happen to be actions that differ only by case, `completing-read` would still allow the proper case to select the required action.