### PR TITLE
Fix and improve rust-analyzer runnables support

### DIFF
--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -274,7 +274,7 @@ See `-let' for a description of the destructuring mechanism."
                (rust-analyzer:ResovedCodeActionParams (:id :codeActionParams) nil)
                (rust-analyzer:JoinLinesParams (:textDocument :ranges) nil)
                (rust-analyzer:RunnablesParams (:textDocument) (:position))
-               (rust-analyzer:Runnable (:label :kind :args) (:location :env :bin :extraArgs))
+               (rust-analyzer:Runnable (:label :kind :args) (:location))
                (rust-analyzer:RunnableArgs (:cargoArgs :executableArgs) (:workspaceRoot))
                (rust-analyzer:InlayHint (:range :label :kind) nil)
                (rust-analyzer:InlayHintsParams (:textDocument) nil)

--- a/lsp-rust.el
+++ b/lsp-rust.el
@@ -670,7 +670,7 @@ The command should include `--message=format=json` or similar option."
 
 (defun lsp-rust-analyzer--runnables ()
   (lsp-send-request (lsp-make-request
-                     "rust-analyzer/runnables"
+                     "experimental/runnables"
                      (lsp-make-rust-analyzer-runnables-params
                       :text-document (lsp--text-document-identifier)
                       :position? (lsp--cur-position)))))
@@ -679,20 +679,27 @@ The command should include `--message=format=json` or similar option."
   (lsp--completing-read
    "Select runnable:"
    (if lsp-rust-analyzer--last-runnable
-       (cons lsp-rust-analyzer--last-runnable (lsp-rust-analyzer--runnables))
+       (cons lsp-rust-analyzer--last-runnable
+             (-remove (-lambda ((&rust-analyzer:Runnable :label))
+                        (equal label (lsp-get lsp-rust-analyzer--last-runnable :label)))
+                      (lsp-rust-analyzer--runnables)))
      (lsp-rust-analyzer--runnables))
    (-lambda ((&rust-analyzer:Runnable :label)) label)))
 
 (defun lsp-rust-analyzer-run (runnable)
+  "Select and run a runnable action."
   (interactive (list (lsp-rust-analyzer--select-runnable)))
-  (-let* (((&rust-analyzer:Runnable :env? :bin? :args :extra-args? :label) runnable)
-          (compilation-environment (lsp-map (lambda (k v) (concat k "=" v)) env?)))
-    (compilation-start
-     (string-join (append (list bin?) args (when extra-args? '("--")) extra-args? '()) " ")
-     ;; cargo-process-mode is nice, but try to work without it...
-     (if (functionp 'cargo-process-mode) 'cargo-process-mode nil)
-     (lambda (_) (concat "*" label "*")))
-    (setq lsp-rust-analyzer--last-runnable runnable)))
+  (-let* (((&rust-analyzer:Runnable :kind :label :args) runnable)
+          ((&rust-analyzer:RunnableArgs :cargo-args :executable-args :workspace-root?) args)
+          (default-directory (or workspace-root? default-directory)))
+    (if (not (string-equal kind "cargo"))
+        (lsp--error "'%s' runnable is not supported" kind)
+      (compilation-start
+       (string-join (append (list "cargo") cargo-args (when executable-args '("--")) executable-args '()) " ")
+       ;; cargo-process-mode is nice, but try to work without it...
+       (if (functionp 'cargo-process-mode) 'cargo-process-mode nil)
+       (lambda (_) (concat "*" label "*")))
+      (setq lsp-rust-analyzer--last-runnable runnable))))
 
 (defun lsp-rust-analyzer-rerun (&optional runnable)
   (interactive (list (or lsp-rust-analyzer--last-runnable


### PR DESCRIPTION
Update the command based on the new Runnables protocol, see [rust-analyzer lsp-extensions doc](https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#runnables).

Also stores the last runnable label (instead of the full runnable which may no longer be valid if there is a code change) in a buffer local var.

This fixes #1833.