### PR TITLE
Add missing quote

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7862,7 +7862,7 @@ reported according to `flycheck-check-syntax-automatically'."
   :type '(choice (const error)
                  (const warning)
                  (const info))
-  :group lsp-mode)
+  :group 'lsp-mode)
 
 (defun lsp--get-buffer-diagnostics ()
   (or (gethash (lsp--fix-path-casing buffer-file-name)


### PR DESCRIPTION
defcustom requires quoted symbol for :group.

Becuase missing quote, my Emacs failed load lsp-mode.el

```
Debugger entered--Lisp error: (wrong-type-argument symbolp (lsp-enable-which-key-integration))
  custom-add-to-group((lsp-enable-which-key-integration) lsp-flycheck-default-level custom-variable)
  custom-handle-keyword(lsp-flycheck-default-level :group (lsp-enable-which-key-integration) custom-variable)
  custom-declare-variable(lsp-flycheck-default-level (funcall (function (closure (lsp-browser-mode-abbrev-table lsp-browser-mode-syntax-table lsp-log-io-mode-abbrev-table lsp-log-io-mode-syntax-table cl-struct-lsp--log-entry-tags cl-struct-lsp-session-tags cl-struct-lsp--workspace-tags cl-struct-lsp--registered-capability-tags lsp-mode-menu cl-struct-lsp--folding-range-tags cl-struct-lsp-diagnostic-tags cl-struct-lsp-watch-tags cl-struct-lsp--client-tags lsp--log-lines c-basic-offset t) nil (quote error)))) "Error level to use when the server does not report back a diagnostic level." :type (choice (const error) (const warning) (const info)) :group (lsp-enable-which-key-integration))
  eval-buffer(#<buffer  *load*> nil "/home/conao/.emacs.d/elpa/lsp-mode-20200525.1959/lsp-mode.el" nil t)  ; Reading at buffer position 341869
  load-with-code-conversion("/home/conao/.emacs.d/elpa/lsp-mode-20200525.1959/lsp-mode.el" "/home/conao/.emacs.d/elpa/lsp-mode-20200525.1959/lsp-mode.el" nil t)
  lsp-deferred()
  run-hooks(change-major-mode-after-body-hook prog-mode-hook emacs-lisp-mode-hook lisp-interaction-mode-hook)
  apply(run-hooks (change-major-mode-after-body-hook prog-mode-hook emacs-lisp-mode-hook lisp-interaction-mode-hook))
  run-mode-hooks(lisp-interaction-mode-hook)
  lisp-interaction-mode()
  command-line()
  normal-top-level()
```