### PR TITLE
Dedup workspace folders upon initialize

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6336,6 +6336,7 @@ SESSION is the active session."
           (list :trace lsp-server-trace))
         (when multi-root
           (->> workspace-folders
+               (-distinct)
                (-map (lambda (folder)
                        (list :uri (lsp--path-to-uri folder)
                              :name (f-filename folder))))


### PR DESCRIPTION
- For multi-root language servers, there are duplicate workspace folders upon initialize. 