### PR TITLE
[breadcrumb] Fix theme from get icons

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2050,6 +2050,7 @@ The `:global' workspace is global one.")
 (declare-function all-the-icons-material "ext:all-the-icons" t t)
 (declare-function treemacs-get-icon-value "ext:treemacs-icons" t t)
 (declare-function lsp-treemacs-symbol-kind->icon "ext:lsp-treemacs" t)
+(defvar lsp-treemacs-theme)
 
 (defun lsp--headerline-breadcrumb-arrow-icon ()
   "Build the arrow icon for headerline breadcrumb."
@@ -2061,7 +2062,7 @@ The `:global' workspace is global one.")
 (lsp-defun lsp--headerline-breadcrumb-symbol-icon ((&DocumentSymbol :kind))
   "Build the SYMBOL icon for headerline breadcrumb."
   (when (require 'lsp-treemacs nil t)
-    (treemacs-get-icon-value (lsp-treemacs-symbol-kind->icon kind))))
+    (treemacs-get-icon-value (lsp-treemacs-symbol-kind->icon kind) nil lsp-treemacs-theme)))
 
 (defun lsp--headerline-build-string (symbols-hierarchy)
   "Build the header-line from SYMBOLS-HIERARCHY."


### PR DESCRIPTION
We were getting the icon from the default user theme, now we pass the `lsp-treemacs-theme` to always get the lsp-treemacs icons.