### PR TITLE
Add check for inconsistency when use-plists

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8094,8 +8094,7 @@ such."
 (defun lsp--any-inconsistency? ()
   "Check for any inconsistency on LSP package"
   (and lsp-use-plists
-       (or (not (fboundp 'lsp-make-range))
-           (not (boundp 'lsp/symbol-kind-field)))))
+       (equal (symbol-function 'lsp-merge) 'ht-merge)))
 
 (defun lsp-shutdown-workspace ()
   "Shutdown language server."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8091,6 +8091,12 @@ such."
       (lsp--warn "No LSP server for %s(check *lsp-log*)." major-mode)
       nil)))
 
+(defun lsp--any-inconsistency? ()
+  "Check for any inconsistency on LSP package"
+  (and lsp-use-plists
+       (or (not (fboundp 'lsp-make-range))
+           (not (boundp 'lsp/symbol-kind-field)))))
+
 (defun lsp-shutdown-workspace ()
   "Shutdown language server."
   (interactive)
@@ -8216,7 +8222,10 @@ You may find the installation instructions at https://emacs-lsp.github.io/lsp-mo
        ;; no matches
        ((-> #'lsp--matching-clients? lsp--filter-clients not)
         (lsp--error "There are no language servers supporting current mode %s registered with `lsp-mode'."
-                    major-mode))))))
+                    major-mode)))
+      (unless (lsp--any-inconsistency?)
+        (lsp--warn "It's seems that one or more LSP packages are outdated or it may need to re-compile it to avoid errors.
+Make sure to update all LSP packages and byte-compile it again.")))))
 
 (defun lsp--init-if-visible ()
   "Run `lsp' for the current buffer if the buffer is visible.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8066,10 +8066,13 @@ The library folders are defined by each client for each of the active workspace.
 
 (defun lsp--persist-session (session)
   "Persist SESSION to `lsp-session-file'."
-  (lsp--persist lsp-session-file (make-lsp-session
-                                  :folders (lsp-session-folders session)
-                                  :folders-blacklist (lsp-session-folders-blacklist session)
-                                  :server-id->folders (lsp-session-server-id->folders session))))
+  (let ((metadata (make-hash-table :test 'equal)))
+    (puthash :plists-already-warned? (lsp-session-get-metadata :plists-already-warned?) metadata)
+    (lsp--persist lsp-session-file (make-lsp-session
+                                    :folders (lsp-session-folders session)
+                                    :folders-blacklist (lsp-session-folders-blacklist session)
+                                    :server-id->folders (lsp-session-server-id->folders session)
+                                    :metadata metadata))))
 
 (defun lsp--try-project-root-workspaces (ask-for-client ignore-multi-folder)
   "Try create opening file as a project file.


### PR DESCRIPTION
Fixes https://github.com/emacs-lsp/lsp-mode/issues/1835

This is an attempt to warn the user when `lsp-use-plists` is enabled but some function/variable of plists feature is not bounded.

Feel free to suggest some better place to move the check and the warning message

