### PR TITLE
[lsp-eslint] Handle source.fixAll code action

### DIFF
--- a/lsp-eslint.el
+++ b/lsp-eslint.el
@@ -88,6 +88,16 @@
   :type 'boolean
   :package-version '(lsp-mode . "6.3"))
 
+(defcustom lsp-eslint-fix-all-problem-type
+  "all"
+  "Determines which problems are fixed when running the
+source.fixAll code action."
+  :type '(choice
+          (const "all")
+          (const "problems")
+          string)
+  :package-version '(lsp-mode . "7.0"))
+
 (defcustom lsp-eslint-quiet nil
   "Turns on quiet mode, which ignores warnings."
   :type 'boolean
@@ -178,7 +188,8 @@
                     (with-current-buffer buffer
                       (list :validate "probe"
                             :packageManager lsp-eslint-package-manager
-                            :codeActionOnSave t
+                            :codeActionOnSave (list :enable t
+                                                    :mode lsp-eslint-fix-all-problem-type)
                             :format (lsp-json-bool lsp-eslint-format)
                             :options (or lsp-eslint-options (ht))
                             :run (or lsp-eslint-run "onType")
@@ -192,17 +203,19 @@
                                                                  (list :enable t
                                                                        :location "separateLine"))
                                          :showDocumentation (or lsp-eslint-code-action-show-documentation
-                                                                (list :enable t)) ))))))
+                                                                (list :enable t))))))))
        (apply #'vector)))
 
 (lsp-defun lsp-eslint--open-doc (_workspace (&eslint:OpenESLintDocParams :url))
-  "Open doccumentation."
+  "Open documentation."
   (browse-url url))
 
 (defun lsp-eslint-apply-all-fixes ()
   "Apply all autofixes in the current buffer."
   (interactive)
   (lsp-send-execute-command "eslint.applyAllFixes" (vector (lsp--versioned-text-document-identifier))))
+
+(lsp-make-interactive-code-action eslint-fix-all "source.fixAll.eslint")
 
 (lsp-register-client
  (make-lsp-client
@@ -235,10 +248,10 @@
                                             :watchers
                                             `[,(lsp-make-file-system-watcher
                                                 :glob-pattern "**/.eslintr{c.js,c.yaml,c.yml,c,c.json}")
-                                               ,(lsp-make-file-system-watcher
-                                                 :glob-pattern "**/.eslintignore")
-                                               ,(lsp-make-file-system-watcher
-                                                 :glob-pattern "**/package.json")])))))))
+                                              ,(lsp-make-file-system-watcher
+                                                :glob-pattern "**/.eslintignore")
+                                              ,(lsp-make-file-system-watcher
+                                                :glob-pattern "**/package.json")])))))))
 
 (provide 'lsp-eslint)
 ;;; lsp-eslint.el ends here

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5509,14 +5509,19 @@ If ACTION is not set it will be selected from `lsp-code-actions-at-point'."
         (lsp--info "No formatting changes provided")
       (lsp--apply-text-edits edits))))
 
-(defun lsp-organize-imports ()
-  "Perform the source.organizeImports code action, if available."
-  (interactive)
-  (condition-case nil
-      (lsp-execute-code-action-by-kind "source.organizeImports")
-    (lsp-no-code-actions
-     (when (called-interactively-p 'any)
-       (lsp--info "source.organizeImports action not available")))))
+(defmacro lsp-make-interactive-code-action (func-name code-action-kind)
+  "Define an interactive function FUNC-NAME that attempts to
+execute a CODE-ACTION-KIND action."
+  `(defun ,(intern (concat "lsp-" (symbol-name func-name))) ()
+     ,(format "Perform the %s code action, if available." code-action-kind)
+     (interactive)
+     (condition-case nil
+         (lsp-execute-code-action-by-kind ,code-action-kind)
+       (lsp-no-code-actions
+        (when (called-interactively-p 'any)
+          (lsp--info ,(format "%s action not available" code-action-kind)))))))
+
+(lsp-make-interactive-code-action organize-imports "source.organizeImports")
 
 (defun lsp--make-document-range-formatting-params (start end)
   "Make DocumentRangeFormattingParams for selected region."


### PR DESCRIPTION
* lsp-mode: define the macro lsp-make-interactive-code-action

Related to #1842 and #1634.

I tested this with VSCode ESLint at commit d89696237a74e16fd6c09c95ae1c0830e6774ef4, prior to the weird `confirmLocalESLint` request. This seems to work from anywhere in the buffer as long as there is something that can be autofixed.

I'm not sure how best to put this on `before-save-hook` since doing it that way will make the fix-all function run in non-ESLint buffers.