### PR TITLE
lsp-diagnostics-modeline: perf improvement

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1894,7 +1894,7 @@ The `:global' workspace is global one.")
 
 (defun lsp--diagnostics-reset-modeline-cache ()
   ""
-  (plist-put lsp--diagnostics-modeline-wks->strings (car (lsp-workspaces)) :global)
+  (plist-put lsp--diagnostics-modeline-wks->strings (car (lsp-workspaces)) nil)
   (plist-put lsp--diagnostics-modeline-wks->strings :global nil)
   (setq lsp--diagnostics-modeline-string nil))
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1894,7 +1894,7 @@ The `:global' workspace is global one.")
 
 (defun lsp--diagnostics-reset-modeline-cache ()
   ""
-  (plist-put lsp--diagnostics-modeline-wks->strings (car (lsp-workspaces)) nil)
+  (plist-put lsp--diagnostics-modeline-wks->strings (car (lsp-workspaces)) :global)
   (plist-put lsp--diagnostics-modeline-wks->strings :global nil)
   (setq lsp--diagnostics-modeline-string nil))
 

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -315,6 +315,7 @@ See `-let' for a description of the destructuring mechanism."
 (defconst lsp/diagnostic-severity-warning 2)
 (defconst lsp/diagnostic-severity-information 3)
 (defconst lsp/diagnostic-severity-hint 4)
+(defconst lsp/diagnostic-severity-max 5)
 (defconst lsp/diagnostic-tag-unnecessary 1)
 (defconst lsp/diagnostic-tag-deprecated 2)
 (defconst lsp/document-highlight-kind-text 1)


### PR DESCRIPTION
Attempt to fix #1793.

- Update mode line only when new diagnostic information is available.
- Modify `lsp-diagnostics` and `lsp--diagnostics-modeline-statistics` to avoid intermediate object.
- Cache the mode line string and recalculate only once