### PR TITLE
Add github action to run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+        branches:
+            - master
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                emacs-version:
+                    - 25.1
+                    - 25.2
+                    - 25.3
+                    - 26.1
+                    - 26.2
+                    - 26.3
+                    # - 27.1
+                    - snapshot
+
+        steps:
+            - uses: actions/checkout@v1
+
+            - uses: actions/setup-python@v1.1.1
+              with:
+                  python-version: "3.6"
+                  architecture: "x64"
+
+            - uses: purcell/setup-emacs@master
+              with:
+                  version: ${{ matrix.emacs-version }}
+
+            - uses: conao3/setup-cask@master
+              with:
+                  version: 0.8.4
+
+            - name: Run tests
+              run: "make ci"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,6 @@
 name: CI
 
-on:
-    push:
-        branches:
-            - master
-    pull_request:
-        branches:
-            - master
+on: [push, pull_request]
 
 jobs:
     build:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 SHELL := /usr/bin/env bash
 
+CASK ?= cask
+
 all:
-	cask build
+	$(CASK) build
 
 test: all
-	cask exec ert-runner -t '!no-win'
+	$(CASK) exec ert-runner -t '!no-win' -t '!org'
 
 docs:
 	make -C docs/ generate

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,69 @@
 SHELL := /usr/bin/env bash
 
+EMACS ?= emacs
 CASK ?= cask
+
+INIT="(progn \
+  (require 'package) \
+  (push '(\"melpa\" . \"https://melpa.org/packages/\") package-archives) \
+  (package-initialize) \
+  (package-refresh-contents))"
+
+LINT="(progn \
+		(unless (package-installed-p 'package-lint) \
+		  (package-install 'package-lint)) \
+		(require 'package-lint) \
+		(package-lint-batch-and-exit))"
 
 all:
 	$(CASK) build
 
-test: all
+build:
+	$(CASK) install
+
+# TODO: add 'checkdoc' and 'lint' here when they pass
+ci: clean build compile testprereq test
+
+compile:
+	@echo "Compiling..."
+	@$(CASK) $(EMACS) -Q --batch \
+		-L . \
+		--eval '(setq byte-compile-error-on-warn t)' \
+		-f batch-byte-compile \
+		*.el
+
+checkdoc:
+	$(eval LOG := $(shell mktemp -d)/checklog.log)
+	@touch $(LOG)
+
+	@echo "checking doc..."
+
+	@for f in *.el ; do \
+		$(CASK) $(EMACS) -Q --batch \
+			-L . \
+			--eval "(checkdoc-file \"$$f\")" \
+			*.el 2>&1 | tee -a $(LOG); \
+	done
+
+	@if [ -s $(LOG) ]; then \
+		echo ''; \
+		exit 1; \
+	else \
+		echo 'checkdoc ok!'; \
+	fi
+
+lint:
+	@echo "package linting..."
+	@$(CASK) $(EMACS) -Q --batch \
+		-L . \
+		--eval $(INIT) \
+		--eval $(LINT) \
+		*.el
+
+testprereq:
+	sudo pip install python-language-server
+
+test:
 	$(CASK) exec ert-runner -t '!no-win' -t '!org'
 
 docs:
@@ -16,4 +74,7 @@ local-webpage: docs
 	docker run --rm --volume "`pwd`:/data" --user `id -u`:`id -g` pandoc/core:2.9 -s CHANGELOG.org -t gfm -o docs/page/CHANGELOG.md
 	docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
 
-.PHONY: all test local-webpage docs
+clean:
+	rm -rf .cask *.elc
+
+.PHONY: all build ci compile checkdoc lint testprereq test docs local-webpage clean

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ description: Language Server Protocol support with multiples languages support f
 [![](https://melpa.org/packages/lsp-mode-badge.svg)](https://melpa.org/#/lsp-mode)
 [![](https://stable.melpa.org/packages/lsp-mode-badge.svg)](https://stable.melpa.org/#/lsp-mode)
 [![](https://badges.gitter.im/emacs-lsp/lsp-mode.svg)](https://gitter.im/emacs-lsp/lsp-mode)
-[![](https://travis-ci.org/emacs-lsp/lsp-mode.svg?branch=master>)](https://travis-ci.org/emacs-lsp/lsp-mode)
+[![](https://github.com/ibizaman/lsp-mode/workflows/CI/badge.svg)](https://github.com/ibizaman/lsp-mode/actions?query=workflow%3ACI)
+
 
 <img src="examples/logo.png" width="240" align="right">
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ description: Language Server Protocol support with multiples languages support f
 [![](https://melpa.org/packages/lsp-mode-badge.svg)](https://melpa.org/#/lsp-mode)
 [![](https://stable.melpa.org/packages/lsp-mode-badge.svg)](https://stable.melpa.org/#/lsp-mode)
 [![](https://badges.gitter.im/emacs-lsp/lsp-mode.svg)](https://gitter.im/emacs-lsp/lsp-mode)
-[![](https://github.com/ibizaman/lsp-mode/workflows/CI/badge.svg)](https://github.com/ibizaman/lsp-mode/actions?query=workflow%3ACI)
+[![](https://github.com/emacs-lsp/lsp-mode/workflows/CI/badge.svg)](https://github.com/emacs-lsp/lsp-mode/actions?query=workflow%3ACI)
 
 
 <img src="examples/logo.png" width="240" align="right">


### PR DESCRIPTION
I stole the makefile from https://github.com/emacs-lsp/lsp-dart/blob/master/Makefile and the github workflow from https://github.com/emacs-lsp/lsp-dart/blob/master/.github/workflows/test.yml

Emacs 27 is not yet available but it could come soon https://github.com/purcell/nix-emacs-ci/issues/22.
That being said, the snapshot version is Emacs 28.0.50 https://github.com/ibizaman/lsp-mode/runs/767702850?check_suite_focus=true#step:4:160

I left the first target `all` as it was on purpose, to avoid the default make target to change. I didn't remove the travis file but I don't see why we should keep it, so I can remove it if you want. The github actions is much faster so that's nice too.
