### PR TITLE
Filter out non-ranges where the beginning is greater than or equal...

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6336,15 +6336,15 @@ an alist
       (let ((sym (pop stack)))
         (push (lsp--get-line-and-col sym) line-col-list)
         (unless (seq-empty-p (gethash "children" sym))
-          (setf stack (append (lsp--imenu-filter-symbols (gethash "children" sym)) stack)))))
+          (setf stack (nconc (lsp--imenu-filter-symbols (gethash "children" sym)) stack)))))
     (-sort #'lsp--line-col-comparator line-col-list)))
 
 (defun lsp--convert-line-col-to-points-batch (line-col-list)
   "Convert a sorted list of positions from line-column
 representation to point representation."
-  (let* ((line-col-to-point-map (ht-create))
-         (inhibit-field-text-motion t)
-         (curr-line 0))
+  (let ((line-col-to-point-map (ht-create))
+        (inhibit-field-text-motion t)
+        (curr-line 0))
     (save-excursion
       (save-restriction
         (widen)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1793,32 +1793,37 @@ WORKSPACE is the workspace that contains the diagnostics."
                                        (-let [(&hash "startLine" start-line
                                                      "startCharacter" start-character
                                                      "endLine" end-line
-                                                     "endCharacter" end-character
-                                                     "kind" _kind)
+                                                     "endCharacter" end-character)
                                               range]
                                          (list (cons start-line start-character)
                                                (cons end-line end-character))))
                                      ranges))))
-           (line-col-to-point-map (lsp--convert-line-col-to-points-batch sorted-line-col-pairs)))
+           (line-col-to-point-map (lsp--convert-line-col-to-points-batch
+                                   sorted-line-col-pairs)))
       (setq lsp--cached-folding-ranges
             (cons (buffer-chars-modified-tick)
-                  (delete-dups
-                   (seq-into
-                    (seq-map
-                     (lambda (range)
-                       (-let [(&hash "startLine" start-line
-                                     "startCharacter" start-character
-                                     "endLine" end-line
-                                     "endCharacter" end-character
-                                     "kind" kind)
-                              range]
-                         (make-lsp--folding-range
-                          :beg (ht-get line-col-to-point-map (cons start-line start-character))
-                          :end (ht-get line-col-to-point-map (cons end-line end-character))
-                          :kind kind
-                          :orig-folding-range range)))
-                     ranges)
-                    'list))))))
+                  (seq-filter (lambda (folding-range)
+                                (< (lsp--folding-range-beg folding-range)
+                                   (lsp--folding-range-end folding-range)))
+                              (delete-dups
+                               (seq-into
+                                (seq-map
+                                 (lambda (range)
+                                   (-let [(&hash "startLine" start-line
+                                                 "startCharacter" start-character
+                                                 "endLine" end-line
+                                                 "endCharacter" end-character
+                                                 "kind" kind)
+                                          range]
+                                     (make-lsp--folding-range
+                                      :beg (ht-get line-col-to-point-map
+                                                   (cons start-line start-character))
+                                      :end (ht-get line-col-to-point-map
+                                                   (cons end-line end-character))
+                                      :kind kind
+                                      :orig-folding-range range)))
+                                 ranges)
+                                'list)))))))
   (cdr lsp--cached-folding-ranges))
 
 (defun lsp--get-nested-folding-ranges ()


### PR DESCRIPTION
...to the end of the folding range.


----

969817d obviates the need to call `lsp--line-character-to-point` for each range.
86a8f41 removes false ranges beginning at the same point as the end. I had a problem with these when working on https://github.com/emacs-lsp/lsp-origami/pull/2.