### PR TITLE
Support nested paths for workspace/configuration

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5498,7 +5498,8 @@ textDocument/didOpen for the new file."
 PARAMS are the `workspace/configuration' request params"
   (->> items
        (-map (-lambda ((&ConfigurationItem :section?))
-               (gethash section? (lsp-configuration-section section?))))
+               (apply 'ht-get* (append (list (lsp-configuration-section section?))
+                                       (split-string section? "\\.")))))
        (apply #'vector)))
 
 (defun lsp--send-request-response (workspace recv-time request response)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5498,8 +5498,14 @@ textDocument/didOpen for the new file."
 PARAMS are the `workspace/configuration' request params"
   (->> items
        (-map (-lambda ((&ConfigurationItem :section?))
-               (apply 'ht-get* (append (list (lsp-configuration-section section?))
-                                       (split-string section? "\\.")))))
+               (-let* ((path-parts (split-string section? "\\."))
+                       (path-without-last (s-join "." (-slice path-parts 0 -1)))
+                       (path-parts-len (length path-parts)))
+                 (cond
+                  ((<= path-parts-len 1)
+                   (apply 'ht-get* `(,(lsp-configuration-section section?) ,@path-parts)))
+                  ((> path-parts-len 1)
+                   (apply 'ht-get* `(,(lsp-configuration-section path-without-last) ,@path-parts)))))))
        (apply #'vector)))
 
 (defun lsp--send-request-response (workspace recv-time request response)

--- a/test/lsp-common-test.el
+++ b/test/lsp-common-test.el
@@ -110,22 +110,49 @@
 (lsp-register-custom-settings '(("section1.prop1" lsp-prop1)))
 
 (ert-deftest lsp--custom-settings-test ()
-  (cl-assert (equal (lsp-ht->alist  (lsp-configuration-section  "section1"))
+  (cl-assert (equal (lsp-ht->alist  (lsp-configuration-section "section1"))
                     '(("section1" ("prop1" . "10")))))
   (let ((lsp-prop1 1))
-    (cl-assert (equal (lsp-ht->alist (lsp-configuration-section  "section1"))
+    (cl-assert (equal (lsp-ht->alist (lsp-configuration-section "section1"))
                       '(("section1" ("prop1" . 1)))))))
+
+(ert-deftest lsp--build-workspace-configuration-response-test ()
+  (let ((request (ht ("items" (list (ht ("section" "section1")))))))
+
+    (cl-assert (equal (lsp-ht->alist (aref (lsp--build-workspace-configuration-response request) 0))
+                      '(("prop1" . "10"))))
+
+    (let ((lsp-prop1 1))
+      (cl-assert (equal (lsp-ht->alist (aref (lsp--build-workspace-configuration-response request) 0))
+                        '(("prop1" . 1))))))
+
+    (let ((request (ht ("items" (list (ht ("section" "section1.prop1")))))))
+      (cl-assert (equal (aref (lsp--build-workspace-configuration-response request) 0) "10"))
+      (let ((lsp-prop1 1))
+        (cl-assert (equal (aref (lsp--build-workspace-configuration-response request) 0) 1)))))
 
 (defcustom lsp-nested-prop1 "10"
   "docs"
   :risky t
   :type 'list)
 
+(defcustom lsp-nested-prop2 "20"
+  "docs"
+  :risky t
+  :type 'string)
+
 (lsp-register-custom-settings '(("section2.nested.prop1" lsp-nested-prop1)))
+(lsp-register-custom-settings '(("section2.nested.prop2" lsp-nested-prop2)))
 
 (ert-deftest lsp--custom-settings-test ()
   (cl-assert (equal (lsp-ht->alist (lsp-configuration-section "section2"))
-                    '(("section2" ("nested" ("prop1" . "10")))))))
+                    '(("section2" ("nested" ("prop1" . "10") ("prop2" . "20")))))))
+
+(ert-deftest lsp--build-workspace-configuration-response-test ()
+  (-let* ((request (ht ("items" (list (ht ("section" "section2.nested"))))))
+          (result (aref (lsp--build-workspace-configuration-response request) 0)))
+    (cl-assert (equal (ht-get result "prop2") "20"))
+    (cl-assert (equal (ht-get result "prop1") "10"))))
 
 (defcustom lsp-prop3 nil
   "docs"
@@ -139,11 +166,20 @@
   (cl-assert (equal (lsp-ht->alist  (lsp-configuration-section  "section3"))
                     '(("section3" ("prop1" . :json-false))))))
 
+(ert-deftest lsp--build-workspace-configuration-response-test ()
+  (let ((request (ht ("items" (list (ht ("section" "section3.prop1")))))))
+    (cl-assert (equal (aref (lsp--build-workspace-configuration-response request) 0)
+                      :json-false))))
+
 (lsp-register-custom-settings '(("section4.prop1" "value")))
 
-(ert-deftest lsp--boolean-property ()
+(ert-deftest lsp--non-boolean-property ()
   (cl-assert (equal (lsp-ht->alist  (lsp-configuration-section "section4"))
                     '(("section4" ("prop1" . "value"))))))
+
+(ert-deftest lsp--build-workspace-configuration-response-test ()
+  (let ((request (ht ("items" (list (ht ("section" "section4.prop1")))))))
+    (cl-assert (equal (aref (lsp--build-workspace-configuration-response request) 0) "value"))))
 
 (ert-deftest lsp--f-ancestor-of? ()
   (should (lsp-f-ancestor-of? "~/tmp" "~/tmp/test"))


### PR DESCRIPTION
- Language servers such as `pyright` request for nested paths in `workspace/configuration` (such as `python.analysis`)