### PR TITLE
Remove Elixir (JakeBecker) support

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -106,14 +106,6 @@
     "debugger": "Yes"
   },
   {
-    "name": "elixir-ls",
-    "full-name": "Elixir",
-    "server-name": "elixir-ls",
-    "server-url": "https://github.com/JakeBecker/elixir-ls",
-    "installation-url": "https://github.com/JakeBecker/elixir-ls",
-    "debugger": "Yes"
-  },
-  {
     "name": "elm",
     "full-name": "Elm",
     "server-name": "elmLS",

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -467,7 +467,7 @@ returned to avoid that the echo area grows uncomfortably."
 (defgroup lsp-elixir nil
   "LSP support for Elixir, using elixir-ls."
   :group 'lsp-mode
-  :link '(url-link "https://github.com/JakeBecker/elixir-ls"))
+  :link '(url-link "https://github.com/elixir-lsp/elixir-ls"))
 
 (defcustom lsp-clients-elixir-server-executable
   (if (equal system-type 'windows-nt)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,6 @@ nav:
     - Dhall: page/lsp-dhall.md
     - Dockerfile: page/lsp-dockerfile.md
     - Elixir (elixir-ls): page/lsp-elixir.md
-    - Elixir (JakeBecker): page/lsp-elixir-ls.md
     - Elm: page/lsp-elm.md
     - Erlang: page/lsp-erlang.md
     - Eslint: page/lsp-eslint.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,7 @@ nav:
     - Dart: https://emacs-lsp.github.io/lsp-dart
     - Dhall: page/lsp-dhall.md
     - Dockerfile: page/lsp-dockerfile.md
-    - Elixir (elixir-ls): page/lsp-elixir.md
+    - Elixir: page/lsp-elixir.md
     - Elm: page/lsp-elm.md
     - Erlang: page/lsp-erlang.md
     - Eslint: page/lsp-eslint.md


### PR DESCRIPTION
https://github.com/JakeBecker/elixir-ls is no longer maintained. The https://github.com/elixir-lsp/elixir-ls fork is being actively developed, and already supported by lsp-mode.