### PR TITLE
Use widget for lsp-string-vector

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1059,15 +1059,15 @@ every element of it is of type string, else nil."
    (vectorp candidate)
    (seq-every-p #'stringp candidate)))
 
-(make-obsolete 'lsp--string-vector-p nil "7.0.2")
+(make-obsolete 'lsp--string-vector-p nil "7.1")
 
-(defun lsp-editable-vector-match (widget value)
+(defun lsp--editable-vector-match (widget value)
   "Function for `lsp-editable-vector' :match."
   ;; Value must be a list or a vector and all the members must match the type.
   (and (or (listp value) (vectorp value))
-       (length (cdr (lsp-editable-vector-match-inline widget value)))))
+       (length (cdr (lsp--editable-vector-match-inline widget value)))))
 
-(defun lsp-editable-vector-match-inline (widget value)
+(defun lsp--editable-vector-match-inline (widget value)
   "Value for `lsp-editable-vector' :match-inline."
   (let ((type (nth 0 (widget-get widget :args)))
         (ok t)
@@ -1082,27 +1082,27 @@ every element of it is of type string, else nil."
           (setq ok nil))))
     (cons found value)))
 
-(define-widget 'lsp-editable-vector 'editable-list
-  "A subclass of `editable-list' that accepts and returns a
-vector instead of a list."
-  :value-to-external 'lsp-editable-vector-value-to-external
-  :value-to-internal 'lsp-editable-vector-value-to-internal
-  :match 'lsp-editable-vector-match
-  :match-inline 'lsp-editable-vector-match-inline)
-
-(defun lsp-editable-vector-value-to-external (_widget internal-value)
+(defun lsp--editable-vector-value-to-external (_widget internal-value)
   "Convert the internal list value to a vector."
   (if (listp internal-value)
       (apply 'vector internal-value)
     internal-value))
 
-(defun lsp-editable-vector-value-to-internal (_widget external-value)
+(defun lsp--editable-vector-value-to-internal (_widget external-value)
   "Convert the external vector value to a list."
   (if (vectorp external-value)
       (append external-value nil)
     external-value))
 
-(define-widget 'lsp-repeatable-vector 'lsp-editable-vector
+(define-widget 'lsp--editable-vector 'editable-list
+  "A subclass of `editable-list' that accepts and returns a
+vector instead of a list."
+  :value-to-external 'lsp--editable-vector-value-to-external
+  :value-to-internal 'lsp--editable-vector-value-to-internal
+  :match 'lsp--editable-vector-match
+  :match-inline 'lsp--editable-vector-match-inline)
+
+(define-widget 'lsp-repeatable-vector 'lsp--editable-vector
   "A variable length homogeneous vector."
   :tag "Repeat"
   :format "%{%t%}:\n%v%i\n")
@@ -1110,10 +1110,14 @@ vector instead of a list."
 (define-widget 'lsp-string-vector 'lazy
   "A vector of zero or more elements, every element of which is a string.
 Appropriate for any language-specific `defcustom' that needs to
-serialize as a JSON array of strings."
+serialize as a JSON array of strings.
+
+Deprecated. Use `lsp-repeatable-vector' instead. "
   :offset 4
   :tag "Vector"
   :type '(lsp-repeatable-vector string))
+
+(make-obsolete 'lsp-string-vector nil "7.1")
 
 (defun lsp--info (format &rest args)
   "Display lsp info message with FORMAT with ARGS."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1059,14 +1059,61 @@ every element of it is of type string, else nil."
    (vectorp candidate)
    (seq-every-p #'stringp candidate)))
 
+(make-obsolete 'lsp--string-vector-p nil "7.0.2")
+
+(defun lsp-editable-vector-match (widget value)
+  "Function for `lsp-editable-vector' :match."
+  ;; Value must be a list or a vector and all the members must match the type.
+  (and (or (listp value) (vectorp value))
+       (length (cdr (lsp-editable-vector-match-inline widget value)))))
+
+(defun lsp-editable-vector-match-inline (widget value)
+  "Value for `lsp-editable-vector' :match-inline."
+  (let ((type (nth 0 (widget-get widget :args)))
+        (ok t)
+        found)
+    (while (and value ok)
+      (let ((answer (widget-match-inline type value)))
+        (if answer
+            (let ((head (if (vectorp answer) (aref answer 0) (car answer)))
+                  (tail (if (vectorp answer) (seq-drop 1 answer) (cdr answer))))
+              (setq found (append found head)
+                    value tail))
+          (setq ok nil))))
+    (cons found value)))
+
+(define-widget 'lsp-editable-vector 'editable-list
+  "A subclass of `editable-list' that accepts and returns a
+vector instead of a list."
+  :value-to-external 'lsp-editable-vector-value-to-external
+  :value-to-internal 'lsp-editable-vector-value-to-internal
+  :match 'lsp-editable-vector-match
+  :match-inline 'lsp-editable-vector-match-inline)
+
+(defun lsp-editable-vector-value-to-external (_widget internal-value)
+  "Convert the internal list value to a vector."
+  (if (listp internal-value)
+      (apply 'vector internal-value)
+    internal-value))
+
+(defun lsp-editable-vector-value-to-internal (_widget external-value)
+  "Convert the external vector value to a list."
+  (if (vectorp external-value)
+      (append external-value nil)
+    external-value))
+
+(define-widget 'lsp-repeatable-vector 'lsp-editable-vector
+  "A variable length homogeneous vector."
+  :tag "Repeat"
+  :format "%{%t%}:\n%v%i\n")
+
 (define-widget 'lsp-string-vector 'lazy
   "A vector of zero or more elements, every element of which is a string.
 Appropriate for any language-specific `defcustom' that needs to
 serialize as a JSON array of strings."
   :offset 4
   :tag "Vector"
-  :type '(restricted-sexp
-          :match-alternatives (lsp--string-vector-p)))
+  :type '(lsp-repeatable-vector string))
 
 (defun lsp--info (format &rest args)
   "Display lsp info message with FORMAT with ARGS."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1059,7 +1059,7 @@ every element of it is of type string, else nil."
    (vectorp candidate)
    (seq-every-p #'stringp candidate)))
 
-(make-obsolete 'lsp--string-vector-p nil "7.1")
+(make-obsolete 'lsp--string-vector-p nil "lsp-mode 7.1")
 
 (defun lsp--editable-vector-match (widget value)
   "Function for `lsp-editable-vector' :match."
@@ -1117,7 +1117,7 @@ Deprecated. Use `lsp-repeatable-vector' instead. "
   :tag "Vector"
   :type '(lsp-repeatable-vector string))
 
-(make-obsolete 'lsp-string-vector nil "7.1")
+(make-obsolete 'lsp-string-vector nil "lsp-mode 7.1")
 
 (defun lsp--info (format &rest args)
   "Display lsp info message with FORMAT with ARGS."


### PR DESCRIPTION
This PR solves a pain point identified in #2008. Currently lsp-mode expects client `defcustom`s to use vectors instead of lists due to limitations in `json-serialize`, but there's no a customization type similar to `repeat` that will return a vector. This forces all `lsp-string-vector` `defcustom`s to simply provide a sexp field. This defeats the purpose of `defcustom`. This PR rectifies this problem by implementing 2 new customization types - `lsp-editable-vector` and `lsp-repeatable-vector`, and change the definition of `lsp-string-vector` to use `(lsp-repeatable-vector string)` instead. This change is completely backward compatible. No change to current clients required.