### PR TITLE
fix go-dot-mod-mode language id

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -853,7 +853,7 @@ Changes take effect only when a new session is started."
                                         (html-mode . "html")
                                         (sgml-mode . "html")
                                         (mhtml-mode . "html")
-                                        (go-dot-mod-mode . "go")
+                                        (go-dot-mod-mode . "go.mod")
                                         (go-mode . "go")
                                         (haskell-mode . "haskell")
                                         (hack-mode . "hack")


### PR DESCRIPTION
Currently gopls tries to parse go.mod files as go files which results
in "LSP :: Error from the Language Server [snip] expected 'package',
found module) (Unknown error)" errors

The correct language id from
github.com/golang/tools/internal/lsp/source/util.go is go.mod, so use
that.