### PR TITLE
Add fallback for flycheck error level when server does not report it

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7867,6 +7867,13 @@ reported according to `flycheck-check-syntax-automatically'."
   :type 'boolean
   :group 'lsp-mode)
 
+(defcustom lsp-flycheck-default-level 'error
+  "Error level to use when the server does not report back a diagnostic level."
+  :type '(choice (const error)
+                 (const warning)
+                 (const info))
+  :group lsp-mode)
+
 (defun lsp--get-buffer-diagnostics ()
   (or (gethash (lsp--fix-path-casing buffer-file-name)
                (lsp-diagnostics))
@@ -7878,7 +7885,8 @@ reported according to `flycheck-check-syntax-automatically'."
                  (1 'error)
                  (2 'warning)
                  (3 'info)
-                 (4 'info)))
+                 (4 'info)
+                 (_ lsp-flycheck-default-level)))
         ;; materialize only first tag.
         (tags (->> diag
                    (lsp-diagnostic-original)


### PR DESCRIPTION
In the LSP spec, the diagnostic level on an error is optional. However,
we do not handle this case when translating to a flycheck error level, which
causes flycheck to not work.

See https://microsoft.github.io/language-server-protocol/specifications/specification-current/#diagnostic.

To solve this, I added a custom option to fall back on when the server does not provide a diagnostic level.