### PR TITLE
Add Lua Language Server, Lua-Lsp and update EmmyLua

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,7 @@
 ** Release 7.1
   * Safe renamed ~lsp-diagnose~ to ~lsp-doctor~.
   * Add ~lsp-modeline-code-actions-segments~ for a better customization.
+  * Add [[https://github.com/sumneko/lua-language-server][Lua Language Server]], [[https://github.com/Alloyed/lua-lsp][Lua-LSP]] and improve EmmyLua.
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -244,6 +244,23 @@
     "debugger": "Not available"
   },
   {
+    "name": "lua-language-server",
+    "full-name": "Lua",
+    "server-name": "lua-language-server",
+    "installation-url": "https://github.com/sumneko/lua-language-server/wiki/Build-and-Run-(Standalone)",
+    "server-url": "https://github.com/sumneko/lua-language-server",
+    "debugger": "Not available"
+  },
+  {
+    "name": "lua-lsp",
+    "full-name": "Lua",
+    "server-name": "lua-lsp",
+    "installation-url": "https://luarocks.org/modules/alloyed/lua-lsp",
+    "server-url": "https://github.com/Alloyed/lua-lsp",
+    "installation": "luarocks install --server=https://luarocks.org/dev lua-lsp --local",
+    "debugger": "Not available"
+  },
+  {
     "name": "nim",
     "full-name": "Nim",
     "server-name": "nimlsp",

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -772,39 +772,6 @@ responsiveness at the cost of possible stability issues."
                   :initialization-options (lambda ()
                                             lsp-clients-vim-initialization-options)))
 
-
-;; LUA
-(defgroup lsp-emmy-lua nil
-  "LSP support for emmy-lua."
-  :group 'lsp-mode
-  :link '(url-link "https://github.com/EmmyLua/EmmyLua-LanguageServer"))
-
-(defcustom lsp-clients-emmy-lua-java-path "java"
-  "Path to java which will be used for running emmy-lua language server."
-  :group 'lsp-emmy-lua
-  :risky t
-  :type 'file)
-
-(defcustom lsp-clients-emmy-lua-jar-path (f-expand "~/.emacs.d/EmmyLua-LS-all.jar")
-  "Path to jar which will be used for running EmmyLua language server."
-  :group 'lsp-emmy-lua
-  :risky t
-  :type 'file)
-
-(defun lsp-clients-emmy-lua--create-connection ()
-  "Create connection to emmy lua language server."
-  (lsp-stdio-connection
-   (lambda ()
-     (list lsp-clients-emmy-lua-java-path "-jar" lsp-clients-emmy-lua-jar-path))
-   (lambda ()
-     (f-exists? lsp-clients-emmy-lua-jar-path))))
-
-(lsp-register-client
- (make-lsp-client :new-connection (lsp-clients-emmy-lua--create-connection)
-                  :major-modes '(lua-mode)
-                  :priority -1
-                  :server-id 'emmy-lua
-                  :notification-handlers (lsp-ht ("emmy/progressReport" #'ignore))))
 
 
 ;; R

--- a/lsp-lua.el
+++ b/lsp-lua.el
@@ -1,0 +1,173 @@
+;;; lsp-lua.el --- description -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 E. Alexander Barbosa
+
+;; Author: E. Alexander Barbosa <elxbarbosa@outlook.com>
+;; Keywords:
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP Clients for the Lua Programming Language
+
+;;; Code:
+
+(require 'lsp-mode)
+(require 'f)
+
+(defgroup lsp-emmy-lua nil
+  "Lua LSP client, provided by the EmmyLua Language Server."
+  :group 'lsp-mode
+  :version "7.1"
+  :link '(url-link "https://github.com/EmmyLua/EmmyLua-LanguageServer"))
+
+(defcustom lsp-clients-emmy-lua-java-path (executable-find "java")
+  "Java Runtime binary location."
+  :group 'lsp-emmy-lua
+  :version "7.1"
+  :risky t
+  :type 'file)
+
+(defcustom lsp-clients-emmy-lua-jar-path (f-join lsp-server-install-dir "EmmyLua-LS-all.jar")
+  "Emmy Lua language server jar file."
+  :group 'lsp-emmy-lua
+  :version "7.1"
+  :risky t
+  :type 'file)
+
+(defcustom lsp-clients-emmy-lua-args '("-jar")
+  "Arguments to the Lua Language server."
+  :group 'lsp-emmy-lua
+  :version "7.1"
+  :risky t
+  :type  '(repeat string))
+
+(defcustom lsp-clients-emmy-lua-command `(,lsp-clients-emmy-lua-java-path
+                                          ,@lsp-clients-emmy-lua-args
+                                          ,lsp-clients-emmy-lua-jar-path)
+  "Final command to call the Lua Language server."
+  :group 'lsp-emmy-lua
+  :version "7.1"
+  :risky t
+  :type '(repeat string))
+
+(defun lsp-clients-emmy-lua-test ()
+  "Test the Emmy Lua binaries and files."
+  (and (f-exists? lsp-clients-emmy-lua-java-path)
+       (f-exists? lsp-clients-emmy-lua-jar-path)))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection lsp-clients-emmy-lua-command
+                                        #'lsp-clients-emmy-lua-test)
+  :major-modes '(lua-mode)
+  :server-id 'emmy-lua
+  :priority -1
+  :notification-handlers (lsp-ht ("emmy/progressReport" #'ignore))))
+
+
+;;; lua-language-server
+(defgroup lsp-lua-language-server nil
+  "Lua LSP client, provided by the Lua Language Server."
+  :group 'lsp-mode
+  :version "7.1"
+  :link '(url-link "https://github.com/sumneko/lua-language-server"))
+
+(defcustom lsp-clients-lua-language-server-install-dir (f-join lsp-server-install-dir "lua-language-server/")
+  "Installation directory for Lua Language Server."
+  :group 'lsp-lua-language-server
+  :version "7.1"
+  :risky t
+  :type 'directory)
+
+(defcustom lsp-clients-lua-language-server-bin (f-join lsp-clients-lua-language-server-install-dir "bin/Linux/lua-language-server")
+  "Location of Lua Language Server."
+  :group 'lsp-lua-language-server
+  :version "7.1"
+  :risky t
+  :type 'file)
+
+(defcustom lsp-clients-lua-language-server-main-location (f-join lsp-clients-lua-language-server-install-dir "main.lua")
+  "Location of Lua Language Server main.lua."
+  :group 'lsp-lua-language-server
+  :version "7.1"
+  :risky t
+  :type 'file)
+
+(defcustom lsp-clients-lua-language-server-args '("-E")
+  "Arguments to run the Lua Language server."
+  :group 'lsp-lua-language-server
+  :version "7.1"
+  :risky t
+  :type '(repeat string))
+
+(defcustom lsp-clients-lua-language-server-command `(,lsp-clients-lua-language-server-bin
+                                                     ,@lsp-clients-lua-language-server-args
+                                                     ,lsp-clients-lua-language-server-main-location)
+  "Command to start Lua Language server."
+  :group 'lsp-lua-language-server
+  :type '(repeat string))
+
+
+(defun lsp-clients-lua-language-server-test ()
+  "Test Lua language server binaries and files."
+  (and (f-exists? lsp-clients-lua-language-server-main-location)
+       (f-exists? lsp-clients-lua-language-server-bin)))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection lsp-clients-lua-language-server-command
+                                        #'lsp-clients-lua-language-server-test)
+  :major-modes '(lua-mode)
+  :priority -2
+  :server-id 'lua-language-server))
+
+
+;;; lua-lsp
+(defgroup lsp-lua-lsp nil
+  "Lua LSP client, provided by the Lua-Lsp."
+  :group 'lsp-mode
+  :version "7.1"
+  :link '(url-link "https://github.com/Alloyed/lua-lsp"))
+
+(defcustom lsp-clients-luarocks-bin-dir (f-join (getenv "HOME") ".luarocks/bin/")
+  "LuaRocks bin directory."
+  :group 'lsp-lua-lsp
+  :version "7.1"
+  :risky t
+  :type 'directory)
+
+(defcustom lsp-clients-lua-lsp-server-install-dir (f-join lsp-clients-luarocks-bin-dir "lua-lsp")
+  "Installation directory for Lua-Lsp Language Server."
+  :group 'lsp-lua-lsp
+  :version "7.1"
+  :risky t
+  :type 'file)
+
+(defun lsp-clients-lua-lsp-test ()
+  "Test Lua-lsp language server files."
+  (and (f-exists? lsp-clients-lua-lsp-server-install-dir)))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection lsp-clients-lua-lsp-server-install-dir
+                                        #'lsp-clients-lua-lsp-test)
+  :major-modes '(lua-mode)
+  :priority -3
+  :server-id 'lsp-lua-lsp))
+
+
+(provide 'lsp-lua)
+;;; lsp-lua.el ends here

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -351,7 +351,7 @@ unless overridden by a more specific face association."
 (defcustom lsp-client-packages
   '(ccls lsp-clients lsp-clojure lsp-csharp lsp-css lsp-dart lsp-elm
          lsp-erlang lsp-eslint lsp-fsharp lsp-gdscript lsp-go lsp-haskell lsp-haxe
-         lsp-intelephense lsp-java lsp-json lsp-metals lsp-perl lsp-pwsh lsp-pyls
+         lsp-intelephense lsp-java lsp-json lsp-lua lsp-metals lsp-perl lsp-pwsh lsp-pyls
          lsp-python-ms lsp-rust lsp-serenata lsp-solargraph lsp-terraform lsp-verilog lsp-vetur
          lsp-vhdl lsp-xml lsp-yaml lsp-sqls)
   "List of the clients to be automatically required."

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,9 @@ nav:
     - Hack: page/lsp-hack.md
     - HTML: page/lsp-html.md
     - Haskell: https://emacs-lsp.github.io/lsp-haskell
-    - Lua: page/lsp-emmy-lua.md
+    - Lua (EmmyLua): page/lsp-emmy-lua.md
+    - Lua (Lua Language Server): page/lsp-lua-language-server.md
+    - Lua (Lua-Lsp): page/lsp-lua-lsp.md
     - Java: https://emacs-lsp.github.io/lsp-java
     - JavaScript/TypeScript (sourcegraph): page/lsp-typescript-javascript.md
     - JavaScript/TypeScript (theia-ide): page/lsp-typescript.md


### PR DESCRIPTION
Hi, 

In an early [discussion](https://github.com/emacs-lsp/lsp-mode/issues/831) the [Lua Language Server](https://github.com/sumneko/lua-language-server) had not enough instructions as on how clients should call it.

Changes:
- add lsp-lua.el
- add lua-lsp and lua-language-server to lsp-clients.json
- update mkdocs.yml
- update changelog
- add to lsp-client-packages

TODO:
- add instruction to install servers
- automatically install/update emmylua and lua-language-server
- test servers are running

---- 
more

[Buildind](https://github.com/sumneko/lua-language-server/wiki/Build-and-Run-(Standalone)) Lua Language Server is simple as it requires only Ninja as an external dependency. It takes no more than a few seconds(20s) to build.

Once built, its binary will be in `bin/Linux/lua-language-server`. 

[Calling](https://github.com/sumneko/lua-language-server/wiki/Setting-without-VSCode) the server goes as **binary** + **flags options** `-E` and its `main.lua` file under the root dir of the project.

As for the **EmmyLua server**, it provides a single jar to be ready, maybe the way that most servers here on lsp-mode "install" can be re-used. 👍🏿 

https://github.com/EmmyLua/EmmyLua-LanguageServer/releases

EmmyLua location aint anymore hard-coded to Emacs `<= 26` location, as Emacs 27 will look for XDG CONFIG HOME too :)