### PR TITLE
formatting-params: using indent as tab size

### DIFF
--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -432,7 +432,7 @@ See `-let' for a description of the destructuring mechanism."
  (FoldingRangeCapabilities nil (:dynamicRegistration :lineFoldingOnly :rangeLimit))
  (FoldingRangeProviderOptions nil (:documentSelector :id))
  (FormattingCapabilities nil (:dynamicRegistration))
- (FormattingOptions (:loadFactor :threshold :accessOrder) nil)
+ (FormattingOptions (:tabSize :insertSpaces) (:trimTrailingWhitespace :insertFinalNewline :trimFinalNewlines))
  (HoverCapabilities nil (:contentFormat :dynamicRegistration))
  (ImplementationCapabilities nil (:dynamicRegistration :linkSupport))
  (Location (:range :uri) nil)


### PR DESCRIPTION
In Emacs we have indent width which different from major mode to major mode and `tab-width`, which is mostly unchanged.
In LSP, the concept of indent width and tab width is merged and considered as `tabSize`.
Until now we have a mitigation for `c-related-mode` to using `c-basic-offset` instead of `tab-width`. However, that should be reconsidered as indent width for each major mode.
After all, it's indent width that's used to indent line (and need formatting) instead of tab width.