### PR TITLE
Prefer lsp-headerline-breadcrumb-symbols-face over -separator-face...

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2275,7 +2275,7 @@ PATH is the current folder to be checked."
                        (concat
                         (propertize (number-to-string index)
                                     'face
-                                    'lsp-headerline-breadcrumb-separator-face)
+                                    'lsp-headerline-breadcrumb-symbols-face)
                         " ")
                      "")
                    (if symbol2-icon


### PR DESCRIPTION
...for optional numbering of breadcrumb symbols.

This is more consistent UX since the numbers are meant to facilitate
selection of symbols, not to emphasize any kind of separation.


----

#