### PR TITLE
lsp--completing-read: no need to take cl-first of collections

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1056,11 +1056,11 @@ TRANSFORM-FN will be used to transform each of the items before displaying.
 
 PROMPT COLLECTION PREDICATE REQUIRE-MATCH INITIAL-INPUT HIST DEF
 INHERIT-INPUT-METHOD will be proxied to `completing-read' without changes."
-  (let* ((result (--map (cons (funcall transform-fn it) it) collection))
-         (completion (completing-read prompt (-map 'cl-first result)
+  (let* ((col (--map (cons (funcall transform-fn it) it) collection))
+         (completion (completing-read prompt col
                                       predicate require-match initial-input hist
                                       def inherit-input-method)))
-    (cdr (assoc completion result))))
+    (cdr (assoc completion col))))
 
 ;; A ‘lsp--client’ object describes the client-side behavior of a language
 ;; server.  It is used to start individual server processes, each of which is


### PR DESCRIPTION
According the example of `completing-read` in https://www.gnu.org/software/emacs/manual/html_node/elisp/Minibuffer-Completion.html, we can pass alist as a collections and have the `car` automatically shown.
We don't need to pluck the `car` manually.