### PR TITLE
Fix company-backends validation on lsp-diagnose and safe rename to lsp-doctor

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Release 7.1
+  * Safe renamed ~lsp-diagnose~ to ~lsp-doctor~.
   * Add ~lsp-modeline-code-actions-segments~ for a better customization.
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.

--- a/docs/page/performance.md
+++ b/docs/page/performance.md
@@ -3,7 +3,7 @@ Performance
 
 ## Tuning
 
-Use `M-x lsp-diagnose` to validate if your `lsp-mode` is properly configured. In the section below, you could find description for each of the checks:
+Use `M-x lsp-doctor` to validate if your `lsp-mode` is properly configured. In the section below, you could find description for each of the checks:
 
 When configured properly `lsp-mode`'s performance is on par with mainstream LSP clients (e. g. `VScode`, `Theia`, etc). Here are steps to achieve optimal results.
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7368,7 +7368,7 @@ This avoids overloading the server with many files when starting Emacs."
 
 ;; lsp internal validation.
 
-(defmacro lsp--validate (&rest checks)
+(defmacro lsp--doctor (&rest checks)
   `(-let [buf (current-buffer)]
      (with-current-buffer (get-buffer-create "*lsp-performance*")
        (with-help-window (current-buffer)
@@ -7380,10 +7380,15 @@ This avoids overloading the server with many files when starting Emacs."
                                       (propertize "ERROR" 'face 'error)))))
                  (-partition 2 checks))))))
 
-(defun lsp-diagnose ()
+(defvar company-backends)
+
+(define-obsolete-function-alias 'lsp-diagnose
+  'lsp-doctor "lsp-mode 7.1")
+
+(defun lsp-doctor ()
   "Validate performance settings."
   (interactive)
-  (lsp--validate
+  (lsp--doctor
    "Checking for Native JSON support" (functionp 'json-serialize)
    "Checking emacs version has `read-process-output-max'" (boundp 'read-process-output-max)
    "Using company-capf" (-contains? company-backends 'company-capf)


### PR DESCRIPTION
Fix https://github.com/emacs-lsp/lsp-mode/issues/2022

During the migration of completion stuff to `lsp-completion.el` we moved this `company-backend` variable.