### PR TITLE
Update `lsp-language-id-configuration` for FORTRAN 77 and older

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -684,6 +684,7 @@ Changes take effect only when a new session is started."
                                         (yaml-mode . "spring-boot-properties-yaml")
                                         (ruby-mode . "ruby")
                                         (enh-ruby-mode . "ruby")
+                                        (fortran-mode . "fortran")
                                         (f90-mode . "fortran")
                                         (elm-mode . "elm")
                                         (dart-mode . "dart")

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -636,7 +636,6 @@ Changes take effect only when a new session is started."
                                         (sql-mode . "sql")
                                         (vimrc-mode . "vim")
                                         (sh-mode . "shellscript")
-                                        (sh-mode . "lua")
                                         (scala-mode . "scala")
                                         (julia-mode . "julia")
                                         (clojure-mode . "clojure")


### PR DESCRIPTION
I also removed an association that looked wrong. It's from https://github.com/emacs-lsp/lsp-mode/commit/3a7bb350f4e53e9d85399d49497a1bc0bb4f810b.