### PR TITLE
Move Flycheck/Flymake to lsp-diagnostics.el

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,9 @@
 * Changelog
 ** Release 7.0.1
+  * Introduced ~lsp-checker-mode~ and ~lsp-checker-enable~.
+  * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-checker-flycheck-default-level~
+  * Safe renamed ~lsp-diagnostics-attributes~ -> ~lsp-checker-diagnostics-attributes~
+  * Safe renamed ~lsp-diagnostic-package~ -> ~lsp-checker-provider~
   * Dropped support for ~company-lsp~, the suggested provider is ~company-capf~.
   * Moved completion features to ~lsp-completion.el~
   * Safe renamed ~lsp-prefer-capf~ -> ~lsp-completion-provider~

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,9 +1,8 @@
 * Changelog
 ** Release 7.0.1
-  * Introduced ~lsp-checker-mode~.
-  * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-checker-flycheck-default-level~
-  * Safe renamed ~lsp-diagnostics-attributes~ -> ~lsp-checker-diagnostics-attributes~
-  * Safe renamed ~lsp-diagnostic-package~ -> ~lsp-checker-provider~
+  * Introduced ~lsp-diagnostics-mode~.
+  * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~
+  * Safe renamed ~lsp-diagnostic-package~ -> ~lsp-diagnostics-provider~
   * Dropped support for ~company-lsp~, the suggested provider is ~company-capf~.
   * Moved completion features to ~lsp-completion.el~
   * Safe renamed ~lsp-prefer-capf~ -> ~lsp-completion-provider~

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,6 +1,6 @@
 * Changelog
 ** Release 7.0.1
-  * Introduced ~lsp-checker-mode~ and ~lsp-checker-enable~.
+  * Introduced ~lsp-checker-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-checker-flycheck-default-level~
   * Safe renamed ~lsp-diagnostics-attributes~ -> ~lsp-checker-diagnostics-attributes~
   * Safe renamed ~lsp-diagnostic-package~ -> ~lsp-checker-provider~

--- a/docs/page/settings.md
+++ b/docs/page/settings.md
@@ -17,7 +17,7 @@ These are `lsp-mode` specific custom settings:
 - `lsp-eldoc-render-all` - Display all of the info returned by `document/onHover`. If this is nil, `eldoc` will show only the symbol information.
 - `lsp-enable-completion-at-point` - Enable `completion-at-point` integration.
 - `lsp-enable-xref` - Enable xref integration.
-- `lsp-diagnostic-package` - Specifies which package to use for diagnostics. Choose from `:auto`, `:flycheck`, `:flymake` and `:none`. Default is `:auto` which means use `:flycheck` if present.
+- `lsp-checker-provider` - Specifies which package to use for diagnostics. Choose from `:auto`, `:flycheck`, `:flymake` and `:none`. Default is `:auto` which means use `:flycheck` if present and fallback to `:flymake`.
 - `lsp-enable-indentation` - Indent regions using the file formatting functionality provided by the language server.
 - `lsp-enable-on-type-formatting` - Enable `textDocument/onTypeFormatting` integration.
 - `lsp-before-save-edits` - If non-nil, `lsp-mode` will apply edits suggested by the language server before saving a document.

--- a/docs/page/settings.md
+++ b/docs/page/settings.md
@@ -17,7 +17,7 @@ These are `lsp-mode` specific custom settings:
 - `lsp-eldoc-render-all` - Display all of the info returned by `document/onHover`. If this is nil, `eldoc` will show only the symbol information.
 - `lsp-enable-completion-at-point` - Enable `completion-at-point` integration.
 - `lsp-enable-xref` - Enable xref integration.
-- `lsp-checker-provider` - Specifies which package to use for diagnostics. Choose from `:auto`, `:flycheck`, `:flymake` and `:none`. Default is `:auto` which means use `:flycheck` if present and fallback to `:flymake`.
+- `lsp-diagnostics-provider` - Specifies which package to use for diagnostics. Choose from `:auto`, `:flycheck`, `:flymake` and `:none`. Default is `:auto` which means use `:flycheck` if present and fallback to `:flymake`.
 - `lsp-enable-indentation` - Indent regions using the file formatting functionality provided by the language server.
 - `lsp-enable-on-type-formatting` - Enable `textDocument/onTypeFormatting` integration.
 - `lsp-before-save-edits` - If non-nil, `lsp-mode` will apply edits suggested by the language server before saving a document.

--- a/lsp-checker.el
+++ b/lsp-checker.el
@@ -311,8 +311,7 @@ See https://github.com/emacs-lsp/lsp-mode."
 
 ;;;###autoload
 (add-hook 'lsp-configure-hook (lambda ()
-                                (when (and lsp-auto-configure
-                                           lsp-checker-enable)
+                                (when lsp-auto-configure
                                   (lsp-checker--enable))))
 
 (provide 'lsp-checker)

--- a/lsp-checker.el
+++ b/lsp-checker.el
@@ -182,15 +182,6 @@ from the language server."
 
 (defun lsp-checker--flycheck-enable (&rest _)
   "Enable flycheck integration for the current buffer."
-  (flycheck-mode 1)
-  (setq-local flycheck-checker 'lsp)
-  (lsp-flycheck-add-mode major-mode)
-  (add-to-list 'flycheck-checkers 'lsp)
-  (add-hook 'lsp-diagnostics-updated-hook #'lsp-checker--flycheck-report nil t)
-  (add-hook 'lsp-managed-mode-hook #'lsp-checker--flycheck-report nil t))
-
-;;;###autoload
-(with-eval-after-load 'flycheck
   (flycheck-define-generic-checker 'lsp
     "A syntax checker using the Language Server Protocol (LSP)
 provided by lsp-mode.
@@ -201,7 +192,13 @@ See https://github.com/emacs-lsp/lsp-mode."
     :error-explainer (lambda (e)
                        (cond ((string-prefix-p "clang-tidy" (flycheck-error-message e))
                               (lsp-cpp-flycheck-clang-tidy-error-explainer e))
-                             (t (flycheck-error-message e))))))
+                             (t (flycheck-error-message e)))))
+  (flycheck-mode 1)
+  (setq-local flycheck-checker 'lsp)
+  (lsp-flycheck-add-mode major-mode)
+  (add-to-list 'flycheck-checkers 'lsp)
+  (add-hook 'lsp-diagnostics-updated-hook #'lsp-checker--flycheck-report nil t)
+  (add-hook 'lsp-managed-mode-hook #'lsp-checker--flycheck-report nil t))
 
 
 ;; Flymake integration
@@ -291,21 +288,21 @@ See https://github.com/emacs-lsp/lsp-mode."
    (lsp-checker-mode
     (cond
      ((or
-       (and (eq lsp-diagnostic-package :auto)
+       (and (eq lsp-checker-provider :auto)
             (functionp 'flycheck-mode))
-       (and (eq lsp-diagnostic-package :flycheck)
+       (and (eq lsp-checker-provider :flycheck)
             (or (functionp 'flycheck-mode)
-                (user-error "The lsp-diagnostic-package is set to :flycheck but flycheck is not installed?")))
+                (user-error "The lsp-checker-provider is set to :flycheck but flycheck is not installed?")))
        ;; legacy
-       (null lsp-diagnostic-package))
+       (null lsp-checker-provider))
       (lsp-checker--flycheck-enable))
      ((and (not (version< emacs-version "26.1"))
-           (or (eq lsp-diagnostic-package :auto)
-               (eq lsp-diagnostic-package :flymake)
-               (eq lsp-diagnostic-package t)))
+           (or (eq lsp-checker-provider :auto)
+               (eq lsp-checker-provider :flymake)
+               (eq lsp-checker-provider t)))
       (require 'flymake)
       (lsp-checker--flymake-setup))
-     ((not (eq lsp-diagnostic-package :none))
+     ((not (eq lsp-checker-provider :none))
       (lsp--warn "Unable to autoconfigure flycheck/flymake. The diagnostics won't be rendered.")))
 
     (add-hook 'lsp-unconfigure-hook #'lsp-checker--disable nil t))

--- a/lsp-checker.el
+++ b/lsp-checker.el
@@ -1,0 +1,241 @@
+;;; lsp-checker.el --- LSP checkers integration -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2020 emacs-lsp maintainers
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;;
+;;  LSP checkers integration
+;;
+;;; Code:
+
+(require 'lsp-mode)
+
+(defcustom lsp-diagnostic-package :auto
+  "`lsp-mode' diagnostics auto-configuration."
+  :type
+  '(choice
+    (const :tag "Pick flycheck if present and fallback to flymake" :auto)
+    (const :tag "Pick flycheck" :flycheck)
+    (const :tag "Pick flymake" :flymake)
+    (const :tag "Use neither flymake nor lsp" :none)
+    (const :tag "Prefer flymake" t)
+    (const :tag "Prefer flycheck" nil))
+  :group 'lsp-mode
+  :package-version '(lsp-mode . "6.3"))
+
+(make-obsolete-variable 'lsp-prefer-flymake 'lsp-diagnostic-package "lsp-mode 6.2")
+
+(defcustom lsp-flycheck-default-level 'error
+  "Error level to use when the server does not report back a diagnostic level."
+  :type '(choice (const error)
+                 (const warning)
+                 (const info))
+  :group 'lsp-mode)
+
+(defvar lsp-diagnostics-attributes
+  `((unnecessary :foreground "dim gray")
+    (deprecated  :strike-through t))
+  "The Attributes used on the diagnostics.
+List containing (tag attributes) where tag is the LSP diagnostic tag and
+attributes is a `plist' containing face attributes which will be applied
+on top the flycheck face for that error level.")
+
+;; Flycheck integration
+
+(declare-function flycheck-mode "ext:flycheck")
+(declare-function flycheck-define-generic-checker
+                  "ext:flycheck" (symbol docstring &rest properties))
+(declare-function flycheck-error-new "ext:flycheck" t t)
+(declare-function flycheck-error-message "ext:flycheck" (err) t)
+(declare-function flycheck-define-error-level "ext:flycheck" (level &rest properties))
+(declare-function flycheck-buffer "ext:flycheck")
+
+(declare-function lsp-cpp-flycheck-clang-tidy-error-explainer "lsp-cpp")
+
+(defvar flycheck-check-syntax-automatically)
+(defvar flycheck-checker)
+(defvar flycheck-checkers)
+
+(defun lsp--flycheck-level (flycheck-level tags)
+  "Generate flycheck level from the original FLYCHECK-LEVEL (e.
+g. `error', `warning') and list of LSP TAGS."
+  (let ((name (format "lsp-flycheck-%s-%s"
+                      flycheck-level
+                      (mapconcat #'symbol-name tags "-"))))
+    (or (intern-soft name)
+        (let* ((face (--doto (intern (format "lsp-%s-face" name))
+                       (copy-face (-> flycheck-level
+                                      (get 'flycheck-overlay-category)
+                                      (get 'face))
+                                  it)
+                       (mapc (lambda (tag)
+                               (apply #'set-face-attribute it nil
+                                      (cl-rest (assoc tag lsp-diagnostics-attributes))))
+                             tags)))
+               (category (--doto (intern (format "lsp-%s-category" name))
+                           (setf (get it 'face) face
+                                 (get it 'priority) 100)))
+               (new-level (intern name))
+               (bitmap (or (get flycheck-level 'flycheck-fringe-bitmaps)
+                           (get flycheck-level 'flycheck-fringe-bitmap-double-arrow))))
+          (flycheck-define-error-level new-level
+            :severity (get flycheck-level 'flycheck-error-severity)
+            :compilation-level (get flycheck-level 'flycheck-compilation-level)
+            :overlay-category category
+            :fringe-bitmap bitmap
+            :fringe-face (get flycheck-level 'flycheck-fringe-face)
+            :error-list-face face)
+          new-level))))
+
+(defun lsp--flycheck-calculate-level (severity tags)
+  "Calculate flycheck level by SEVERITY and TAGS."
+  (let ((level (pcase severity
+                 (1 'error)
+                 (2 'warning)
+                 (3 'info)
+                 (4 'info)
+                 (_ lsp-flycheck-default-level)))
+        ;; materialize only first tag.
+        (tags (seq-map (lambda (tag)
+                         (cond
+                          ((= tag lsp/diagnostic-tag-unnecessary) 'unnecessary)
+                          ((= tag lsp/diagnostic-tag-deprecated) 'deprecated)))
+                       tags)))
+    (if tags
+        (lsp--flycheck-level level tags)
+      level)))
+
+(defun lsp--flycheck-start (checker callback)
+  "Start an LSP syntax check with CHECKER.
+
+CALLBACK is the status callback passed by Flycheck."
+
+  (remove-hook 'lsp-on-idle-hook #'lsp--flycheck-buffer t)
+
+  (->> (lsp--get-buffer-diagnostics)
+       (-map (-lambda ((&Diagnostic :message :severity? :tags? :code?
+                                    :range (&Range :start (&Position :line      start-line
+                                                                     :character start-character)
+                                                   :end   (&Position :line      end-line
+                                                                     :character end-character))))
+               (flycheck-error-new
+                :buffer (current-buffer)
+                :checker checker
+                :filename buffer-file-name
+                :message message
+                :level (lsp--flycheck-calculate-level severity? tags?)
+                :id code?
+                :line (lsp-translate-line (1+ start-line))
+                :column (1+ (lsp-translate-column start-character))
+                :end-line (lsp-translate-line (1+ end-line))
+                :end-column (1+ (lsp-translate-column end-character)))))
+       (funcall callback 'finished)))
+
+(defun lsp--flycheck-buffer ()
+  "Trigger flyckeck on buffer."
+  (remove-hook 'lsp-on-idle-hook #'lsp--flycheck-buffer t)
+  (flycheck-buffer))
+
+(defun lsp--flycheck-report ()
+  "Report flycheck.
+This callback is invoked when new diagnostics are received
+from the language server."
+  (when (and (or (memq 'idle-change flycheck-check-syntax-automatically)
+                 (and (memq 'save flycheck-check-syntax-automatically)
+                      (not (buffer-modified-p))))
+             lsp--cur-workspace)
+    ;; make sure diagnostics are published even if the diagnostics
+    ;; have been received after idle-change has been triggered
+    (->> lsp--cur-workspace
+         (lsp--workspace-buffers)
+         (mapc (lambda (buffer)
+                 (when (lsp-buffer-live-p buffer)
+                   (lsp-with-current-buffer buffer
+                     (add-hook 'lsp-on-idle-hook #'lsp--flycheck-buffer nil t)
+                     (lsp--idle-reschedule (current-buffer)))))))))
+
+(defun lsp-flycheck-enable (&rest _)
+  "Enable flycheck integration for the current buffer."
+  (flycheck-mode 1)
+  (setq-local flycheck-checker 'lsp)
+  (lsp-flycheck-add-mode major-mode)
+  (add-to-list 'flycheck-checkers 'lsp)
+  (add-hook 'lsp-diagnostics-updated-hook #'lsp--flycheck-report nil t)
+  (add-hook 'lsp-managed-mode-hook #'lsp--flycheck-report nil t))
+
+;;;###autoload
+(with-eval-after-load 'flycheck
+  (flycheck-define-generic-checker 'lsp
+    "A syntax checker using the Language Server Protocol (LSP)
+provided by lsp-mode.
+See https://github.com/emacs-lsp/lsp-mode."
+    :start #'lsp--flycheck-start
+    :modes '(lsp-placeholder-mode) ;; placeholder
+    :predicate (lambda () lsp-mode)
+    :error-explainer (lambda (e)
+                       (cond ((string-prefix-p "clang-tidy" (flycheck-error-message e))
+                              (lsp-cpp-flycheck-clang-tidy-error-explainer e))
+                             (t (flycheck-error-message e))))))
+
+;;;###autoload
+(defun lsp-checker--enable ()
+  "Enable LSP checker support."
+  (when lsp-checker-enable
+    (lsp-checker-mode 1)))
+
+(defun lsp-checker--disable ()
+  "Disable LSP checker support."
+  (lsp-checker-mode -1))
+
+;;;###autoload
+(define-minor-mode lsp-checker-mode
+  "Toggle LSP checker integration."
+  :group 'lsp-mode
+  :global nil
+  :lighter ""
+  (cond
+   (lsp-checker-mode
+    (cond
+     ((or
+       (and (eq lsp-diagnostic-package :auto)
+            (functionp 'flycheck-mode))
+       (and (eq lsp-diagnostic-package :flycheck)
+            (or (functionp 'flycheck-mode)
+                (user-error "The lsp-diagnostic-package is set to :flycheck but flycheck is not installed?")))
+       ;; legacy
+       (null lsp-diagnostic-package))
+      (lsp-flycheck-enable))
+     ((and (not (version< emacs-version "26.1"))
+           (or (eq lsp-diagnostic-package :auto)
+               (eq lsp-diagnostic-package :flymake)
+               (eq lsp-diagnostic-package t)))
+      (require 'flymake)
+      (lsp--flymake-setup))
+     ((not (eq lsp-diagnostic-package :none))
+      (lsp--warn "Unable to autoconfigure flycheck/flymake. The diagnostics won't be rendered.")))
+
+    (add-hook 'lsp-unconfigure-hook #'lsp-checker--disable nil t))
+   (t
+    (remove-hook 'lsp-unconfigure-hook #'lsp-checker--disable t))))
+
+;;;###autoload
+(add-hook 'lsp-configure-hook (lambda ()
+                                (when (and lsp-auto-configure
+                                           lsp-checker-enable)
+                                  (lsp-checker--enable))))
+
+(provide 'lsp-checker)
+;;; lsp-checker.el ends here

--- a/lsp-checker.el
+++ b/lsp-checker.el
@@ -271,7 +271,7 @@ See https://github.com/emacs-lsp/lsp-mode."
 ;;;###autoload
 (defun lsp-checker--enable ()
   "Enable LSP checker support."
-  (when lsp-checker-enable
+  (unless (eq lsp-checker-provider :none)
     (lsp-checker-mode 1)))
 
 (defun lsp-checker--disable ()

--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -23,12 +23,6 @@
 
 (require 'lsp-mode)
 
-(define-obsolete-variable-alias 'lsp-prefer-flymake
-  'lsp-diagnostics-provider  "lsp-mode 6.2")
-
-(define-obsolete-variable-alias 'lsp-diagnostic-package
-  'lsp-diagnostics-provider  "lsp-mode 7.0.1")
-
 (defcustom lsp-diagnostics-provider :auto
   "The checker backend provider."
   :type

--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -23,6 +23,10 @@
 
 (require 'lsp-mode)
 
+;;;###autoload
+(define-obsolete-variable-alias 'lsp-diagnostic-package
+  'lsp-diagnostics-provider  "lsp-mode 7.0.1")
+
 (defcustom lsp-diagnostics-provider :auto
   "The checker backend provider."
   :type

--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -1,4 +1,4 @@
-;;; lsp-checker.el --- LSP checkers integration -*- lexical-binding: t; -*-
+;;; lsp-diagnostics.el --- LSP diagnostics integration -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (C) 2020 emacs-lsp maintainers
 ;;
@@ -17,19 +17,19 @@
 ;;
 ;;; Commentary:
 ;;
-;;  LSP checkers integration
+;;  LSP diagnostics integration
 ;;
 ;;; Code:
 
 (require 'lsp-mode)
 
 (define-obsolete-variable-alias 'lsp-prefer-flymake
-  'lsp-checker-provider  "lsp-mode 6.2")
+  'lsp-diagnostics-provider  "lsp-mode 6.2")
 
 (define-obsolete-variable-alias 'lsp-diagnostic-package
-  'lsp-checker-provider  "lsp-mode 7.0.1")
+  'lsp-diagnostics-provider  "lsp-mode 7.0.1")
 
-(defcustom lsp-checker-provider :auto
+(defcustom lsp-diagnostics-provider :auto
   "The checker backend provider."
   :type
   '(choice
@@ -43,9 +43,9 @@
   :package-version '(lsp-mode . "6.3"))
 
 (define-obsolete-variable-alias 'lsp-flycheck-default-level
-  'lsp-checker-flycheck-default-level  "lsp-mode 7.0.1")
+  'lsp-diagnostics-flycheck-default-level  "lsp-mode 7.0.1")
 
-(defcustom lsp-checker-flycheck-default-level 'error
+(defcustom lsp-diagnostics-flycheck-default-level 'error
   "Error level to use when the server does not report back a diagnostic level."
   :type '(choice
           (const error)
@@ -53,10 +53,7 @@
           (const info))
   :group 'lsp-mode)
 
-(define-obsolete-variable-alias 'lsp-diagnostics-attributes
-  'lsp-checker-diagnostics-attributes  "lsp-mode 7.0.1")
-
-(defcustom lsp-checker-diagnostics-attributes
+(defcustom lsp-diagnostics-attributes
   `((unnecessary :foreground "dim gray")
     (deprecated  :strike-through t))
   "The Attributes used on the diagnostics.
@@ -82,7 +79,7 @@ on top the flycheck face for that error level."
 (defvar flycheck-checker)
 (defvar flycheck-checkers)
 
-(defun lsp-checker--flycheck-level (flycheck-level tags)
+(defun lsp-diagnostics--flycheck-level (flycheck-level tags)
   "Generate flycheck level from the original FLYCHECK-LEVEL (e.
 g. `error', `warning') and list of LSP TAGS."
   (let ((name (format "lsp-flycheck-%s-%s"
@@ -96,7 +93,7 @@ g. `error', `warning') and list of LSP TAGS."
                                   it)
                        (mapc (lambda (tag)
                                (apply #'set-face-attribute it nil
-                                      (cl-rest (assoc tag lsp-checker-diagnostics-attributes))))
+                                      (cl-rest (assoc tag lsp-diagnostics-attributes))))
                              tags)))
                (category (--doto (intern (format "lsp-%s-category" name))
                            (setf (get it 'face) face
@@ -113,7 +110,7 @@ g. `error', `warning') and list of LSP TAGS."
             :error-list-face face)
           new-level))))
 
-(defun lsp-checker--flycheck-calculate-level (severity tags)
+(defun lsp-diagnostics--flycheck-calculate-level (severity tags)
   "Calculate flycheck level by SEVERITY and TAGS."
   (let ((level (pcase severity
                  (1 'error)
@@ -128,15 +125,15 @@ g. `error', `warning') and list of LSP TAGS."
                           ((= tag lsp/diagnostic-tag-deprecated) 'deprecated)))
                        tags)))
     (if tags
-        (lsp-checker--flycheck-level level tags)
+        (lsp-diagnostics--flycheck-level level tags)
       level)))
 
-(defun lsp-checker--flycheck-start (checker callback)
+(defun lsp-diagnostics--flycheck-start (checker callback)
   "Start an LSP syntax check with CHECKER.
 
 CALLBACK is the status callback passed by Flycheck."
 
-  (remove-hook 'lsp-on-idle-hook #'lsp-checker--flycheck-buffer t)
+  (remove-hook 'lsp-on-idle-hook #'lsp-diagnostics--flycheck-buffer t)
 
   (->> (lsp--get-buffer-diagnostics)
        (-map (-lambda ((&Diagnostic :message :severity? :tags? :code?
@@ -149,7 +146,7 @@ CALLBACK is the status callback passed by Flycheck."
                 :checker checker
                 :filename buffer-file-name
                 :message message
-                :level (lsp-checker--flycheck-calculate-level severity? tags?)
+                :level (lsp-diagnostics--flycheck-calculate-level severity? tags?)
                 :id code?
                 :line (lsp-translate-line (1+ start-line))
                 :column (1+ (lsp-translate-column start-character))
@@ -157,12 +154,12 @@ CALLBACK is the status callback passed by Flycheck."
                 :end-column (1+ (lsp-translate-column end-character)))))
        (funcall callback 'finished)))
 
-(defun lsp-checker--flycheck-buffer ()
+(defun lsp-diagnostics--flycheck-buffer ()
   "Trigger flyckeck on buffer."
-  (remove-hook 'lsp-on-idle-hook #'lsp-checker--flycheck-buffer t)
+  (remove-hook 'lsp-on-idle-hook #'lsp-diagnostics--flycheck-buffer t)
   (flycheck-buffer))
 
-(defun lsp-checker--flycheck-report ()
+(defun lsp-diagnostics--flycheck-report ()
   "Report flycheck.
 This callback is invoked when new diagnostics are received
 from the language server."
@@ -177,16 +174,16 @@ from the language server."
          (mapc (lambda (buffer)
                  (when (lsp-buffer-live-p buffer)
                    (lsp-with-current-buffer buffer
-                     (add-hook 'lsp-on-idle-hook #'lsp-checker--flycheck-buffer nil t)
+                     (add-hook 'lsp-on-idle-hook #'lsp-diagnostics--flycheck-buffer nil t)
                      (lsp--idle-reschedule (current-buffer)))))))))
 
-(defun lsp-checker--flycheck-enable (&rest _)
+(defun lsp-diagnostics--flycheck-enable (&rest _)
   "Enable flycheck integration for the current buffer."
   (flycheck-define-generic-checker 'lsp
     "A syntax checker using the Language Server Protocol (LSP)
 provided by lsp-mode.
 See https://github.com/emacs-lsp/lsp-mode."
-    :start #'lsp-checker--flycheck-start
+    :start #'lsp-diagnostics--flycheck-start
     :modes '(lsp-placeholder-mode) ;; placeholder
     :predicate (lambda () lsp-mode)
     :error-explainer (lambda (e)
@@ -197,8 +194,8 @@ See https://github.com/emacs-lsp/lsp-mode."
   (setq-local flycheck-checker 'lsp)
   (lsp-flycheck-add-mode major-mode)
   (add-to-list 'flycheck-checkers 'lsp)
-  (add-hook 'lsp-diagnostics-updated-hook #'lsp-checker--flycheck-report nil t)
-  (add-hook 'lsp-managed-mode-hook #'lsp-checker--flycheck-report nil t))
+  (add-hook 'lsp-diagnostics-updated-hook #'lsp-diagnostics--flycheck-report nil t)
+  (add-hook 'lsp-managed-mode-hook #'lsp-diagnostics--flycheck-report nil t))
 
 
 ;; Flymake integration
@@ -209,33 +206,33 @@ See https://github.com/emacs-lsp/lsp-mode."
 
 (defvar flymake-diagnostic-functions)
 (defvar flymake-mode)
-(defvar-local lsp-checker--flymake-report-fn nil)
+(defvar-local lsp-diagnostics--flymake-report-fn nil)
 
-(defun lsp-checker--flymake-setup ()
+(defun lsp-diagnostics--flymake-setup ()
   "Setup flymake."
-  (setq lsp-checker--flymake-report-fn nil)
+  (setq lsp-diagnostics--flymake-report-fn nil)
   (flymake-mode 1)
-  (add-hook 'flymake-diagnostic-functions 'lsp-checker--flymake-backend nil t)
-  (add-hook 'lsp-diagnostics-updated-hook 'lsp-checker--flymake-after-diagnostics nil t))
+  (add-hook 'flymake-diagnostic-functions 'lsp-diagnostics--flymake-backend nil t)
+  (add-hook 'lsp-diagnostics-updated-hook 'lsp-diagnostics--flymake-after-diagnostics nil t))
 
-(defun lsp-checker--flymake-after-diagnostics ()
+(defun lsp-diagnostics--flymake-after-diagnostics ()
   "Handler for `lsp-diagnostics-updated-hook'."
   (cond
-   ((and lsp-checker--flymake-report-fn flymake-mode)
-    (lsp-checker--flymake-update-diagnostics))
+   ((and lsp-diagnostics--flymake-report-fn flymake-mode)
+    (lsp-diagnostics--flymake-update-diagnostics))
    ((not flymake-mode)
-    (setq lsp-checker--flymake-report-fn nil))))
+    (setq lsp-diagnostics--flymake-report-fn nil))))
 
-(defun lsp-checker--flymake-backend (report-fn &rest _args)
+(defun lsp-diagnostics--flymake-backend (report-fn &rest _args)
   "Flymake backend using REPORT-FN."
-  (let ((first-run (null lsp-checker--flymake-report-fn)))
-    (setq lsp-checker--flymake-report-fn report-fn)
+  (let ((first-run (null lsp-diagnostics--flymake-report-fn)))
+    (setq lsp-diagnostics--flymake-report-fn report-fn)
     (when first-run
-      (lsp-checker--flymake-update-diagnostics))))
+      (lsp-diagnostics--flymake-update-diagnostics))))
 
-(defun lsp-checker--flymake-update-diagnostics ()
+(defun lsp-diagnostics--flymake-update-diagnostics ()
   "Report new diagnostics to flymake."
-  (funcall lsp-checker--flymake-report-fn
+  (funcall lsp-diagnostics--flymake-report-fn
            (-some->> (lsp-diagnostics t)
              (gethash (lsp--fix-path-casing buffer-file-name))
              (--map (-let* (((&Diagnostic :message :severity?
@@ -269,50 +266,50 @@ See https://github.com/emacs-lsp/lsp-mode."
 
 
 ;;;###autoload
-(defun lsp-checker--enable ()
+(defun lsp-diagnostics--enable ()
   "Enable LSP checker support."
-  (unless (eq lsp-checker-provider :none)
-    (lsp-checker-mode 1)))
+  (unless (eq lsp-diagnostics-provider :none)
+    (lsp-diagnostics-mode 1)))
 
-(defun lsp-checker--disable ()
+(defun lsp-diagnostics--disable ()
   "Disable LSP checker support."
-  (lsp-checker-mode -1))
+  (lsp-diagnostics-mode -1))
 
 ;;;###autoload
-(define-minor-mode lsp-checker-mode
-  "Toggle LSP checker integration."
+(define-minor-mode lsp-diagnostics-mode
+  "Toggle LSP diagnostics integration."
   :group 'lsp-mode
   :global nil
   :lighter ""
   (cond
-   (lsp-checker-mode
+   (lsp-diagnostics-mode
     (cond
      ((or
-       (and (eq lsp-checker-provider :auto)
+       (and (eq lsp-diagnostics-provider :auto)
             (functionp 'flycheck-mode))
-       (and (eq lsp-checker-provider :flycheck)
+       (and (eq lsp-diagnostics-provider :flycheck)
             (or (functionp 'flycheck-mode)
-                (user-error "The lsp-checker-provider is set to :flycheck but flycheck is not installed?")))
+                (user-error "The lsp-diagnostics-provider is set to :flycheck but flycheck is not installed?")))
        ;; legacy
-       (null lsp-checker-provider))
-      (lsp-checker--flycheck-enable))
+       (null lsp-diagnostics-provider))
+      (lsp-diagnostics--flycheck-enable))
      ((and (not (version< emacs-version "26.1"))
-           (or (eq lsp-checker-provider :auto)
-               (eq lsp-checker-provider :flymake)
-               (eq lsp-checker-provider t)))
+           (or (eq lsp-diagnostics-provider :auto)
+               (eq lsp-diagnostics-provider :flymake)
+               (eq lsp-diagnostics-provider t)))
       (require 'flymake)
-      (lsp-checker--flymake-setup))
-     ((not (eq lsp-checker-provider :none))
+      (lsp-diagnostics--flymake-setup))
+     ((not (eq lsp-diagnostics-provider :none))
       (lsp--warn "Unable to autoconfigure flycheck/flymake. The diagnostics won't be rendered.")))
 
-    (add-hook 'lsp-unconfigure-hook #'lsp-checker--disable nil t))
+    (add-hook 'lsp-unconfigure-hook #'lsp-diagnostics--disable nil t))
    (t
-    (remove-hook 'lsp-unconfigure-hook #'lsp-checker--disable t))))
+    (remove-hook 'lsp-unconfigure-hook #'lsp-diagnostics--disable t))))
 
 ;;;###autoload
 (add-hook 'lsp-configure-hook (lambda ()
                                 (when lsp-auto-configure
-                                  (lsp-checker--enable))))
+                                  (lsp-diagnostics--enable))))
 
-(provide 'lsp-checker)
-;;; lsp-checker.el ends here
+(provide 'lsp-diagnostics)
+;;; lsp-diagnostics.el ends here

--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -262,7 +262,7 @@ See https://github.com/emacs-lsp/lsp-mode."
 ;;;###autoload
 (defun lsp-diagnostics--enable ()
   "Enable LSP checker support."
-  (unless (eq lsp-diagnostics-provider :none)
+  (when (member lsp-diagnostics-provider '(:auto :none :flycheck :flymake t nil))
     (lsp-diagnostics-mode 1)))
 
 (defun lsp-diagnostics--disable ()

--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -293,10 +293,9 @@ See https://github.com/emacs-lsp/lsp-mode."
        ;; legacy
        (null lsp-diagnostics-provider))
       (lsp-diagnostics--flycheck-enable))
-     ((and (not (version< emacs-version "26.1"))
-           (or (eq lsp-diagnostics-provider :auto)
-               (eq lsp-diagnostics-provider :flymake)
-               (eq lsp-diagnostics-provider t)))
+     ((or (eq lsp-diagnostics-provider :auto)
+          (eq lsp-diagnostics-provider :flymake)
+          (eq lsp-diagnostics-provider t))
       (require 'flymake)
       (lsp-diagnostics--flymake-setup))
      ((not (eq lsp-diagnostics-provider :none))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -748,9 +748,6 @@ diagnostics until server publishes the new set of diagnostics"
   :group 'lsp-mode
   :package-version '(lsp-mode . "7.0.1"))
 
-(define-obsolete-variable-alias 'lsp-diagnostic-package
-  'lsp-diagnostics-provider  "lsp-mode 7.0.1")
-
 (defcustom lsp-server-trace nil
   "Request tracing on the server side.
 The actual trace output at each level depends on the language server in use.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -599,11 +599,6 @@ If this is set to nil, `eldoc' will show only the symbol information."
   :type 'boolean
   :group 'lsp-mode)
 
-(defcustom lsp-checker-enable t
-  "Enable diagnostics checker integration."
-  :type 'boolean
-  :group 'lsp-mode)
-
 (defcustom lsp-enable-symbol-highlighting t
   "Highlight references of the symbol at point."
   :type 'boolean

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -412,10 +412,12 @@ following `projectile'/`project.el' conventions."
   :type 'file)
 
 (defcustom lsp-auto-configure t
-  "Auto configure `lsp-mode'.
-When set to t `lsp-mode' will auto-configure `company',
-`flycheck', `flymake', `imenu', symbol highlighting, lenses,
-links, and so on. For finer granularity you may use `lsp-enable-*' properties."
+  "Auto configure `lsp-mode' main features.
+When set to t `lsp-mode' will auto-configure completion,
+code-actions, breadcrumb, `flycheck', `flymake', `imenu', symbol highlighting,
+lenses, links, and so on.
+
+For finer granularity you may use `lsp-enable-*' properties."
   :group 'lsp-mode
   :type 'boolean
   :package-version '(lsp-mode . "6.1"))
@@ -597,6 +599,11 @@ If this is set to nil, `eldoc' will show only the symbol information."
   :type 'boolean
   :group 'lsp-mode)
 
+(defcustom lsp-checker-enable t
+  "Enable diagnostics checker integration."
+  :type 'boolean
+  :group 'lsp-mode)
+
 (defcustom lsp-enable-symbol-highlighting t
   "Highlight references of the symbol at point."
   :type 'boolean
@@ -737,19 +744,6 @@ returns a negative number, 0, or a positive number indicating
 whether the first parameter is less than, equal to, or greater
 than the second parameter.")
 
-(defcustom lsp-diagnostic-package :auto
-  "`lsp-mode' diagnostics auto-configuration."
-  :type
-  '(choice
-    (const :tag "Pick flycheck if present and fallback to flymake" :auto)
-    (const :tag "Pick flycheck" :flycheck)
-    (const :tag "Pick flymake" :flymake)
-    (const :tag "Use neither flymake nor lsp" :none)
-    (const :tag "Prefer flymake" t)
-    (const :tag "Prefer flycheck" nil))
-  :group 'lsp-mode
-  :package-version '(lsp-mode . "6.3"))
-
 (defcustom lsp-diagnostic-clean-after-change t
   "When non-nil, clean the diagnostics on change.
 
@@ -758,8 +752,6 @@ diagnostics until server publishes the new set of diagnostics"
   :type 'boolean
   :group 'lsp-mode
   :package-version '(lsp-mode . "7.0.1"))
-
-(make-obsolete-variable 'lsp-prefer-flymake 'lsp-diagnostic-package "lsp-mode 6.2")
 
 (defcustom lsp-server-trace nil
   "Request tracing on the server side.
@@ -4179,6 +4171,13 @@ and the position respectively."
   (list :textDocument (or identifier (lsp--text-document-identifier))
         :position (or position (lsp--cur-position))))
 
+(defun lsp--get-buffer-diagnostics ()
+  "Return buffer diagnostics."
+  (gethash (or
+            (plist-get lsp--virtual-buffer :buffer-file-name)
+            (lsp--fix-path-casing buffer-file-name))
+           (lsp-diagnostics t)))
+
 (defun lsp-cur-line-diagnostics ()
   "Return any diagnostics that apply to the current line."
   (-let [(&plist :start (&plist :line start) :end (&plist :line end)) (lsp--region-or-line)]
@@ -6281,26 +6280,6 @@ returns the command to execute."
   (when lsp-lens-enable
     (add-hook 'lsp-configure-hook 'lsp-lens-mode))
 
-  (cond
-   ((or
-     (and (eq lsp-diagnostic-package :auto)
-          (functionp 'flycheck-mode))
-     (and (eq lsp-diagnostic-package :flycheck)
-          (or (functionp 'flycheck-mode)
-              (user-error
-               "lsp-diagnostic-package is set to :flycheck but flycheck is not installed?")))
-     ;; legacy
-     (null lsp-diagnostic-package))
-    (lsp-flycheck-enable))
-   ((and (not (version< emacs-version "26.1"))
-         (or (eq lsp-diagnostic-package :auto)
-             (eq lsp-diagnostic-package :flymake)
-             (eq lsp-diagnostic-package t)))
-    (require 'flymake)
-    (lsp--flymake-setup))
-   ((not (eq lsp-diagnostic-package :none))
-    (lsp--warn "Unable to autoconfigure flycheck/flymake. The diagnostics won't be rendered.")))
-
   ;; yas-snippet config
   (setq-local yas-inhibit-overlay-modification-protection t))
 
@@ -7359,51 +7338,6 @@ This avoids overloading the server with many files when starting Emacs."
            ,@body)
        (fset 'file-truename old-fn))))
 
-;; flycheck
-
-(declare-function flycheck-define-generic-checker
-                  "ext:flycheck" (symbol docstring &rest properties))
-(declare-function flycheck-error-message "ext:flycheck" (err) t)
-(declare-function flycheck-define-error-level "ext:flycheck" (level &rest properties))
-(declare-function flycheck-mode "ext:flycheck")
-(declare-function flycheck-checker-supports-major-mode-p "ext:flycheck")
-(declare-function flycheck-error-new "ext:flycheck" t t)
-(declare-function flycheck-buffer "ext:flycheck")
-(declare-function flycheck-add-mode "ext:flycheck")
-
-(defvar flycheck-check-syntax-automatically)
-(defvar flycheck-checker)
-(defvar flycheck-checkers)
-
-(defcustom lsp-flycheck-default-level 'error
-  "Error level to use when the server does not report back a diagnostic level."
-  :type '(choice (const error)
-                 (const warning)
-                 (const info))
-  :group 'lsp-mode)
-
-(defun lsp--get-buffer-diagnostics ()
-  (gethash (or
-            (plist-get lsp--virtual-buffer :buffer-file-name)
-            (lsp--fix-path-casing buffer-file-name))
-           (lsp-diagnostics t)))
-
-(defun lsp--flycheck-calculate-level (severity tags)
-  (let ((level (pcase severity
-                 (1 'error)
-                 (2 'warning)
-                 (3 'info)
-                 (4 'info)
-                 (_ lsp-flycheck-default-level)))
-        ;; materialize only first tag.
-        (tags (seq-map (lambda (tag)
-                         (cond
-                          ((= tag lsp/diagnostic-tag-unnecessary) 'unnecessary)
-                          ((= tag lsp/diagnostic-tag-deprecated) 'deprecated)))
-                       tags)))
-    (if tags
-        (lsp--flycheck-level level tags)
-      level)))
 
 (defun lsp-virtual-buffer-call (key &rest args)
   (when lsp--virtual-buffer
@@ -7429,127 +7363,6 @@ This avoids overloading the server with many files when starting Emacs."
 ;;   "Translate COLUMN taking into account virtual buffers."
 ;;   (or (lsp-virtual-buffer-call :real<-virtual-char column)
 ;;       column))
-
-(defun lsp--flycheck-start (checker callback)
-  "Start an LSP syntax check with CHECKER.
-
-CALLBACK is the status callback passed by Flycheck."
-
-  (remove-hook 'lsp-on-idle-hook #'lsp--flycheck-buffer t)
-
-  (->> (lsp--get-buffer-diagnostics)
-       (-map (-lambda ((&Diagnostic :message :severity? :tags? :code?
-                                    :range (&Range :start (&Position :line      start-line
-                                                                     :character start-character)
-                                                   :end   (&Position :line      end-line
-                                                                     :character end-character))))
-               (flycheck-error-new
-                :buffer (current-buffer)
-                :checker checker
-                :filename buffer-file-name
-                :message message
-                :level (lsp--flycheck-calculate-level severity? tags?)
-                :id code?
-                :line (lsp-translate-line (1+ start-line))
-                :column (1+ (lsp-translate-column start-character))
-                :end-line (lsp-translate-line (1+ end-line))
-                :end-column (1+ (lsp-translate-column end-character)))))
-       (funcall callback 'finished)))
-
-(defun lsp--flycheck-buffer ()
-  (remove-hook 'lsp-on-idle-hook #'lsp--flycheck-buffer t)
-  (flycheck-buffer))
-
-(defun lsp--buffer-visible? ()
-  (or (get-buffer-window (current-buffer))
-      (eq (window-buffer (selected-window))
-          (current-buffer))))
-
-(defun lsp--flycheck-report ()
-  "This callback is invoked when new diagnostics are received
-from the language server."
-  (when (and (or (memq 'idle-change flycheck-check-syntax-automatically)
-                 (and (memq 'save flycheck-check-syntax-automatically)
-                      (not (buffer-modified-p))))
-             lsp--cur-workspace)
-    ;; make sure diagnostics are published even if the diagnostics
-    ;; have been received after idle-change has been triggered
-    (->> lsp--cur-workspace
-         (lsp--workspace-buffers)
-         (mapc (lambda (buffer)
-                 (when (lsp-buffer-live-p buffer)
-                   (lsp-with-current-buffer buffer
-                     (add-hook 'lsp-on-idle-hook #'lsp--flycheck-buffer nil t)
-                     (lsp--idle-reschedule (current-buffer)))))))))
-
-
-(declare-function lsp-cpp-flycheck-clang-tidy-error-explainer "lsp-cpp")
-
-(defvar lsp-diagnostics-attributes
-  `((unnecessary :foreground "dim gray")
-    (deprecated  :strike-through t))
-  "List containing (tag attributes) where tag is the LSP
-  diagnostic tag and attributes is a `plist' containing face
-  attributes which will be applied on top the flycheck face for
-  that error level.")
-
-(defun lsp--flycheck-level (flycheck-level tags)
-  "Generate flycheck level from the original FLYCHECK-LEVEL (e.
-g. `error', `warning') and list of LSP TAGS."
-  (let ((name (format "lsp-flycheck-%s-%s"
-                      flycheck-level
-                      (mapconcat #'symbol-name tags "-"))))
-    (or (intern-soft name)
-        (let* ((face (--doto (intern (format "lsp-%s-face" name))
-                       (copy-face (-> flycheck-level
-                                      (get 'flycheck-overlay-category)
-                                      (get 'face))
-                                  it)
-                       (mapc (lambda (tag)
-                               (apply #'set-face-attribute it nil
-                                      (cl-rest (assoc tag lsp-diagnostics-attributes))))
-                             tags)))
-               (category (--doto (intern (format "lsp-%s-category" name))
-                           (setf (get it 'face) face
-                                 (get it 'priority) 100)))
-               (new-level (intern name))
-               (bitmap (or (get flycheck-level 'flycheck-fringe-bitmaps)
-                           (get flycheck-level 'flycheck-fringe-bitmap-double-arrow))))
-          (flycheck-define-error-level new-level
-            :severity (get flycheck-level 'flycheck-error-severity)
-            :compilation-level (get flycheck-level 'flycheck-compilation-level)
-            :overlay-category category
-            :fringe-bitmap bitmap
-            :fringe-face (get flycheck-level 'flycheck-fringe-face)
-            :error-list-face face)
-          new-level))))
-
-(with-eval-after-load 'flycheck
-  (flycheck-define-generic-checker 'lsp
-    "A syntax checker using the Language Server Protocol (LSP)
-provided by lsp-mode.
-See https://github.com/emacs-lsp/lsp-mode."
-    :start #'lsp--flycheck-start
-    :modes '(lsp-placeholder-mode) ;; placeholder
-    :predicate (lambda () lsp-mode)
-    :error-explainer (lambda (e)
-                       (cond ((string-prefix-p "clang-tidy" (flycheck-error-message e))
-                              (lsp-cpp-flycheck-clang-tidy-error-explainer e))
-                             (t (flycheck-error-message e))))))
-
-(defun lsp-flycheck-add-mode (mode)
-  "Register flycheck support for MODE."
-  (unless (flycheck-checker-supports-major-mode-p 'lsp mode)
-    (flycheck-add-mode 'lsp mode)))
-
-(defun lsp-flycheck-enable (&rest _)
-  "Enable flycheck integration for the current buffer."
-  (flycheck-mode 1)
-  (setq-local flycheck-checker 'lsp)
-  (lsp-flycheck-add-mode major-mode)
-  (add-to-list 'flycheck-checkers 'lsp)
-  (add-hook 'lsp-after-diagnostics-hook #'lsp--flycheck-report nil t)
-  (add-hook 'lsp-managed-mode-hook #'lsp--flycheck-report nil t))
 
 
 ;; lsp internal validation.
@@ -7648,6 +7461,14 @@ See https://github.com/emacs-lsp/lsp-mode."
     (if (<= point (+ (point-at-bol) indentation))
         (point-at-bol)
       point)))
+
+(declare-function flycheck-checker-supports-major-mode-p "ext:flycheck")
+(declare-function flycheck-add-mode "ext:flycheck")
+
+(defun lsp-flycheck-add-mode (mode)
+  "Register flycheck support for MODE."
+  (unless (flycheck-checker-supports-major-mode-p 'lsp mode)
+    (flycheck-add-mode 'lsp mode)))
 
 (defun lsp-org ()
   (interactive)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -748,6 +748,9 @@ diagnostics until server publishes the new set of diagnostics"
   :group 'lsp-mode
   :package-version '(lsp-mode . "7.0.1"))
 
+(define-obsolete-variable-alias 'lsp-diagnostic-package
+  'lsp-diagnostics-provider  "lsp-mode 7.0.1")
+
 (defcustom lsp-server-trace nil
   "Request tracing on the server side.
 The actual trace output at each level depends on the language server in use.

--- a/test/lsp-integration-test.el
+++ b/test/lsp-integration-test.el
@@ -32,7 +32,7 @@
 (require 'lsp-mode)
 (require 'lsp-modeline)
 (require 'lsp-completion)
-(require 'lsp-checker)
+(require 'lsp-diagnostics)
 
 (defconst lsp-test-location (file-name-directory (or load-file-name buffer-file-name)))
 
@@ -266,7 +266,7 @@
     (lsp-workspace-folders-add (f-expand "fixtures/org-mode"))
     (lsp-org)
 
-    (setq lsp-checker-provider nil)
+    (setq lsp-diagnostics-provider nil)
 
     (-> (lsp-test-wait
          (eq 'initialized (lsp--workspace-status
@@ -293,7 +293,7 @@
     (lsp-workspace-folders-add (f-expand "fixtures/org-mode"))
     (lsp-org)
 
-    (setq lsp-checker-provider nil)
+    (setq lsp-diagnostics-provider nil)
 
     (-> (lsp-test-wait
          (eq 'initialized (lsp--workspace-status
@@ -651,7 +651,7 @@
     (lsp-workspace-folders-add (f-expand "fixtures/org-mode"))
     (lsp-org)
 
-    (setq lsp-checker-provider nil)
+    (setq lsp-diagnostics-provider nil)
 
     (-> (lsp-test-wait
          (eq 'initialized (lsp--workspace-status

--- a/test/lsp-integration-test.el
+++ b/test/lsp-integration-test.el
@@ -32,6 +32,7 @@
 (require 'lsp-mode)
 (require 'lsp-modeline)
 (require 'lsp-completion)
+(require 'lsp-checker)
 
 (defconst lsp-test-location (file-name-directory (or load-file-name buffer-file-name)))
 
@@ -265,7 +266,7 @@
     (lsp-workspace-folders-add (f-expand "fixtures/org-mode"))
     (lsp-org)
 
-    (setq lsp-diagnostic-package nil)
+    (setq lsp-checker-provider nil)
 
     (-> (lsp-test-wait
          (eq 'initialized (lsp--workspace-status
@@ -292,7 +293,7 @@
     (lsp-workspace-folders-add (f-expand "fixtures/org-mode"))
     (lsp-org)
 
-    (setq lsp-diagnostic-package nil)
+    (setq lsp-checker-provider nil)
 
     (-> (lsp-test-wait
          (eq 'initialized (lsp--workspace-status
@@ -650,7 +651,7 @@
     (lsp-workspace-folders-add (f-expand "fixtures/org-mode"))
     (lsp-org)
 
-    (setq lsp-diagnostic-package nil)
+    (setq lsp-checker-provider nil)
 
     (-> (lsp-test-wait
          (eq 'initialized (lsp--workspace-status


### PR DESCRIPTION
* Move Flycheck integration to `lsp-checker.el`
* Move Flymake integration to `lsp-checker.el`
* Create `lsp-checker-mode` and `lsp-checker-enable`
* Define obsolete variable `lsp-diagnostic-package` -> `lsp-checker-provider`
* Define obsolete variable `lsp-flycheck-default-level` -> `lsp-checker-flycheck-default-level`
* Define obsolete variable `lsp-diagnostics-attributes` -> `lsp-checker-diagnostics-attributes`