### PR TITLE
lsp-copy: change definition into copy-sequence for better perf

### DIFF
--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -155,7 +155,7 @@ Example usage with `dash`.
               (-partition 2 value )))
       (defalias 'lsp-merge 'append)
       (defalias 'lsp-empty? 'null)
-      (defalias 'lsp-copy 'copy-list))
+      (defalias 'lsp-copy 'copy-sequence))
   (defun lsp-get (from key)
     (when from
       (gethash (lsp-keyword->string key) from)))


### PR DESCRIPTION
Bench mark
``` elisp
(benchmark-run 1000000 (copy-list '(1 2 3 4 5 6 7 8 9 10)))
(0.776661 0 0.0)

(benchmark-run 1000000 (copy-sequence '(1 2 3 4 5 6 7 8 9 10)))
(0.329688 0 0.0)
```