### PR TITLE
Fix some bytecompiler warnings/gccemacs errors

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,7 +1,7 @@
 (source gnu)
 (source melpa)
 (package-file "lsp-mode.el")
-(files "*.el")
+(files "lsp-protocol.el" "lsp-mode.el" "*.el")
 
 (development
  (depends-on "ert-runner")

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4927,11 +4927,12 @@ If INCLUDE-DECLARATION is non-nil, request the server to include declarations."
   (run-hooks 'lsp-eldoc-hook)
   eldoc-last-message)
 
-(defun dash-expand:&lsp-wks (key source)
-  `(,(intern-soft (format "lsp--workspace-%s" (eval key) )) ,source))
+(eval-when-compile
+  (defun dash-expand:&lsp-wks (key source)
+    `(,(intern-soft (format "lsp--workspace-%s" (eval key) )) ,source))
 
-(defun dash-expand:&lsp-cln (key source)
-  `(,(intern-soft (format "lsp--client-%s" (eval key) )) ,source))
+  (defun dash-expand:&lsp-cln (key source)
+    `(,(intern-soft (format "lsp--client-%s" (eval key) )) ,source)))
 
 (defun lsp--point-on-highlight? ()
   (-some? (lambda (overlay)


### PR DESCRIPTION
among other things, this change explicitly lists `lsp-protocol.el` and `lsp-mode.el` as the first members of Cask's `files` list (which leads to some byte compiler errors being shown that may get masked if files are compiled in a different order, such as late-macro-definition warnings). I left the glob `*.el` unchanged, so with this change Cask would compile these two files twice. I guess a simple way to fix this would be to have Cask automatically ignore duplicates caused by overlapping globs