### PR TITLE
Only show "truncated" if doc-lines > 0

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5018,7 +5018,9 @@ It will show up only if current point has signature help."
                             (length signatures)
                             (propertize "│ " 'face 'shadow)))
             (prefix-length (- (length prefix) 2))
-            (method-docs (when lsp-signature-render-documentation
+            (method-docs (when
+                             (and lsp-signature-render-documentation
+                                  (or (not (numberp lsp-signature-doc-lines)) (< 0 lsp-signature-doc-lines)))
                            (let ((docs (lsp--render-element
                                         (gethash "documentation" signature))))
                              (when (s-present? docs)


### PR DESCRIPTION
When `lsp-signature-doc-lines` is zero, it does not make sense to show the
"Truncated" message in every case. With the new behaviour, setting
`lsp-signature-doc-lines` to zero becomes useful: only the signature is
shown by default, but `lsp-signature-toggle-full-docs` can be used to
view the full documentation.

If this is not the right way to do this, I'm happy about any feedback.