### PR TITLE
Optionally number breadcrumb entries

### DIFF
--- a/docs/page/main-features.md
+++ b/docs/page/main-features.md
@@ -70,6 +70,8 @@ You can customize the breadcrumb segments via `lsp-headerline-breadcrumb-segment
 
 ![](../examples/headerline-breadcrumb-symbols.png)
 
+If `lsp-headerline-breadcrumb-segments` contains `'symbols`, you can optionally label the corresponding entries in the headerline display by setting `lsp-headerline-breadcrumb-enable-symbol-numbers` to `t`.
+
 ## Symbol highlights
 
 In case LSP server supports `hover` feature:


### PR DESCRIPTION
This obviates the need for the user to manually count symbol positions
when using lsp-breadcrumb-narrow-to-symbol and lsp-breadcrumb-go-to-symbol.