### PR TITLE
Add modeline code actions support

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1934,7 +1934,7 @@ WORKSPACE is the workspace that contains the progress token."
                                        (interactive)
                                        (if single-action?
                                            (lsp-execute-code-action (lsp-seq-first actions))
-                                         (call-interactively #'lsp-execute-code-action)))))))
+                                         (lsp-execute-code-action (lsp--select-action actions))))))))
 
 (defun lsp-modeline--update-code-actions (actions)
   "Update modeline with new code ACTIONS."
@@ -1965,7 +1965,6 @@ WORKSPACE is the workspace that contains the progress token."
   :group 'lsp-mode
   :global nil
   :lighter ""
-  :init-value nil
   (cond
    (lsp-modeline-code-actions-mode
     (add-hook 'lsp-on-idle-hook 'lsp--modeline-check-code-actions nil t))
@@ -2630,6 +2629,7 @@ BINDINGS is a list of (key def cond)."
       "Tl" lsp-lens-mode (lsp-feature? "textDocument/codeLens")
       "TL" lsp-toggle-trace-io t
       "Th" lsp-toggle-symbol-highlight (lsp-feature? "textDocument/documentHighlight")
+      "Ta" lsp-modeline-code-actions-mode (lsp-feature? "textDocument/codeAction")
       "TS" lsp-ui-sideline-mode (featurep 'lsp-ui-sideline)
       "Td" lsp-ui-doc-mode (featurep 'lsp-ui-doc)
       "Ts" lsp-toggle-signature-auto-activate (lsp-feature? "textDocument/signatureHelp")
@@ -2711,6 +2711,7 @@ active `major-mode', or for all major modes when ALL-MODES is t."
        "T h" "toggle highlighting"
        "T L" "toggle log io"
        "T s" "toggle signature"
+       "T a" "toggle modeline code actions"
        "T S" "toggle sideline"
        "T d" "toggle documentation popup"
        "T p" "toggle signature help"
@@ -2816,7 +2817,8 @@ active `major-mode', or for all major modes when ALL-MODES is t."
       ["Add" lsp-workspace-folders-add]
       ["Remove" lsp-workspace-folders-remove]
       ["Open" lsp-workspace-folders-open])
-     ["Toggle Lenses" lsp-lens-mode]))
+     ["Toggle Lenses" lsp-lens-mode]
+     ["Toggle modeline code actions" lsp-modeline-code-actions-mode]))
   "Menu for lsp-mode.")
 
 (defun lsp-mode-line ()
@@ -6954,6 +6956,10 @@ returns the command to execute."
   "Autoconfigure `company', `flycheck', `lsp-ui',  if they are installed."
   (when (functionp 'lsp-ui-mode)
     (lsp-ui-mode))
+
+  (when (and lsp-modeline-code-actions-enable
+             (lsp--capability "codeActionProvider"))
+    (lsp-modeline-code-actions-mode 1))
 
   (cond
    ((or

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -650,6 +650,26 @@ If this is set to nil, `eldoc' will show only the symbol information."
   :type 'boolean
   :group 'lsp-mode)
 
+(defcustom lsp-modeline-code-actions-enable nil
+  "Wheter to show code actions on modeline."
+  :type 'boolean
+  :group 'lsp-mode)
+
+(defcustom lsp-modeline-code-actions-delay 0.2
+  "Number of seconds to wait before checking for code actions to show on modeline."
+  :type 'number
+  :group 'lsp-mode)
+
+(defcustom lsp-modeline-code-actions-kind-regex "quickfix.*\\|refactor.*"
+  "Regex for the code actions kinds to show in the modeline."
+  :type 'string
+  :group 'lsp-mode)
+
+(defface lsp-modeline-code-actions-face
+  '((t :foreground "cyan2"))
+  "Face used to highlight code action text on modeline."
+  :group 'lsp-faces)
+
 (defcustom lsp-after-diagnostics-hook nil
   "Hooks to run after diagnostics are received.
 Note: it runs only if the receiving buffer is open. Use
@@ -1876,6 +1896,101 @@ WORKSPACE is the workspace that contains the progress token."
                             (not (-contains? global-mode-string status)))
                        (cons status global-mode-string))
                       (t (remove status global-mode-string))))))
+
+
+;; code actions modeline
+
+(defvar-local lsp--modeline-code-actions-string nil
+  "Holds the current code action string on modeline.")
+
+(declare-function all-the-icons-octicon "ext:all-the-icons")
+
+(defun lsp--modeline-code-actions-icon ()
+  "Build the icon for modeline code actions."
+  (if (featurep 'all-the-icons)
+      (all-the-icons-octicon "light-bulb"
+                             :face 'lsp-modeline-code-actions-face
+                             :v-adjust -0.0575)
+    (propertize "💡" 'face 'lsp-modeline-code-actions-face)))
+
+(defun lsp--modeline-build-code-actions-string (actions)
+  "Build the string to be presented on modeline for code ACTIONS."
+  (-let* ((icon (lsp--modeline-code-actions-icon))
+          (first-action-string (propertize (->> actions
+                                                lsp-seq-first
+                                                (gethash "title")
+                                                (replace-regexp-in-string "[\n\t ]+" " "))
+                                           'face 'lsp-modeline-code-actions-face))
+          (single-action? (= (length actions) 1))
+          (string (if single-action?
+                      (format " %s %s " icon first-action-string)
+                    (format " %s %s %s " icon first-action-string
+                            (propertize (format "(%d more)" (seq-length actions))
+                                        'display `((height 0.9))
+                                        'face 'lsp-modeline-code-actions-face)))))
+    (propertize string
+                'help-echo (concat "Apply code actions (s-l a a)\nmouse-1: "
+                                   (if single-action?
+                                       first-action-string
+                                     "select from multiple code actions"))
+                'mouse-face 'mode-line-highlight
+                'local-map (make-mode-line-mouse-map
+                            'mouse-1 (lambda ()
+                                       (interactive)
+                                       (if single-action?
+                                           (lsp-execute-code-action (lsp-seq-first actions))
+                                         (call-interactively #'lsp-execute-code-action)))))))
+
+(defun lsp-modeline--update-code-actions (actions)
+  "Update modeline with new code ACTIONS."
+  (when lsp-modeline-code-actions-kind-regex
+    (setq actions (seq-filter (-lambda ((&hash "kind"))
+                                (or (not kind)
+                                    (s-match lsp-modeline-code-actions-kind-regex kind)))
+                              actions)))
+  (if (seq-empty-p actions)
+      (setq-local global-mode-string (remove '(t (:eval lsp--modeline-code-actions-string)) global-mode-string))
+    (progn
+      (setq lsp--modeline-code-actions-string (lsp--modeline-build-code-actions-string actions))
+      (add-to-list 'global-mode-string '(t (:eval lsp--modeline-code-actions-string))))))
+
+(defun lsp--modeline-request-code-actions ()
+  "Requests for code actions to update modeline."
+  (lsp-request-async
+   "textDocument/codeAction"
+   (lsp--text-document-code-action-params)
+   #'lsp-modeline--update-code-actions
+   :mode 'alive
+   :cancel-token :lsp-modeline-code-actions))
+
+(defvar-local lsp--modeline-code-actions--timer nil)
+
+(defun lsp--modeline-check-code-actions ()
+  "Check for code actions showing it on modeline."
+  (if t
+      (progn
+        (when lsp--modeline-code-actions--timer
+          (cancel-timer lsp--modeline-code-actions--timer))
+        (let ((buf (current-buffer)))
+          (setq lsp--modeline-code-actions--timer
+                (run-with-idle-timer lsp-modeline-code-actions-delay
+                                     nil
+                                     (lambda ()
+                                       ;; check for code actions only if current-buffer is the same.
+                                       (when (equal buf (current-buffer))
+                                         (lsp--modeline-request-code-actions)))))))))
+
+(define-minor-mode lsp-modeline-code-actions-mode
+  "Toggle code actions on modeline."
+  :group 'lsp-mode
+  :global nil
+  :lighter ""
+  :init-value lsp-modeline-code-actions-enable
+  (cond
+   (lsp-modeline-code-actions-mode
+    (add-hook 'post-command-hook 'lsp--modeline-check-code-actions nil t))
+   (t
+    (remove-hook 'post-command-hook 'lsp--modeline-check-code-actions t))))
 
 
 
@@ -5560,7 +5675,7 @@ It will show up only if current point has signature help."
 
 (lsp-defun lsp-execute-code-action ((action &as &CodeAction :command? :edit?))
   "Execute code action ACTION.
-If ACTION is not set it will be selected from `lsp-code-actions'."
+If ACTION is not set it will be selected from `lsp-code-actions-at-point'."
   (interactive (list (lsp--select-action (lsp-code-actions-at-point))))
   (when edit?
     (lsp--apply-workspace-edit edit?))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1947,18 +1947,17 @@ WORKSPACE is the workspace that contains the progress token."
       (setq-local global-mode-string (remove '(t (:eval lsp--modeline-code-actions-string)) global-mode-string))
     (progn
       (setq lsp--modeline-code-actions-string (lsp--modeline-build-code-actions-string actions))
-      (add-to-list 'global-mode-string '(t (:eval lsp--modeline-code-actions-string))))))
+      (add-to-list 'global-mode-string '(t (:eval lsp--modeline-code-actions-string)))))
+  (force-mode-line-update))
 
-(defun lsp--modeline-check-code-actions (&optional buffer)
+(defun lsp--modeline-check-code-actions (&rest _)
   "Request code actions to update modeline for given BUFFER."
-  (when (or (not buffer)
-            (eq (current-buffer) buffer))
-    (lsp-request-async
-     "textDocument/codeAction"
-     (lsp--text-document-code-action-params)
-     #'lsp-modeline--update-code-actions
-     :mode 'alive
-     :cancel-token :lsp-modeline-code-actions)))
+  (lsp-request-async
+   "textDocument/codeAction"
+   (lsp--text-document-code-action-params)
+   #'lsp-modeline--update-code-actions
+   :mode 'tick
+   :cancel-token :lsp-modeline-code-actions))
 
 (define-minor-mode lsp-modeline-code-actions-mode
   "Toggle code actions on modeline."


### PR DESCRIPTION
As suggested [here](https://github.com/emacs-lsp/lsp-ui/pull/456), this PR adds support for code actions via modeline enabling it via `lsp-modeline-code-actions-mode` or setting `lsp-modeline-code-actions-enable` to `t`.

* Single code action:
![image](https://user-images.githubusercontent.com/7820865/84223440-52e61d80-aab0-11ea-82c2-1c66ccf61eaf.png)
* Multiple code actions:
![image](https://user-images.githubusercontent.com/7820865/84223459-5d081c00-aab0-11ea-955c-e92507f85c15.png)
* Fallback to unicode if `all-the-icons` is not installed:
![image](https://user-images.githubusercontent.com/7820865/84223712-0222f480-aab1-11ea-8b79-01461c35620d.png)

Closes https://github.com/emacs-lsp/lsp-mode/issues/1237
