### PR TITLE
[docs] update installation command wrong usage of long dash

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -398,7 +398,7 @@
     "server-url": "https://github.com/latex-lsp/texlab",
     "client-name": "lsp-latex",
     "client-url": "https://github.com/ROCKTAKEY/lsp-latex",
-    "installation": "cargo install –git https://github.com/latex-lsp/texlab.git",
+    "installation": "cargo install --git https://github.com/latex-lsp/texlab.git",
     "debugger": "Not available"
   },
   {
@@ -414,7 +414,7 @@
     "full-name": "TeX, LaTeX, etc.",
     "server-name": "texlab",
     "server-url": "https://github.com/latex-lsp/texlab",
-    "installation": "cargo install –git https://github.com/latex-lsp/texlab.git",
+    "installation": "cargo install --git https://github.com/latex-lsp/texlab.git",
     "debugger": "Not available"
   },
   {
@@ -422,7 +422,7 @@
     "full-name": "Verilog/SystemVerilog",
     "server-name": "hdl_checker",
     "server-url": "https://github.com/suoto/hdl_checker",
-    "installation": "pip install hdl-checker –upgrade",
+    "installation": "pip install hdl-checker --upgrade",
     "debugger": "Not available"
   },
   {


### PR DESCRIPTION
The long dash (`0x2013`) is used instead of double dash (`0x2D`), due to from copying the old org mode rendered table.
We have to use double dash