### PR TITLE
Avoid downcasing paths in uri conversion code

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1570,7 +1570,6 @@ On other systems, returns path without change."
                           file))))
     (->> file-name
          (concat (-some #'lsp--workspace-host-root (lsp-workspaces)))
-         (lsp--fix-path-casing)
          (lsp-remap-path-if-needed))))
 
 (defun lsp--buffer-uri ()
@@ -1904,7 +1903,7 @@ The `:global' workspace is global one.")
                 (let ((str (lsp--diagnostics-modeline-statistics)))
                   (if (string-empty-p str) ""
                     (concat " " str)))))
-    (setq lsp--diagnostics-modeline-string 
+    (setq lsp--diagnostics-modeline-string
           (cl-case lsp-diagnostics-modeline-scope
             (:file (or lsp--diagnostics-modeline-string
                        (calc-modeline)))
@@ -2132,7 +2131,7 @@ interface PublishDiagnosticsParams {
 PARAMS contains the diagnostics data.
 WORKSPACE is the workspace that contains the diagnostics."
   (let* ((lsp--virtual-buffer-mappings (ht))
-         (file (lsp--uri-to-path uri))
+         (file (lsp--fix-path-casing (lsp--uri-to-path uri)))
          (workspace-diagnostics (lsp--workspace-diagnostics workspace)))
 
     (if (seq-empty-p diagnostics)
@@ -4451,8 +4450,12 @@ Added to `after-change-functions'."
         ;; force cleanup overlays after each change
         (lsp--remove-overlays 'lsp-highlight)
         (lsp--after-change  (current-buffer))
-        (setq lsp--signature-last-index nil)
-        (setq lsp--signature-last nil)))))
+        (setq lsp--signature-last-index nil
+              lsp--signature-last nil)
+        ;; cleanup diagnostics
+        (lsp-foreach-workspace
+         (-let [diagnostics (lsp--workspace-diagnostics lsp--cur-workspace)]
+           (remhash (lsp--fix-path-casing (buffer-file-name)) diagnostics)))))))
 
 
 
@@ -8208,8 +8211,7 @@ This avoids overloading the server with many files when starting Emacs."
 (defun lsp--get-buffer-diagnostics ()
   (gethash (or
             (plist-get lsp--virtual-buffer :buffer-file-name)
-            (lsp--fix-path-casing buffer-file-name)
-            (lsp--fix-path-casing (file-truename buffer-file-name)))
+            (lsp--fix-path-casing buffer-file-name))
            (lsp-diagnostics t)))
 
 (defun lsp--flycheck-calculate-level (severity tags)

--- a/test/lsp-common-test.el
+++ b/test/lsp-common-test.el
@@ -33,7 +33,7 @@
 (ert-deftest lsp--path-to-uri ()
   (let ((lsp--uri-file-prefix "file:///")
         (system-type 'windows-nt))
-    (should (equal (lsp--uri-to-path "file:///c:/Users/%7B%7D/") "c:/users/{}/")))
+    (should (equal (lsp--uri-to-path "file:///c:/Users/%7B%7D/") "c:/Users/{}/")))
   (let ((lsp--uri-file-prefix "file://"))
     (should (equal (lsp--uri-to-path "/root/%5E/%60") "/root/^/`"))))
 
@@ -49,7 +49,7 @@
 (ert-deftest lsp--uri-to-path--handle-utf8 ()
   (let ((lsp--uri-file-prefix "file:///")
         (system-type 'windows-nt))
-    (should (equal (lsp--uri-to-path "file:///c:/Users/%E4%BD%A0%E5%A5%BD/") "c:/users/你好/")))
+    (should (equal (lsp--uri-to-path "file:///c:/Users/%E4%BD%A0%E5%A5%BD/") "c:/Users/你好/")))
   (let ((lsp--uri-file-prefix "file://"))
     (should (equal (lsp--uri-to-path "/root/%E4%BD%A0%E5%A5%BD/%E8%B0%A2%E8%B0%A2") "/root/你好/谢谢"))))
 


### PR DESCRIPTION
... do that when storing the URI.

Fixes https://github.com/emacs-lsp/lsp-java/issues/190
Fixes #1792

- Cleanup diagnostics after the buffer has changed