### PR TITLE
Change lsp-erlang-server-connection-type to symbol

### DIFF
--- a/lsp-erlang.el
+++ b/lsp-erlang.el
@@ -43,7 +43,7 @@
   "Type of connection to use with the Erlang Language Server: tcp or stdio"
   :group 'lsp-erlang
   :risky t
-  :type 'string)
+  :type 'symbol)
 
 (defun lsp-erlang-server-start-fun (port)
   `(,lsp-erlang-server-path


### PR DESCRIPTION
For customisation.

As reported at https://github.com/emacs-lsp/lsp-mode/pull/1166/files/54e5c310eb679ead539896e4751fe8ae875b1384#r419802972