### PR TITLE
Move customizable options back to lsp-mode group

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -122,7 +122,7 @@
 
 (defcustom lsp-log-io nil
   "If non-nil, log all messages to and from the language server to a *lsp-log* buffer."
-  :group 'lsp
+  :group 'lsp-mode
   :type 'boolean)
 
 (defcustom lsp-print-performance nil
@@ -223,7 +223,7 @@ the buffer when it becomes large."
 
 (defcustom lsp-progress-via-spinner t
   "If non-nil, display LSP $/progress reports via a spinner in the modeline."
-  :group 'lsp
+  :group 'lsp-mode
   :type 'boolean)
 
 (defvar-local lsp--cur-workspace nil)


### PR DESCRIPTION
There is no such custom group called `lsp` defined.