### PR TITLE
add ess-julia-mode to language-id list

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -691,6 +691,7 @@ Changes take effect only when a new session is started."
                                         (vhdl-mode . "vhdl")
                                         (verilog-mode . "verilog")
                                         (terraform-mode . "terraform")
+                                        (ess-julia-mode . "julia")
                                         (ess-r-mode . "r")
                                         (crystal-mode . "crystal")
                                         (nim-mode . "nim")


### PR DESCRIPTION
Add `ess-julia-mode` to `lsp-language-id-configuration` list. This change is necessary to add support for `ess-julia-mode` in [lsp-julia](https://github.com/non-Jedi/lsp-julia).