### PR TITLE
[infra] Add a .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# Configure git to ignore commits listed in this file with:
+#
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Fix another typo (#1965)
+1530757b9c66c88ef77cf97bd023211de9833ed0
+
+# Migrate to new form of ‘if-let’ and ‘when-let’. (#1991)
+c7199f6bd95d174b20bb5f6fb4e7b24c6ce1784a
+
+# Fix typos (#1964)
+1c18d4362d7cacc3b4ef8ff5cc9f336c123a89e5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ reliably would also make a huge difference.
 * Make sure that the unit tests are passing locally via `make test` or via the CI.
 * Write [good commit messages][3].
 * Update the [changelog][6].
+* Code-style/formatting changes and typo-fixes should go into their own commits and put into the `.git-blame-ignore-revs` file to avoid thrashing the `git blame` data.
 
 [1]: https://github.com/emacs-lsp/lsp-mode/issues
 [2]: http://gun.io/blog/how-to-github-fork-branch-and-pull-request


### PR DESCRIPTION
Git 2.23 added the blame.ignoreRevsFile option. After running the
configuration command once, `magit-blame` should no longer display the
ignored commits.