### PR TITLE
[docs] fix JS/TS clients descriptions

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -195,18 +195,18 @@
   },
   {
     "name": "typescript",
-    "full-name": "JavaScript/TypeScript",
-    "server-name": "javascript-typescript-stdio",
+    "full-name": "JavaScript/TypeScript (theia-ide)",
+    "server-name": "typescript-language-server (recommended)",
     "server-url": "https://github.com/theia-ide/typescript-language-server",
-    "installation": "npm i -g javascript-typescript-langserver",
+    "installation": "npm i -g typescript-language-server; npm i -g typescript",
     "debugger": "Yes (Firefox/Chrome)"
   },
   {
     "name": "typescript-javascript",
-    "full-name": "JavaScript/TypeScript",
-    "server-name": "typescript-language-server (recommended)",
+    "full-name": "JavaScript/TypeScript (sourcegraph)",
+    "server-name": "javascript-typescript-stdio",
     "server-url": "https://github.com/sourcegraph/javascript-typescript-langserver",
-    "installation": "npm i -g typescript-language-server; npm i -g typescript",
+    "installation": "npm i -g javascript-typescript-langserver",
     "debugger": "Yes (Firefox/Chrome)"
   },
   {


### PR DESCRIPTION
Hello, while looking at documentation on web I noticed that links for JS/TS servers were mixed.

Currently if someone clicks on 
**JavaScript/TypeScript (sourcegraph)** link in [languages/](https://emacs-lsp.github.io/lsp-mode/page/) page they will be redirected to https://emacs-lsp.github.io/lsp-mode/page/lsp-typescript-javascript/
In which server name and installation procedure is for **theia-ide** instead of **sourcegraph**. While link to server repository is correct. (points to https://github.com/sourcegraph/javascript-typescript-langserver).  

Same problem with **JavaScript/TypeScript (theia-ide)** link in [languages/](https://emacs-lsp.github.io/lsp-mode/page/). Links to correct page, but installation procedures are for  **sourcegraph**

Fixed this in this PR.

P.S.
I was not sure though which one should be marked as `(recommended)`, so I left `typescript-language-server` as recommended 