### PR TITLE
Enable plists and fix tests + byte-compile loading

### DIFF
--- a/test/lsp-clients-test.el
+++ b/test/lsp-clients-test.el
@@ -95,13 +95,24 @@
 
 (ert-deftest lsp-clients-extract-signature-from-clangd-on-hover ()
   (should (string= (lsp-clients-extract-signature-on-hover
-                         #s(hash-table size 30 test equal data ("value" "Sample\n ```cpp\n// In Function.hpp\nvoid function(int n);\n```")) 'clangd) "void function(int n);"))
+                    (lsp-make-markup-content :kind lsp/markup-kind-markdown
+                                             :value "Sample\n ```cpp\n// In Function.hpp\nvoid function(int n);\n```")
+                    'clangd)
+                   "void function(int n);"))
   (should (string= (lsp-clients-extract-signature-on-hover
-                         #s(hash-table size 30 test equal data ("value" "Sample\n ```cpp\nvoid function(int n);\n```")) 'clangd) "void function(int n);"))
+                    (lsp-make-markup-content :kind lsp/markup-kind-markdown
+                                             :value "Sample\n ```cpp\nvoid function(int n);\n```")
+                    'clangd)
+                   "void function(int n);"))
   (should (string= (lsp-clients-extract-signature-on-hover
-                         #s(hash-table size 30 test equal data ("value" "Sample\n ```cpp\n   void function(int n);\n```")) 'clangd) "void function(int n);"))
+                    (lsp-make-markup-content :kind lsp/markup-kind-markdown
+                                             :value "Sample\n ```cpp\n   void function(int n);\n```")
+                    'clangd)
+                   "void function(int n);"))
   (should-error (lsp-clients-extract-signature-on-hover
-                 #s(hash-table size 30 test equal data ("value" "Wrong")) 'clangd)))
+                 (lsp-make-markup-content :kind nil
+                                          :value "Wrong")
+                 'clangd)))
 
 (ert-deftest lsp-clients-join-region ()
   (with-temp-buffer

--- a/test/lsp-integration-test.el
+++ b/test/lsp-integration-test.el
@@ -63,7 +63,7 @@
                         (lsp-def-request-async "textDocument/hover"
                                                (lsp--text-document-position-params)) ))
       (deferred:nextc (lambda (contents)
-                        (should (hash-table-p contents))))
+                        (should (lsp-hover? contents))))
       (deferred:sync!))
   (kill-buffer)
   (lsp-workspace-folders-remove (f-join lsp-test-location "fixtures")))


### PR DESCRIPTION
- Enable `lsp-use-plists` by default
- Fix travis
- Fix loading from byte compile errors of `lsp-get/put/...` not defined.