### PR TITLE
Change lsp--modeline-code-actions-icon

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1898,11 +1898,11 @@ WORKSPACE is the workspace that contains the progress token."
 (defvar-local lsp--modeline-code-actions-string nil
   "Holds the current code action string on modeline.")
 
-(declare-function all-the-icons-octicon "ext:all-the-icons")
+(declare-function all-the-icons-octicon "ext:all-the-icons" t t)
 
 (defun lsp--modeline-code-actions-icon ()
   "Build the icon for modeline code actions."
-  (if (featurep 'all-the-icons)
+  (if (require 'all-the-icons nil t)
       (all-the-icons-octicon "light-bulb"
                              :face lsp-modeline-code-actions-face
                              :v-adjust -0.0575)


### PR DESCRIPTION
* If all-the-icons is not already loaded, it never gets detected with
featurep. So require it optionally.

* declare-function does not understand when functions are defined in
macros. all-the-icons-octicon is defined by the macro
all-the-icons-define-icon. So set the fourth argument of
declare-function to t.