### PR TITLE
ci: fix gh action to triggered on pull_request too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: push
+on: [push, pull_request]
 
 jobs:
     build:


### PR DESCRIPTION
We need this on `pull_request` too. Else pull request from other repository will not trigger ci