### PR TITLE
Fix defcustom version and remove macro invocation in lsp-eslint

### DIFF
--- a/lsp-eslint.el
+++ b/lsp-eslint.el
@@ -215,7 +215,17 @@ source.fixAll code action."
   (interactive)
   (lsp-send-execute-command "eslint.applyAllFixes" (vector (lsp--versioned-text-document-identifier))))
 
-(lsp-make-interactive-code-action eslint-fix-all "source.fixAll.eslint")
+;; XXX: replace with `lsp-make-interactive-code-action' macro
+;; (lsp-make-interactive-code-action eslint-fix-all "source.fixAll.eslint")
+
+(defun lsp-eslint-fix-all ()
+  "Perform the source.fixAll.eslint code action, if available."
+  (interactive)
+  (condition-case nil
+      (lsp-execute-code-action-by-kind "source.fixAll.eslint")
+    (lsp-no-code-actions
+     (when (called-interactively-p 'any)
+       (lsp--info "source.fixAll.eslint action not available")))))
 
 (lsp-register-client
  (make-lsp-client

--- a/lsp-eslint.el
+++ b/lsp-eslint.el
@@ -96,7 +96,7 @@ source.fixAll code action."
           (const "all")
           (const "problems")
           string)
-  :package-version '(lsp-mode . "7.0"))
+  :package-version '(lsp-mode . "7.0.1"))
 
 (defcustom lsp-eslint-quiet nil
   "Turns on quiet mode, which ignores warnings."


### PR DESCRIPTION
@yyoncho I'm still a bit confused about the problem. For now I propose removing the macro invocation and simply writing the function manually. From your post it sounds like the problem will go away when we cut a new version?