### PR TITLE
fix workspace configuration path at lsp-sqls

### DIFF
--- a/lsp-sqls.el
+++ b/lsp-sqls.el
@@ -59,7 +59,7 @@
                                  ".sqls/config.json")
                                 ((equal lsp-sqls-workspace-config-path "root")
                                  (-> (lsp-workspace-root)
-                                     (f-join "/.sqls/config.json"))))))
+                                     (f-join ".sqls/config.json"))))))
     (when (file-exists-p config-json-path)
       (lsp--set-configuration (lsp--read-json-file config-json-path)))))
 


### PR DESCRIPTION
I fixed an issue about json file path of workspace configuration for lsp-sqls.

This PR modify the json file path to able to f-join when `lsp-sqls-workspace-config-path` is "root".

Relative path ".sqls/config.json" can be join, and will be created correct path "{root directory of workspace}/.sqls/config.json".

Best Regards,
v2okimochi