### PR TITLE
Provide easier way to edit hash tables defcustom + add one for go codelens

### DIFF
--- a/lsp-go.el
+++ b/lsp-go.el
@@ -55,12 +55,14 @@ completing function calls."
   :risky t
   :package-version '(lsp-mode "6.2"))
 
-(defcustom lsp-gopls-env (make-hash-table)
+(defcustom lsp-gopls-env '()
   "`gopls' has the unusual ability to set environment variables,
   intended to affect the behavior of commands invoked by `gopls'
   on the user's behalf. This variable takes a hash table of env
   var names to desired values."
-  :type '(restricted-sexp :match-alternatives (hash-table-p))
+  :type '(repeat (cons (string :tag "env var name") (string :tag "value")))
+  :set 'lsp--defcustom-set-hashtable-from-set
+  :get 'lsp--defcustom-get-set-from-hashtable
   :group 'lsp-gopls
   :risky t
   :package-version '(lsp-mode "6.2"))

--- a/lsp-go.el
+++ b/lsp-go.el
@@ -80,11 +80,32 @@ completing function calls."
   :risky t
   :package-version '(lsp-mode "6.2"))
 
+(defvar lsp-gopls-available-codelens
+  '(("generate" . "Run `go generate` for a directory")
+	("test" . "Run `go test` for a specific test function")
+	("tidy" . "Run `go mod tidy` for a module")
+	("upgrade_dependency" . "Upgrade a dependency")
+	("regenerate_cgo" . "Regenerate cgo definitions"))
+  "Available codelens that can be further enabled or disabled
+  through `lsp-gopls-codelens'.")
+
+(defcustom lsp-gopls-codelens '(("generate" . t) ("test" . t))
+  "Select what codelens should be enabled or not.
+
+The codelens can be found at https://github.com/golang/tools/blob/4d5ea46c79fe3bbb57dd00de9c167e93d94f4710/internal/lsp/source/options.go#L102-L108."
+  :type (lsp--defcustom-available-as-hash-table-type lsp-gopls-available-codelens)
+  :group 'lsp-gopls
+  :set 'lsp--defcustom-set-hashtable-from-set
+  :get 'lsp--defcustom-get-set-from-hashtable
+  :risky t
+  :package-version '(lsp-mode "6.4"))
+
 (lsp-register-custom-settings
  '(("gopls.usePlaceholders" lsp-gopls-use-placeholders t)
    ("gopls.hoverKind" lsp-gopls-hover-kind)
    ("gopls.buildFlags" lsp-gopls-build-flags)
-   ("gopls.env" lsp-gopls-env)))
+   ("gopls.env" lsp-gopls-env)
+   ("gopls.codelens" lsp-gopls-codelens)))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8441,6 +8441,26 @@ See https://github.com/emacs-lsp/lsp-mode."
         (lsp--info "Disconnected from buffer %s" file-name))
     (lsp--error "Nothing to disconnect from?")))
 
+(defun lsp--defcustom-available-as-hash-table-type (alist)
+  "Returns a list suitable for the `:type' field in a `defcustom' used to populate a hash table.
+
+The input ALIST has the form `((\"name\" . \"documentation sentence\") [...])'
+
+The returned type provides a tri-state that either:
+  - does not include the element in the hash-table
+  - sets element to false (actually, nil)
+  - sets element to true (actually, t)
+"
+  (let ((list '()))
+	(dolist (v alist)
+	  (push `(cons
+			  :tag ,(cdr v)
+			  (const :format "" ,(car v))
+			  (choice (const :tag "Enable" t) (const :tag "Disable" nil)))
+			list))
+	(push 'set list)
+	list))
+
 (defun lsp--defcustom-set-hashtable-from-set (symbol value)
   "Funtion to set SYMBOL's value to VALUE after transforming
 it from a defcustom set to a hash table. "

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8441,6 +8441,41 @@ See https://github.com/emacs-lsp/lsp-mode."
         (lsp--info "Disconnected from buffer %s" file-name))
     (lsp--error "Nothing to disconnect from?")))
 
+(defun lsp--defcustom-set-hashtable-from-set (symbol value)
+  "Funtion to set SYMBOL's value to VALUE after transforming
+it from a defcustom set to a hash table. "
+  (set-default symbol (lsp--set-to-hash-table value)))
+
+(defun lsp--defcustom-get-set-from-hashtable (symbol)
+  "Funtion to get SYMBOL's value after transforming its value
+from a hash table to a defcustom set."
+  (lsp--hash-table-to-set (default-value symbol)))
+
+(defun lsp--set-to-hash-table (list)
+  "Transforms a LIST to a `hash-table' suitable to be jsonified.
+
+With an input LIST setting a to true and b to false:
+  ((a . t) (b) (c . 'other))
+And will output:
+  #s(hash-table data ((a t b :json-false c 'other))
+"
+  (let ((hash (make-hash-table :size (length list))))
+	(dolist (v list)
+	  (puthash (car v) (if (null (cdr v)) :json-false (cdr v)) hash) list)
+	hash))
+
+(defun lsp--hash-table-to-set (hash)
+  "Transforms a HASH table suitable to be jsonified to a `list'.
+
+The input HASH is of the form:
+  #s(hash-table data ((a t b :json-false c 'other))
+And will output a list setting a to true and b to false:
+  ((a . t) (b) (c . 'other))
+"
+  (let ((list '()))
+	(maphash (lambda (k v) (push (cons k (if (eq v :json-false) nil v)) list)) hash)
+	list))
+
 
 
 (provide 'lsp-mode)

--- a/lsp-yaml.el
+++ b/lsp-yaml.el
@@ -86,9 +86,11 @@
   :group 'lsp-yaml
   :package-version '(lsp-mode . "6.2"))
 
-(defcustom lsp-yaml-schemas (make-hash-table)
+(defcustom lsp-yaml-schemas '()
   "Associate schemas to YAML files in a glob pattern."
-  :type '(restricted-sexp :match-alternatives (hash-table-p))
+  :type '(repeat (cons (string :tag "schema") (string :tag "files (glob)")))
+  :set 'lsp--defcustom-set-hashtable-from-set
+  :get 'lsp--defcustom-get-set-from-hashtable
   :group 'lsp-yaml
   :package-version '(lsp-mode . "6.2"))
 


### PR DESCRIPTION
There are currently two `defcustom`s that are used to edit hash-tables:
https://github.com/emacs-lsp/lsp-mode/blob/485d8d23d096cb98aa9b79249a3c96c25ad61e6a/lsp-yaml.el#L89
and
https://github.com/emacs-lsp/lsp-mode/blob/53bc160f0337877f1314fa6eb4835f2dbf52da4b/lsp-go.el#L58

They provide subpar editing feature because they require the user to use the hash-table syntax as can be seen with this screenshot:
![image](https://user-images.githubusercontent.com/1044950/84057089-05609800-a96c-11ea-822a-d1af93a30b2c.png)

This PR changes that to allow editing those as "normal" `alist`:
![image](https://user-images.githubusercontent.com/1044950/84057337-5ff9f400-a96c-11ea-8eae-9ae445cccbc8.png)
![image](https://user-images.githubusercontent.com/1044950/84057354-66886b80-a96c-11ea-90f6-07e6e6abee25.png)
while maintaining the underlying variable as a hash-table:
![image](https://user-images.githubusercontent.com/1044950/84057385-71db9700-a96c-11ea-8982-9f6a396e3889.png)

This PR also adds a third hash-table `defcustom` that allows the user to enable/disable go codelens features. Indeed, `gopls` provides [5 codelens](https://github.com/golang/tools/blob/4d5ea46c79fe3bbb57dd00de9c167e93d94f4710/internal/lsp/source/options.go#L102-L108) but only [enables 3 by default](https://github.com/golang/tools/blob/4d5ea46c79fe3bbb57dd00de9c167e93d94f4710/internal/lsp/source/options.go#L119-L123) and there's no way to configure that currently in `lsp-mode`.

As I'm writing the above paragraph, looks like this PR does two things although the second commit depends on the first. Feel free to tell me to split it in two.

Also, I tried my best at documentation but even I can tell it's lacking although I can't find better phrasing.

Finally, I saw #1683 and I don't think it goes against that work.