### PR TITLE
Horizontal rule affects lsp-ui-doc width

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5176,7 +5176,9 @@ Stolen from `org-copy-visible'."
     (while (re-search-forward
             (rx (or
                  (seq bol (+ "-") eol)
-                 (seq "\* \* \*" eol)))
+                 (seq "\* \* \*" eol)
+                 (seq "\-\-\-" eol)
+                 (seq "\_\_\_" eol)))
             nil t)
       (replace-match ""))
 


### PR DESCRIPTION
Fixes emacs-lsp/lsp-ui#442. Adds a few more patterns to remove before
rendering markdown. Because there are multiple ways to represent a horizontal
rule (`<hr/>`) in markdown, the original attempts to fix this did not hit them
all. The issue manifests in an extremely large lsp-ui-doc popup window. Because
the horizontal rule is extending the length of the window, and couldn't be
controlled by the variables available to control the max width of a child frame,
this 'hack' was required to simply strip out the offending markdown. This has
the side affect of not showing the horizontal rules at all.

@yyoncho  @alanz  - This should fix the issue emacs-lsp/lsp-ui#442 regarding the massive lsp-ui-doc child frames. I have tested it in my setup and seems to work specifically for the rust-mode lsp-rust scenario (specifically with rust-analyzer, if it matters).

EDIT: had the wrong repo issue linked. Fixed it.