### PR TITLE
Add all serenata supported initial config options

### DIFF
--- a/lsp-serenata.el
+++ b/lsp-serenata.el
@@ -39,21 +39,57 @@ It can be downloaded from https://gitlab.com/Serenata/Serenata/-/releases."
   :group 'lsp-serenata
   :type 'file)
 
+(defcustom lsp-serenata-php-version
+  7.3
+  "Allows you to specify the PHP version your project is written in.
+At the moment this directive is still ignored, but it will
+influence functionality such as refactoring in the future, where
+older PHP versions may not support scalar type hints, which may
+then be omitted from places such as getters and setters."
+  :group 'lsp-serenata
+  :type 'number)
+
+(defcustom lsp-serenata-file-extensions
+  ["php"]
+  "List of file extensions (without dot) to process.
+Files that do not match this whitelist will be ignored during
+indexing.  Usually you'll want to set this to at least include
+php, as it is the most common PHP extension.  phpt is not
+included by default as it is often used to contain test code that
+is not directly part of the code.  Note that for existing
+projects, removing extensions will not not automatically prune
+files having them from the index if they are already present.
+Adding new ones will cause the files having them to be picked up
+on the next project initialization."
+  :group 'lsp-serenata
+  :type 'array)
+
 (defun lsp-serenata-server-start-fun (port)
   "Define serenata start function, it requires a PORT."
   `(,lsp-serenata-server-path
     "-u" ,(number-to-string port)))
+
+(defun lsp-serenata-init-options ()
+  "Init options for lsp-serenata."
+  `(
+    :phpVersion ,lsp-serenata-php-version
+    :fileExtensions ,lsp-serenata-file-extensions))
+
 
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-tcp-connection 'lsp-serenata-server-start-fun)
   :major-modes '(php-mode)
   :priority -2
-  :server-id 'serenata
+  :notification-handlers (ht ("serenata/didProgressIndexing"
+			      (lambda (server data)
+				(message "%s" (ht-get data "info")))))
+  :initialization-options #'lsp-serenata-init-options
   :initialized-fn (lambda (workspace)
                     (with-lsp-workspace workspace
                       (lsp--set-configuration
-                       (lsp-configuration-section "serenata"))))))
+                       (lsp-configuration-section "serenata"))))
+  :server-id 'serenata))
 
 (provide 'lsp-serenata)
 ;;; lsp-serenata.el ends here

--- a/lsp-serenata.el
+++ b/lsp-serenata.el
@@ -79,7 +79,7 @@ on the next project initialization."
   :group 'lsp-serenata
   :type 'lsp-string-vector)
 
-(defcustom lsp-serenata-index-database-uri (lsp--path-to-uri (f-join  "~/.emacs.d/index.sqlite"))
+(defcustom lsp-serenata-index-database-uri (lsp--path-to-uri (f-join  user-emacs-directory "index.sqlite"))
   "The location to store the index database.
 Note that, as the index database uses SQLite and WAL mode,
 additional files (usually two) may be generated and used in the


### PR DESCRIPTION
Add support for all the Serenata [config](https://gitlab.com/Serenata/Serenata/-/wikis/Setting%20Up%20Your%20Project) options.

I had to do some workaround in the uris parameter, because all has to be filled with data, setting up the root workspace by hand for every project seems a little inconvenience, so I decided to set a default value base on the workspace root location given by `lsp-workspace-root`.

Maybe it need more documentation or there is a better way to do it, as always, I'm open to suggestions :+1: 