### PR TITLE
Disable willSave and includeText when textDocumentSync is a number

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3218,8 +3218,7 @@ in that particular folder."
 (defun lsp--send-will-save-p ()
   "Return whether will save notifications should be sent to the server."
   (let ((sync (gethash "textDocumentSync" (lsp--server-capabilities))))
-    (or (memq sync '(1 2))
-        (and (hash-table-p sync) (gethash "willSave" sync)))))
+    (and (hash-table-p sync) (gethash "willSave" sync))))
 
 (defun lsp--send-will-save-wait-until-p ()
   "Return whether will save wait until notifications should be sent to the server."
@@ -3235,10 +3234,9 @@ in that particular folder."
 (defun lsp--save-include-text-p ()
   "Return whether save notifications should include the text document's contents."
   (let ((sync (gethash "textDocumentSync" (lsp--server-capabilities))))
-    (or (memq sync '(1 2))
-        (and (hash-table-p sync)
-             (hash-table-p (gethash "save" sync nil))
-             (gethash "includeText" (gethash "save" sync))))))
+    (and (hash-table-p sync)
+         (hash-table-p (gethash "save" sync nil))
+         (gethash "includeText" (gethash "save" sync)))))
 
 (defun lsp--suggest-project-root ()
   "Get project root."


### PR DESCRIPTION
## Specification
https://microsoft.github.io/language-server-protocol/specification#textDocument_didClose

## VSCode implementation
Default params when textDocumentSync is a number.
https://github.com/microsoft/vscode-languageserver-node/blob/03179b00aef101d4a46e705c048717e3f4560e08/client/src/client.ts#L3012-L3027

willSave not included when number kind.
https://github.com/microsoft/vscode-languageserver-node/blob/03179b00aef101d4a46e705c048717e3f4560e08/client/src/client.ts#L1131

includeText only if save.includeText.
https://github.com/microsoft/vscode-languageserver-node/blob/03179b00aef101d4a46e705c048717e3f4560e08/client/src/client.ts#L1211

There is also a small difference in didSave notifications which in vscode implementation are sent when textDocumentSync.save is a boolean and it's false, but I didn't change that.