### PR TITLE
Improve breadcrumb

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2097,15 +2097,14 @@ The `:global' workspace is global one.")
                                       (lsp-treemacs-symbol-icon kind))))
                            :background (face-attribute 'header-line :background))))))
 
-(lsp-defun lsp--headerline-breadcrumb-go-to-symbol ((&DocumentSymbol :selection-range (&Range :start)))
+(lsp-defun lsp--headerline-breadcrumb-go-to-symbol ((&DocumentSymbol :selection-range (&RangeToPoint :start)))
   "Go to breadcrumb symbol."
   (->> start
-       lsp--position-to-point
        goto-char))
 
-(lsp-defun lsp--headerline-breadcrumb-narrow-to-symbol ((&DocumentSymbol :range (&Range :start :end)))
+(lsp-defun lsp--headerline-breadcrumb-narrow-to-symbol ((&DocumentSymbol :range (&RangeToPoint :start :end)))
   "Narrow to breadcrumb symbol range."
-  (narrow-to-region (lsp--position-to-point start) (lsp--position-to-point end)))
+  (narrow-to-region start end))
 
 (lsp-defun lsp--headerline-with-action ((symbol &as &DocumentSymbol :name) symbol-string)
   "Build action for SYMBOL and SYMBOL-STRING."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2144,7 +2144,7 @@ The `:global' workspace is global one.")
 (defun lsp--headerline-dirs-until-root (root-path path)
   "Find recursively the folders until the project ROOT-PATH.
 PATH is the current folder to be checked."
-  (let ((cur-path (list (f-base path))))
+  (let ((cur-path (list (f-filename path))))
     (if (lsp-f-same? root-path (lsp-f-parent path))
         cur-path
       (append (lsp--headerline-dirs-until-root root-path (lsp-f-parent path)) cur-path))))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2156,7 +2156,7 @@ PATH is the current folder to be checked."
                         last-dirs
                         (lsp--headerline-breadcrumb-arrow-icon)
                         (propertize next-dir 'font-lock-face lsp-headerline-breadcrumb-face)))
-              (lsp--headerline-dirs-until-root (lsp--suggest-project-root) (buffer-file-name)) ""))
+              (lsp--headerline-dirs-until-root (lsp-workspace-root) (buffer-file-name)) ""))
 
 (defun lsp--headerline-build-string (symbols-hierarchy)
   "Build the header-line from SYMBOLS-HIERARCHY."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1251,6 +1251,16 @@ Symlinks are not followed."
      (lsp-f-canonical (directory-file-name (f-expand path-a)))
      (lsp-f-canonical (directory-file-name (f-expand path-b))))))
 
+(defun lsp-f-parent (path)
+  "Return the parent directory to PATH.
+Symlinks are not followed"
+  (let ((parent (file-name-directory
+                 (directory-file-name (f-expand path default-directory)))))
+    (unless (lsp-f-same? path parent)
+      (if (f-relative? path)
+          (f-relative parent)
+        (directory-file-name parent)))))
+
 (defun lsp-f-ancestor-of? (path-a path-b)
   "Return t if PATH-A is ancestor of PATH-B.
 Symlinks are not followed."
@@ -2136,9 +2146,9 @@ The `:global' workspace is global one.")
   "Find recursively the folders until the project ROOT-PATH.
 PATH is the current folder to be checked."
   (let ((cur-path (list (f-base path))))
-    (if (f-same? root-path (f-parent path))
+    (if (lsp-f-same? root-path (lsp-f-parent path))
         cur-path
-      (append (lsp--headerline-dirs-until-root root-path (f-parent path)) cur-path))))
+      (append (lsp--headerline-dirs-until-root root-path (lsp-f-parent path)) cur-path))))
 
 (defun lsp--headerline-breadcrumb-build-prefix-string ()
   "Build the prefix for breadcrumb."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2213,7 +2213,7 @@ PATH is the current folder to be checked."
     (setq header-line-format (remove '(t (:eval lsp--headerline-breadcrumb-string)) header-line-format)))))
 
 ;;;###autoload
-(defun lsp-breadrumb-go-to-symbol (symbol-position)
+(defun lsp-breadcrumb-go-to-symbol (symbol-position)
   "Go to the symbol on breadcrumb at SYMBOL-POSITION."
   (interactive "P")
   (if (numberp symbol-position)
@@ -2227,7 +2227,7 @@ PATH is the current folder to be checked."
     (lsp--info "Call this function with a number representing the symbol position on breadcrumb")))
 
 ;;;###autoload
-(defun lsp-breadrumb-narrow-to-symbol (symbol-position)
+(defun lsp-breadcrumb-narrow-to-symbol (symbol-position)
   "Narrow to the symbol range on breadcrumb at SYMBOL-POSITION."
   (interactive "P")
   (if (numberp symbol-position)


### PR DESCRIPTION
Improves on our current breadcrumb following some ideas from https://github.com/emacs-lsp/lsp-mode/pull/1899:

* Add project path on breadcrumb (like vscode), currently without any mouse support/action 
* Add mouse support for document symbols
  * mouse-1: go to symbol 
  * mouse-2: narrow to region (following @danielmartin [suggestion](https://github.com/emacs-lsp/lsp-mode/issues/1823#issuecomment-651365097))
* Add function to go to symbol and function to narrow via prefix args: `C-3 M-x lsp-breadcrumb-go-to-symbol`

![image](https://user-images.githubusercontent.com/7820865/87236463-6bec3200-c3c0-11ea-889e-6fde506ed363.png)
