### PR TITLE
Add LSP configuration to use sqls for SQL

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -352,6 +352,22 @@
     "debugger": "Not available"
   },
   {
+    "name": "rust",
+    "full-name": "Rust",
+    "server-name": "rls",
+    "server-url": "https://github.com/rust-lang/rls",
+    "installation-url": "https://github.com/rust-lang/rls",
+    "debugger": "Yes"
+  },
+  {
+    "name": "rust-analyzer",
+    "full-name": "Rust",
+    "server-name": "rust-analyzer",
+    "server-url": "https://github.com/rust-analyzer/rust-analyzer",
+    "installation-url": "https://github.com/rust-analyzer/rust-analyzer#language-server-quick-start",
+    "debugger": "Not available"
+  },
+  {
     "name": "serenata",
     "full-name": "PHP (Serenata)",
     "server-name": "Serenata",
@@ -368,19 +384,11 @@
     "debugger": "Yes"
   },
   {
-    "name": "rust",
-    "full-name": "Rust",
-    "server-name": "rls",
-    "server-url": "https://github.com/rust-lang/rls",
-    "installation-url": "https://github.com/rust-lang/rls",
-    "debugger": "Yes"
-  },
-  {
-    "name": "rust-analyzer",
-    "full-name": "Rust",
-    "server-name": "rust-analyzer",
-    "server-url": "https://github.com/rust-analyzer/rust-analyzer",
-    "installation-url": "https://github.com/rust-analyzer/rust-analyzer#language-server-quick-start",
+    "name": "sqls",
+    "full-name": "SQL (sqls)",
+    "server-name": "sqls",
+    "server-url": "https://github.com/lighttiger2505/sqls",
+    "installation": "go get github.com/lighttiger2505/sqls",
     "debugger": "Not available"
   },
   {

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -381,7 +381,7 @@ unless overridden by a more specific face association."
          lsp-erlang lsp-eslint lsp-fsharp lsp-gdscript lsp-go lsp-haskell lsp-haxe
          lsp-intelephense lsp-java lsp-json lsp-metals lsp-perl lsp-pwsh lsp-pyls
          lsp-python-ms lsp-rust lsp-serenata lsp-solargraph lsp-terraform lsp-verilog lsp-vetur
-         lsp-vhdl lsp-xml lsp-yaml)
+         lsp-vhdl lsp-xml lsp-yaml lsp-sqls)
   "List of the clients to be automatically required."
   :group 'lsp-mode
   :type '(repeat symbol))
@@ -6526,6 +6526,12 @@ WORKSPACE is the active workspace."
                                'hash-table))
            (json-false nil))
        (json-read-from-string ,str))))
+
+(defun lsp--read-json-file (file-path)
+  "Read json file."
+  (-> file-path
+      (f-read-text)
+      (lsp--read-json)))
 
 (defun lsp--log-request-time (server-id method id start-time before-send received-time after-parsed-time after-processed-time)
   (when lsp-print-performance

--- a/lsp-sqls.el
+++ b/lsp-sqls.el
@@ -59,7 +59,7 @@
                                  ".sqls/config.json")
                                 ((equal lsp-sqls-workspace-config-path "root")
                                  (-> (lsp-workspace-root)
-                                     (concat "/.sqls/config.json"))))))
+                                     (f-join "/.sqls/config.json"))))))
     (when (file-exists-p config-json-path)
       (lsp--set-configuration (lsp--read-json-file config-json-path)))))
 

--- a/lsp-sqls.el
+++ b/lsp-sqls.el
@@ -1,0 +1,76 @@
+;;; lsp-sqls.el --- SQL Client settings -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 Shunya Ishii
+
+;; Author: Shunya Ishii
+;; Keywords: sql lsp
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP client for SQL
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-sqls nil
+  "LSP support for SQL, using sqls"
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/lighttiger2505/sqls")
+  :package-version `(lsp-mode . "6.4"))
+
+(defcustom lsp-sqls-server "sqls"
+  "Path to the `sqls` binary."
+  :group 'lsp-sqls
+  :risky t
+  :type 'file
+  :package-version `(lsp-mode . "6.4"))
+
+(defcustom lsp-sqls-workspace-config-path "workspace"
+  "If non-nil then setup workspace configuration with json file path."
+  :group 'lsp-sqls
+  :risky t
+  :type '(choice (const "workspace")
+                 (const "root"))
+  :package-version `(lsp-mode . "6.4"))
+
+(defun lsp-sqls--make-launch-cmd ()
+  (-let [base `(,lsp-sqls-server)]
+    ;; we can add some options to command. (e.g. "-config")
+    base))
+
+(defun lsp-sqls-setup-workspace-configuration ()
+  "Setup workspace configuration using json file depending on `lsp-sqls-workspace-config-path'."
+  (when-let ((config-json-path (cond
+                                ((equal lsp-sqls-workspace-config-path "workspace")
+                                 ".sqls/config.json")
+                                ((equal lsp-sqls-workspace-config-path "root")
+                                 (-> (lsp-workspace-root)
+                                     (concat "/.sqls/config.json"))))))
+    (when (file-exists-p config-json-path)
+      (lsp--set-configuration (lsp--read-json-file config-json-path)))))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection #'lsp-sqls--make-launch-cmd)
+                  :major-modes '(sql-mode)
+                  :priority -1
+                  :server-id 'sqls
+                  :initialized-fn (lambda (workspace)
+                                    (with-lsp-workspace workspace
+                                      (lsp-sqls-setup-workspace-configuration)))))
+
+(provide 'lsp-sqls)
+;;; lsp-sqls.el ends here

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
     - Ruby: page/lsp-solargraph.md
     - Rust: page/lsp-rust.md
     - Scala: https://emacs-lsp.github.io/lsp-metals
+    - SQL (sqls): page/lsp-sqls.md
     - Swift: https://emacs-lsp.github.io/lsp-sourcekit
     - Terraform: page/lsp-terraform.md
     - TeX, LaTeX, etc (digestif): page/lsp-tex.md


### PR DESCRIPTION
I added LSP configuration for [sqls](https://github.com/lighttiger2505/sqls).

To use sqls, it need following steps:
- Get sqls through golang ( `go get`) according to sqls document
- Put workspace configuration to connect to DB

[There are some configuration methods](https://github.com/lighttiger2505/sqls#configuration-methods) to use sqls features, and this PR has one of method that `workspace/configuration`.

We can use this method through creating `config.json` under `.sqls/` at workspace root directory.

Sample `config.json` is following (cf. [workspace configuration sample by sqls official](https://github.com/lighttiger2505/sqls#workspace-configuration-sample))

```json:workspace-root-dir/.sqls/config.json
{
  "sqls": {
    "connections": [
      {
        "driver": "mysql",
        "dataSourceName": "user1:password1@tcp(localhost:3306)/sample_db"
      }
    ]
  }
}
```

If anyone have more great way than this PR, I would like to agree it.