### PR TITLE
Activate rust-analyzer inlay hints mode in :after-open-fn 

### DIFF
--- a/lsp-rust.el
+++ b/lsp-rust.el
@@ -564,6 +564,9 @@ The command should include `--message=format=json` or similar option."
   :notification-handlers (ht<-alist lsp-rust-notification-handlers)
   :action-handlers (ht<-alist lsp-rust-action-handlers)
   :library-folders-fn (lambda (_workspace) lsp-rust-library-directories)
+  :after-open-fn (lambda ()
+                   (when lsp-rust-analyzer-server-display-inlay-hints
+                     (lsp-rust-analyzer-inlay-hints-mode)))
   :ignore-messages nil
   :server-id 'rust-analyzer))
 
@@ -631,12 +634,6 @@ The command should include `--message=format=json` or similar option."
    (t
     (remove-overlays (point-min) (point-max) 'lsp-rust-analyzer-inlay-hint t)
     (remove-hook 'lsp-on-change-hook #'lsp-rust-analyzer-inlay-hints-change-handler t))))
-
-;; activate `lsp-rust-analyzer-inlay-hints-mode'
-(when lsp-rust-analyzer-server-display-inlay-hints
-  (add-hook 'lsp-after-open-hook (lambda ()
-                                   (when (lsp-find-workspace 'rust-analyzer nil)
-                                     (lsp-rust-analyzer-inlay-hints-mode)))))
 
 (defun lsp-rust-analyzer-expand-macro ()
   "Expands the macro call at point recursively."


### PR DESCRIPTION
Check whether inlay hints are enabled in the :after-open-fn rather than at load time. Currently it requires setting `lsp-rust-analyzer-server-display-inlay-hints` before loading lsp-rust to activate it.

This also fixes the issue where it attempts to activate inlay hints for other non-rust buffers when there are two active workspaces with one of them being RA