### PR TITLE
Make semantic tokens fetching conform to spec

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -948,6 +948,11 @@ directory")
     ("textDocument/rename" :capability :renameProvider)
     ("textDocument/selectionRange" :capability :selectionRangeProvider)
     ("textDocument/semanticTokens" :capability :semanticTokensProvider)
+    ("textDocument/semanticTokensLegacy"
+     :check-command (lambda (workspace)
+                      (with-lsp-workspace workspace
+                        (lsp-get (lsp--capability :semanticTokensProvider)
+                                 :rangeProvider))))
     ("textDocument/semanticTokensRangeProvider"
      :check-command (lambda (workspace)
                       (with-lsp-workspace workspace
@@ -6190,7 +6195,11 @@ A reference is highlighted only if it is visible in a window."
     (when lsp--semantic-tokens-idle-timer
       (cancel-timer lsp--semantic-tokens-idle-timer))
     (lsp-request-async
-     (if region "textDocument/semanticTokens/range" "textDocument/semanticTokens/full")
+     (cond
+      (region "textDocument/semanticTokens/range")
+      ((lsp-feature? "textDocument/semanticTokensLegacy")
+       "textDocument/semanticTokens")
+      (t "textDocument/semanticTokens/full"))
      `(:textDocument ,(lsp--text-document-identifier)
        ,@(if region (list :range (lsp--region-to-range (car region) (cdr region))) '()))
      (lambda (response)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -948,11 +948,11 @@ directory")
     ("textDocument/rename" :capability :renameProvider)
     ("textDocument/selectionRange" :capability :selectionRangeProvider)
     ("textDocument/semanticTokens" :capability :semanticTokensProvider)
-    ("textDocument/semanticTokensLegacy"
+    ("textDocument/semanticTokensFull"
      :check-command (lambda (workspace)
                       (with-lsp-workspace workspace
                         (lsp-get (lsp--capability :semanticTokensProvider)
-                                 :rangeProvider))))
+                                 :full))))
     ("textDocument/semanticTokensRangeProvider"
      :check-command (lambda (workspace)
                       (with-lsp-workspace workspace
@@ -6197,9 +6197,9 @@ A reference is highlighted only if it is visible in a window."
     (lsp-request-async
      (cond
       (region "textDocument/semanticTokens/range")
-      ((lsp-feature? "textDocument/semanticTokensLegacy")
-       "textDocument/semanticTokens")
-      (t "textDocument/semanticTokens/full"))
+      ((lsp-feature? "textDocument/semanticTokensFull")
+       "textDocument/semanticTokens/full")
+      (t "textDocument/semanticTokens"))
      `(:textDocument ,(lsp--text-document-identifier)
        ,@(if region (list :range (lsp--region-to-range (car region) (cdr region))) '()))
      (lambda (response)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6190,7 +6190,7 @@ A reference is highlighted only if it is visible in a window."
     (when lsp--semantic-tokens-idle-timer
       (cancel-timer lsp--semantic-tokens-idle-timer))
     (lsp-request-async
-     (if region "textDocument/semanticTokens/range" "textDocument/semanticTokens")
+     (if region "textDocument/semanticTokens/range" "textDocument/semanticTokens/full")
      `(:textDocument ,(lsp--text-document-identifier)
        ,@(if region (list :range (lsp--region-to-range (car region) (cdr region))) '()))
      (lambda (response)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -951,7 +951,7 @@ directory")
     ("textDocument/semanticTokensRangeProvider"
      :check-command (lambda (workspace)
                       (with-lsp-workspace workspace
-                        (lsp-get (lsp--capability :semanticTokensProvider) :rangeProvider))))
+                        (lsp-get (lsp--capability :semanticTokensProvider) :range))))
     ("textDocument/signatureHelp" :capability :signatureHelpProvider)
     ("textDocument/typeDefinition" :capability :typeDefinitionProvider)
     ("workspace/executeCommand" :capability :executeCommandProvider)


### PR DESCRIPTION
My reading of the [LSP specification for semantic tokens](https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#textDocument_semanticTokens) seems to indicate that:

  1. The method to get tokens for the entire file is `textDocument/semanticTokens/full`, not just `textDocument/semanticTokens`.
  2. The server capability to indicate support for semantic token range requests is just `range`, not `rangeProvider`.

I assume there is a reason for the current implementation, but maybe this can start a discussion if some existing language servers require some sort of backwards compatibility.