### PR TITLE
expand-snippet: indent according to the line where snippet is expanded

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -427,7 +427,8 @@ Others: TRIGGER-CHARS"
                        'lsp-completion-markers markers
                        'lsp-completion-prefix prefix)
                (text-properties-at 0 candidate))
-              ((&CompletionItem :label :insert-text? :text-edit? :insert-text-format? :additional-text-edits?)
+              ((&CompletionItem :label :insert-text? :text-edit? :insert-text-format?
+                                :additional-text-edits? :keep-whitespace?)
                item))
         (cond
          (text-edit?
@@ -440,12 +441,12 @@ Others: TRIGGER-CHARS"
           (delete-region start-point (point))
           (insert (or insert-text? label))))
 
-        (when (eq insert-text-format? 2)
-          (let ((yas-indent-line (lsp--indent-snippets?)))
-            (yas-expand-snippet
-             (lsp--to-yasnippet-snippet (buffer-substring start-point (point)))
-             start-point
-             (point))))
+        (when (equal insert-text-format? lsp/insert-text-format-snippet)
+          (lsp--expand-snippet (buffer-substring start-point (point))
+                               start-point
+                               (point)
+                               nil
+                               keep-whitespace?))
 
         (when lsp-completion-enable-additional-text-edit
           (if (or (get-text-property 0 'lsp-completion-resolved candidate)

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -404,7 +404,7 @@ See `-let' for a description of the destructuring mechanism."
  (Command (:title :command) (:arguments))
  (CompletionCapabilities nil (:completionItem :completionItemKind :contextSupport :dynamicRegistration))
  (CompletionContext (:triggerKind) (:triggerCharacter))
- (CompletionItem (:label) (:additionalTextEdits :command :commitCharacters :data :deprecated :detail :documentation :filterText :insertText :insertTextFormat :kind :preselect :sortText :tags :textEdit :score))
+ (CompletionItem (:label) (:additionalTextEdits :command :commitCharacters :data :deprecated :detail :documentation :filterText :insertText :insertTextFormat :kind :preselect :sortText :tags :textEdit :score :keepWhitespace))
  (CompletionItemCapabilities nil (:commitCharactersSupport :deprecatedSupport :documentationFormat :preselectSupport :snippetSupport :tagSupport))
  (CompletionItemKindCapabilities nil (:valueSet))
  (CompletionItemTagSupportCapabilities (:valueSet) nil)


### PR DESCRIPTION
Doing what's suggest in #1935 to simply align the expanded snippet with the indentation level of where snippet is expanded.
This should be fairly fast and could be used even in `org-mode`.