### PR TITLE
Change regexp for Angular language server

### DIFF
--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -678,7 +678,7 @@ responsiveness at the cost of possible stability issues."
  (make-lsp-client :new-connection (lsp-stdio-connection
                                    (lambda () lsp-clients-angular-language-server-command))
                   :activation-fn (lambda (&rest _args)
-                                   (and (string-match-p ".*\.html$" (buffer-file-name))
+                                   (and (string-match-p "\\.html\\'" (buffer-file-name))
                                         (lsp-workspace-root)
                                         (file-exists-p (f-join (lsp-workspace-root) "angular.json"))))
                   :priority -1


### PR DESCRIPTION
The second backslash is required. End-of-string pattern is preferred
here over end-of-line metacharacter. The ".*" isn't necessary.


----

#