### PR TITLE
Revert "lsp--capf-cache: also clear cache on company completion start"

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7146,7 +7146,6 @@ returns the command to execute."
 (defun lsp--setup-company ()
   (add-hook 'company-completion-started-hook
             (lambda (&rest _)
-              (lsp--capf-clear-cache)
               (setq-local lsp-inhibit-lsp-hooks t))
             nil
             t)


### PR DESCRIPTION
Reverts emacs-lsp/lsp-mode#1887
Due to `company-completion-started-hook` is run **after** we're getting candidates from server