### PR TITLE
Switched redundant initialized-fn to initialization-options. 

### DIFF
--- a/lsp-haxe.el
+++ b/lsp-haxe.el
@@ -64,7 +64,8 @@
 ;; The build spec for the project.
 (defcustom lsp-haxe-hxml "build.hxml"
   "The compile file for the haxe project."
-  :type 'file)
+  :type 'file
+  :package-version '(lsp-mode . "6.4"))
 
 ;; https://github.com/emacs-lsp/lsp-mode/blob/150a933694349df960dc8fd7a15e04f5727e6433/lsp-rust.el#L251
 (defun lsp-clients--haxe-processStart (_workspace params)
@@ -152,7 +153,9 @@
                   :notification-handlers (lsp-ht ("haxe/progressStart" 'lsp-clients--haxe-processStart)
                                                  ("haxe/progressStop" 'ignore)
                                                  ("haxe/didDetectOldPreview" 'ignore)
-                                                 ("haxe/didChangeDisplayPort" 'ignore))))
+                                                 ("haxe/didChangeDisplayPort" 'ignore)
+                                                 ("haxe/didRunHaxeMethod" 'ignore)
+                                                 ("haxe/didChangeRequestQueue" 'ignore))))
 
 (provide 'lsp-haxe)
 ;;; lsp-haxe.el ends here

--- a/lsp-haxe.el
+++ b/lsp-haxe.el
@@ -61,6 +61,11 @@
   :risky t
   :type '(repeat string))
 
+;; The build spec for the project.
+(defcustom lsp-haxe-hxml "build.hxml"
+  "The compile file for the haxe project."
+  :type 'file)
+
 ;; https://github.com/emacs-lsp/lsp-mode/blob/150a933694349df960dc8fd7a15e04f5727e6433/lsp-rust.el#L251
 (defun lsp-clients--haxe-processStart (_workspace params)
   "Handle processStart notification.  Just logs PARAMS."
@@ -131,8 +136,8 @@
                                        (lsp-configuration-section "haxe"))))
                   :priority -1
                   :server-id 'haxe
-                  :initialized-fn (lambda (_workspace)
-                                    '(("sendMethodResults" . t)
+                  :initialization-options (lambda ()
+                                    `(("sendMethodResults" . t)
                                       ("haxelibConfig"
                                        ("executable" . "haxelib"))
                                       ("displayServerConfig"
@@ -143,7 +148,7 @@
                                         [])
                                        ("env")
                                        ("path" . "haxe"))
-                                      ("displayArguments" . ["build.hxml"])))
+                                      ("displayArguments" . [,lsp-haxe-hxml])))
                   :notification-handlers (lsp-ht ("haxe/progressStart" 'lsp-clients--haxe-processStart)
                                                  ("haxe/progressStop" 'ignore)
                                                  ("haxe/didDetectOldPreview" 'ignore)

--- a/lsp-haxe.el
+++ b/lsp-haxe.el
@@ -156,7 +156,8 @@
                                                  ("haxe/didDetectOldPreview" 'ignore)
                                                  ("haxe/didChangeDisplayPort" 'ignore)
                                                  ("haxe/didRunHaxeMethod" 'ignore)
-                                                 ("haxe/didChangeRequestQueue" 'ignore))))
+                                                 ("haxe/didChangeRequestQueue" 'ignore)
+                                                 ("haxe/cacheBuildFailed" 'ignore))))
 
 (provide 'lsp-haxe)
 ;;; lsp-haxe.el ends here

--- a/lsp-haxe.el
+++ b/lsp-haxe.el
@@ -107,7 +107,8 @@
 (defcustom lsp-haxe-postfix-completion nil nil :type 'string)
 
 (lsp-register-custom-settings
- '(("haxe.postfixCompletion" lsp-haxe-postfix-completion)
+ '(("haxe.hxml" lsp-haxe-hxml)
+   ("haxe.postfixCompletion" lsp-haxe-postfix-completion)
    ("haxe.exclude" lsp-haxe-exclude)
    ("haxe.codeGeneration" lsp-haxe-code-generation)
    ("haxe.enableCompletionCacheWarning" lsp-haxe-enable-completion-cache-warning t)


### PR DESCRIPTION
Replacing the redundant `initialized-fn key` with `initialization-options`, for `make-lsp-client`, properly imports `build.hxml`, making libraries referenced in `build.hxml` available for auto completion etc. 

Fixes bug where Flymake would be unable to find classes, even though the project compiles correctly using `haxe build.hxml`.

This pull request also pulls out `build.hxml` into it's own custom `lsp-haxe-hxml`, since most projects use other names, such as `compile.hxml`, `all.hxml`, etc.

edit: 
Addressed (read ignored) two new notifications 
- `haxe/didChangeRequestQueue`
- `haxe/didRunHaxeMethod`

