### PR TITLE
Fix mixed-up typescript server links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,8 +49,8 @@ nav:
     - Haskell: https://emacs-lsp.github.io/lsp-haskell
     - Lua: page/lsp-emmy-lua.md
     - Java: https://emacs-lsp.github.io/lsp-java
-    - JavaScript/TypeScript (sourcegraph): page/lsp-typescript.md
-    - JavaScript/TypeScript (theia-ide): page/lsp-typescript-javascript.md
+    - JavaScript/TypeScript (sourcegraph): page/lsp-typescript-javascript.md
+    - JavaScript/TypeScript (theia-ide): page/lsp-typescript.md
     - JavaScript Flow: page/lsp-flow.md
     - Json: page/lsp-json.md
     - Julia: page/lsp-julia.md


### PR DESCRIPTION
The typescript server links are pointing to the wrong servers.

# Reproduce
- goto https://emacs-lsp.github.io/lsp-mode/page/languages/
- click `JavaScript/TypeScript (sourcegraph)`
- verify the page is actually for the `theia-ide` server