### PR TITLE
lsp-rust-analyzer-update-inlay-hints: make overlay advances with text

### DIFF
--- a/lsp-rust.el
+++ b/lsp-rust.el
@@ -612,7 +612,7 @@ The command should include `--message=format=json` or similar option."
          (dolist (hint res)
            (-let* (((&hash "range" "label" "kind") hint)
                    ((beg . end) (lsp--range-to-region range))
-                   (overlay (make-overlay beg end)))
+                   (overlay (make-overlay beg end nil 'front-advance 'end-advance)))
              (overlay-put overlay 'lsp-rust-analyzer-inlay-hint t)
              (overlay-put overlay 'evaporate t)
              (cond


### PR DESCRIPTION
Here is the issue:
![45933196-276d-4f3c-81af-846d18434f04](https://user-images.githubusercontent.com/2631472/82776428-e7803700-9e85-11ea-8621-c60101819343.gif)
You can see that when I try to insert `bar`, it's displayed after the inlay overlay `: i32`.

And here is after the fix
![167f8d10-849a-4acc-8373-32ad5b4709d5](https://user-images.githubusercontent.com/2631472/82776524-3c23b200-9e86-11ea-8c11-96d590672b34.gif)
The text `bar` is display **before** inlay, and in correct place