### PR TITLE
lsp-capf: properly check for trigger-chars condition

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4192,7 +4192,7 @@ and the position respectively."
             (when-let (kind-name (and kind (aref lsp--completion-item-kind kind)))
               (format " (%s)" kind-name)))))
 
-(defun lsp--looking-back-trigger-characters-p (trigger-characters)
+(defun lsp--looking-back-trigger-characterp (trigger-characters)
   "Return trigger character if text before point matches any of the TRIGGER-CHARACTERS."
   (unless (= (point) (point-at-bol))
     (seq-some
@@ -4344,7 +4344,7 @@ Also, additional data to attached to each candidate can be passed via PLIST."
   "Get completion context with provided TRIGGER-CHARACTERS."
   (let* (trigger-char
          (trigger-kind (cond
-                        ((setq trigger-char (lsp--looking-back-trigger-characters-p
+                        ((setq trigger-char (lsp--looking-back-trigger-characterp
                                              trigger-characters))
                          'character)
                         ((equal lsp--capf-cache 'incomplete) 'incomplete)
@@ -4359,10 +4359,15 @@ Also, additional data to attached to each candidate can be passed via PLIST."
   (when (or (--some (lsp--client-completion-in-comments? (lsp--workspace-client it))
                     (lsp-workspaces))
             (not (nth 4 (syntax-ppss))))
-    (let* ((bounds-start (or (car (bounds-of-thing-at-point 'symbol)) (point)))
-           (trigger-chars (->> (lsp--server-capabilities)
+    (let* ((trigger-chars (->> (lsp--server-capabilities)
                                (gethash "completionProvider")
                                (gethash "triggerCharacters")))
+           (bounds-start (--> (or (car (bounds-of-thing-at-point 'symbol)) (point))
+                              (save-excursion
+                                (goto-char it)
+                                (if (lsp--looking-back-trigger-characterp trigger-chars)
+                                    (- it 1)
+                                  it))))
            result done?)
       (list
        bounds-start
@@ -4410,9 +4415,9 @@ Also, additional data to attached to each candidate can be passed via PLIST."
        :annotation-function #'lsp--annotate
        :company-require-match 'never
        :company-prefix-length
-       (save-excursion
-         (goto-char bounds-start)
-         (and (lsp--looking-back-trigger-characters-p trigger-chars) t))
+       (when (or lsp--capf-cache
+                 (lsp--looking-back-trigger-characterp trigger-chars))
+         t)
        :company-match #'lsp--capf-company-match
        :company-doc-buffer (-compose #'company-doc-buffer
                                      #'lsp--capf-get-documentation)
@@ -4453,7 +4458,7 @@ Also, additional data to attached to each candidate can be passed via PLIST."
 
          (setq-local lsp-inhibit-lsp-hooks nil)
 
-         (when (lsp--looking-back-trigger-characters-p trigger-chars)
+         (when (lsp--looking-back-trigger-characterp trigger-chars)
            (setq this-command 'self-insert-command)))))))
 
 (advice-add #'completion-at-point :before #'lsp--capf-clear-cache)


### PR DESCRIPTION
Up until now, we've detected if the trigger characters are there and continue to trigger the completion by:
- go to bound start (decided by `symbol` boundary)
- check if the previous char is trigger char.

This doesn't work well when the `symbol` boundary is also including the trigger character already.
This change is to mitigate that problem by:
- Only detect if previous character is trigger char, and will request completion list.
- If there's cache, that means we're still trying to complete a same symbol, thus continue to request for completions.
- Recalculate the boundary start point to include trigger character.

The first two changes ensure that once we detect the trigger character and still complete the same symbol, `company-mode` will continue to request for completions. Archive the same effect (minus bug) of the original approach.
The last change ensure that `company-mode` will not suddenly reset the cache due to boundaries are changed. Since the trigger character will trigger completion, it should be included in current symbol to prevent `company-mode` detecting different boundary start and then treat new completion as for different symbol with the one triggered by trigger character.