### PR TITLE
Cancel lenses requests per buffer.

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2399,7 +2399,7 @@ CALLBACK - callback for the lenses."
                              :error-handler #'ignore
                              :mode 'tick
                              :no-merge t
-                             :cancel-token :lenses))
+                             :cancel-token (concat (buffer-name (current-buffer)) "-lenses")))
       (if (-all? #'lsp--lens-backend-present? lsp--lens-backend-cache)
           (funcall callback lsp--lens-backend-cache lsp--cur-version)
         (lsp--lens-backend-fetch-missing lsp--lens-backend-cache callback lsp--cur-version)))))


### PR DESCRIPTION
Currently lenses requests have common global cancel token which means
we can't send lenses requests for different buffer simultaneously.
But there are cases when we receive a notification from a server that
lenses where changed for all buffers (lsp-metals) and we need to
refresh them. Currently lenses are not refreshed after buffer switch
which also means that lenses can be lost if user switches buffers
right after a buffer change.