### PR TITLE
Watch subdirectories

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -507,7 +507,7 @@ entire project."
   :group 'lsp-mode
   :type '(repeat string)
   :package-version '(lsp-mode . "6.3.1"))
-;;;###autoload(put 'lsp-watch-folders 'safe-local-variable #'booleanp)
+;;;###autoload(put 'lsp-watch-folders 'safe-local-variable #'t)
 
 (defcustom lsp-file-watch-ignored '(; SCM tools
                                     "[/\\\\]\\.git$"
@@ -3669,7 +3669,7 @@ disappearing, unset all the variables related to it."
         (let ((watch (make-lsp-watch :root-directory folder)))
           (puthash folder watch created-watches)
           (lsp-watch-root-folder (file-truename folder)
-                                 (when (f-equal? folder workspace-root)
+                                 (when (lsp-f-same? folder workspace-root)
                                    workspace-sub-folders)
                                  (-partial #'lsp--file-process-event (lsp-session) folder)
                                  watch
@@ -7217,7 +7217,6 @@ returns the command to execute."
 INITIALIZATION-OPTIONS are passed to initialize function.
 SESSION is the active session."
   (lsp--spinner-start)
-  (hack-local-variables)
   (-let* ((default-directory root)
           (client (copy-lsp--client client-template))
           (workspace (make-lsp--workspace


### PR DESCRIPTION
Create a defcustom `lsp-watch-folders`.

At work our project has thousands of directories and many directories at the top level that are not interesting as watch roots. There is a way to ignore files and these are checked at every level. It would be far easier to create an allow list. However, this allow-list should be checked only at the top level rather than everywhere like the ignore list.

This PR creates this functionality. It can be easily set in dir-locals like:

```emacs-lisp
((nil
  (lsp-watch-folders . ("src" "shared-src" "test" "dashboard/src"))
  ))
```

I added some tests but I've found a few relating to the file watchers a) don't run in CI due to the presence of the `:tags '(no-win)` metadata and b) when i specify to run them explicitly, they fail.

```shell
# on my branch
cask exec ert-runner test/lsp-file-watch-test.el

Ran 11 tests in 2.088 seconds
5 unexpected results:
   FAILED  lsp-file-notifications-sub-folders-test # new test mimicing the existing
   FAILED  lsp-file-notifications-test
   FAILED  lsp-file-watch--adding-watches
   FAILED  lsp-file-watch--recursive
   FAILED  lsp-file-watch--relative-path-glob-patterns
```

and on master:

```shell
4 unexpected results:
   FAILED  lsp-file-notifications-test
   FAILED  lsp-file-watch--adding-watches
   FAILED  lsp-file-watch--recursive
   FAILED  lsp-file-watch--relative-path-glob-patterns
```