### PR TITLE
Use find-buffer-visiting lsp--buffer-for-file

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1901,10 +1901,10 @@ The `:global' workspace is global one.")
 (defun lsp--diagnostics-update-modeline ()
   "Update diagnostics modeline string."
   (cl-labels ((calc-modeline ()
-                (let ((str (lsp--diagnostics-modeline-statistics)))
-                  (if (string-empty-p str) ""
-                    (concat " " str)))))
-    (setq lsp--diagnostics-modeline-string 
+                             (let ((str (lsp--diagnostics-modeline-statistics)))
+                               (if (string-empty-p str) ""
+                                 (concat " " str)))))
+    (setq lsp--diagnostics-modeline-string
           (cl-case lsp-diagnostics-modeline-scope
             (:file (or lsp--diagnostics-modeline-string
                        (calc-modeline)))
@@ -2118,10 +2118,6 @@ The `:global' workspace is global one.")
     (setq header-line-format (remove '(t (:eval lsp--headerline-breadcrumb-string)) header-line-format)))))
 
 
-
-(defalias 'lsp--buffer-for-file (if (eq system-type 'windows-nt)
-                                    #'find-buffer-visiting
-                                  #'get-file-buffer))
 
 (lsp-defun lsp--on-diagnostics (workspace (&PublishDiagnosticsParams :uri :diagnostics))
   "Callback for textDocument/publishDiagnostics.
@@ -4125,7 +4121,7 @@ interface TextDocumentEdit {
     ("rename" (-let* (((&RenameFile :old-uri :new-uri :options? (&RenameFileOptions? :overwrite?)) edit)
                       (old-file-name (lsp--uri-to-path old-uri))
                       (new-file-name (lsp--uri-to-path new-uri))
-                      (buf (lsp--buffer-for-file old-file-name)))
+                      (buf (find-buffer-visiting old-file-name)))
                 (when buf
                   (lsp-with-current-buffer buf
                     (save-buffer)
@@ -4140,7 +4136,7 @@ interface TextDocumentEdit {
                              (lsp:text-document-edit-text-document)
                              (lsp:versioned-text-document-identifier-uri)
                              (lsp--uri-to-path))))
-         (lsp-with-current-buffer (lsp--buffer-for-file file-name)
+         (lsp-with-current-buffer (find-buffer-visiting file-name)
            (lsp-with-filename file-name
              (lsp--apply-text-edits (lsp:text-document-edit-edits edit))))))))
 
@@ -5159,7 +5155,7 @@ Others: TRIGGER-CHARS"
                (file-locs location-link)
                (-let [(filename . matches) file-locs]
                  (condition-case err
-                     (let ((visiting (lsp--buffer-for-file filename))
+                     (let ((visiting (find-buffer-visiting filename))
                            (fn (lambda (loc)
                                  (lsp-with-filename filename
                                    (lsp--xref-make-item
@@ -6688,7 +6684,7 @@ an alist
     (not (eq (->> location
                   (lsp:location-uri)
                   (lsp--uri-to-path)
-                  (lsp--buffer-for-file))
+                  (find-buffer-visiting))
              (current-buffer)))))
 
 (lsp-defun lsp--get-symbol-type ((&SymbolInformation :kind))


### PR DESCRIPTION
Fixes https://github.com/emacs-lsp/lsp-mode/issues/1027

- we no longer need that hack because lsp-mode is using smarter strategy for
handling the diagnostics updates. We just trigger an even and only the active
buffer will concernted.