### PR TITLE
lsp-headerline--go-to-symbol: widen to include already narrowed region

### DIFF
--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -112,19 +112,19 @@ for caching purposes.")
     (concat (lsp-headerline--fix-image-background (lsp-treemacs-symbol-icon kind))
             " ")))
 
-(lsp-defun lsp-headerline--go-to-symbol
-  ((&DocumentSymbol :selection-range (&RangeToPoint :start selection-range-start)
-                    :range (&RangeToPoint :start narrowing-range-start
-                                          :end narrowing-range-end)))
+(lsp-defun lsp-headerline--go-to-symbol ((&DocumentSymbol
+                                          :selection-range (&RangeToPoint :start selection-start)
+                                          :range (&RangeToPoint :start narrowing-start
+                                                                :end narrowing-end)))
   "Go to breadcrumb symbol.
 If the buffer is narrowed and the target symbol lies before the
 minimum reachable point in the narrowed buffer, then widen and
 narrow to the outer symbol."
-  (when (< selection-range-start (point-min))
-      (narrow-to-region
-       narrowing-range-start
-       narrowing-range-end))
-  (goto-char selection-range-start))
+  (when (buffer-narrowed-p)
+    (narrow-to-region
+     (min (point-min) narrowing-start)
+     (max (point-max) narrowing-end)))
+  (goto-char selection-start))
 
 (lsp-defun lsp-headerline--narrow-to-symbol ((&DocumentSymbol :range (&RangeToPoint :start :end)))
   "Narrow to breadcrumb symbol range."


### PR DESCRIPTION
Follow up on #1916 to make sure the user narrowed region is also included.