### PR TITLE
Killed lsp--describe-buffer causes errors when type M-x

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2250,7 +2250,8 @@ BINDINGS is a list of (key def cond)."
                     ,(format "maybe-%s" def)
                     ,def
                     :filter (lambda (item)
-                              (when (with-current-buffer (or lsp--describe-buffer
+                              (when (with-current-buffer (or (when (buffer-live-p lsp--describe-buffer)
+                                                               lsp--describe-buffer)
                                                              (current-buffer))
                                       ,cond)
                                 item))))))


### PR DESCRIPTION
Dear maintainers,

After we killed the buffer which is set to the variable `lsp--describe-buffer`, some errors occur when we type `M-x` (For detail of the error, Issue #1409 is helpful, I think).
Therefore, we should check whether `lsp--describe-buffer` is killed or not by using `buffer-live-p` (Note: `(buffer-live-p nil)` returns `nil`).

I am sorry for not being familiar with Emacs Lisp.  So, could you point out if something wrong.

Thanks,