### PR TITLE
Remove lsp--extract-line-from-buffer

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6146,9 +6146,9 @@ perform the request synchronously."
   "Send request named METHOD and get cross references of the symbol under point.
 EXTRA is a plist of extra parameters.
 REFERENCES? t when METHOD returns references."
-  (if-let ((loc (lsp-request method
+  (if-let ((locs (lsp-request method
                              (append (lsp--text-document-position-params) extra))))
-      (lsp-show-xrefs (lsp--locations-to-xref-items loc) display-action references?)
+      (lsp-show-xrefs (lsp--locations-to-xref-items locs) display-action references?)
     (message "Not found for: %s" (thing-at-point 'symbol t))))
 
 (cl-defun lsp-find-declaration (&key display-action)


### PR DESCRIPTION
When lsp-find-references searches a file for references, it causes
lsp--line-char-to-point to be called once for each reference in that
file, which can be time-consuming since each invocation of
lsp--line-char-to-point requires a run
of (save-excursion (save-restriction (widen) (goto-char (point-min)
[...]))). Instead, collect all the references within Emacs with O(1)
passes per file using lsp--xref-make-items, which
uses (save-excursion (save-restriction (widen) (goto-char (point-min)
[...]))) once per file.