### PR TITLE
Add a few ‘eval-and-compile’ forms.

### DIFF
--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -32,15 +32,16 @@
 (require 'ht)
 (require 's)
 
-(defun lsp-keyword->symbol (keyword)
-  "Convert a KEYWORD to symbol."
-  (intern (substring (symbol-name keyword) 1)))
+(eval-and-compile
+  (defun lsp-keyword->symbol (keyword)
+    "Convert a KEYWORD to symbol."
+    (intern (substring (symbol-name keyword) 1)))
 
-(defun lsp-keyword->string (keyword)
-  "Convert a KEYWORD to string."
-  (substring (symbol-name keyword) 1))
+  (defun lsp-keyword->string (keyword)
+    "Convert a KEYWORD to string."
+    (substring (symbol-name keyword) 1))
 
-(defvar lsp-use-plists nil)
+  (defvar lsp-use-plists nil))
 
 (defmacro lsp-interface (&rest interfaces)
   "Generate LSP bindings from INTERFACES triplet.

--- a/test/lsp-protocol-test.el
+++ b/test/lsp-protocol-test.el
@@ -28,7 +28,8 @@
 (require 'lsp-protocol)
 (require 'ert)
 
-(lsp-interface (MyPosition (:line :character :camelCase) (:optional)))
+(eval-and-compile
+  (lsp-interface (MyPosition (:line :character :camelCase) (:optional))))
 
 (ert-deftest lsp-test-lsp-interface ()
   (let ((position (lsp-make-my-position :character 1 :line 2)))


### PR DESCRIPTION
Depending whether and how these files are byte-compiled, the definitions need
to be available during compile time as well.