### PR TITLE
lsp-capf: should not include trigger char in boundary

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4362,12 +4362,13 @@ Also, additional data to attached to each candidate can be passed via PLIST."
     (let* ((trigger-chars (->> (lsp--server-capabilities)
                                (gethash "completionProvider")
                                (gethash "triggerCharacters")))
-           (bounds-start (--> (or (car (bounds-of-thing-at-point 'symbol)) (point))
-                              (save-excursion
-                                (goto-char it)
-                                (if (lsp--looking-back-trigger-characterp trigger-chars)
-                                    (- it 1)
-                                  it))))
+           (bounds-start (or (-some--> (car (bounds-of-thing-at-point 'symbol))
+                               (save-excursion
+                                 (goto-char (+ it 1))
+                                 (if (lsp--looking-back-trigger-characterp trigger-chars)
+                                     (+ it 1)
+                                   it)))
+                             (point)))
            result done?)
       (list
        bounds-start


### PR DESCRIPTION
This goes with a little but other direction with #1662 .
The reason is because I realize if we include the trigger char in current symbol boundary, `company-mode` will try to replace the trigger char with the new text (we will correct this process in `:exit-function` though). This will create not so nice for `company-tng`, this PR fixes that.
Here is what looks like before
![image](https://user-images.githubusercontent.com/2631472/81248139-b2d34980-9056-11ea-8d6d-412c1ce7a5de.gif)

And after
![011a7254-20c4-4db7-9e75-8e68a60db9dc](https://user-images.githubusercontent.com/2631472/81251960-9ee01580-905f-11ea-942e-7f7f21387125.gif)

You can notice that the `.` is not being replaced when previewing.