### PR TITLE
Crystal clients to lsp-crystal.el

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -70,7 +70,7 @@
     "full-name": "Crystal",
     "server-name": "scry",
     "server-url": "https://github.com/crystal-lang-tools/scry",
-    "installation-url": "https://github.com/crystal-lang-tools/scry",
+    "installation-url": "https://github.com/crystal-lang-tools/scry#installation",
     "debugger": "Not available"
   },
   {

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -774,23 +774,6 @@ responsiveness at the cost of possible stability issues."
                   :server-id 'lsp-r))
 
 
-;; Crystal
-(defgroup lsp-crystal nil
-  "LSP support for Crystal via scry."
-  :group 'lsp-mode
-  :link '(url-link "https://github.com/crystal-lang-tools/scry"))
-
-(defcustom lsp-clients-crystal-executable '("scry" "--stdio")
-  "Command to start the scry language server."
-  :group 'lsp-crystal
-  :risky t
-  :type 'file)
-
-(lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection lsp-clients-crystal-executable)
-                  :major-modes '(crystal-mode)
-                  :server-id 'scry))
-
 
 ;; Nim
 (defgroup lsp-nim nil

--- a/lsp-crystal.el
+++ b/lsp-crystal.el
@@ -1,0 +1,47 @@
+;;; lsp-crystal.el --- description -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 emacs-lsp maintainers
+
+;; Author: emacs-lsp maintainers
+;; Keywords: lsp,
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP Clients for the Crystal Programming Language.
+
+;;; Code:
+
+(require 'lsp-mode)
+
+;; Scry
+(defgroup lsp-scry nil
+  "LSP support for Crystal via scry."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/crystal-lang-tools/scry"))
+
+(defcustom lsp-clients-crystal-executable '("scry" "--stdio")
+  "Command to start the scry language server."
+  :group 'lsp-scry
+  :risky t
+  :type 'file)
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection lsp-clients-crystal-executable)
+                  :major-modes '(crystal-mode)
+                  :server-id 'scry))
+
+(provide 'lsp-crystal)
+;;; lsp-crystal.el ends here

--- a/lsp-crystal.el
+++ b/lsp-crystal.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 emacs-lsp maintainers
 
 ;; Author: emacs-lsp maintainers
-;; Keywords: lsp,
+;; Keywords: lsp, crystal
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -26,7 +26,6 @@
 
 (require 'lsp-mode)
 
-;; Scry
 (defgroup lsp-scry nil
   "LSP support for Crystal via scry."
   :group 'lsp-mode

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -348,7 +348,7 @@ unless overridden by a more specific face association."
   :package-version '(lsp-mode . "6.1"))
 
 (defcustom lsp-client-packages
-  '(ccls lsp-clients lsp-clojure lsp-csharp lsp-css lsp-dart lsp-dockerfile lsp-elm
+  '(ccls lsp-clients lsp-clojure lsp-crystal lsp-csharp lsp-css lsp-dart lsp-dockerfile lsp-elm
          lsp-erlang lsp-eslint lsp-fsharp lsp-gdscript lsp-go lsp-haskell lsp-haxe
          lsp-intelephense lsp-java lsp-json lsp-lua lsp-metals lsp-perl lsp-pwsh lsp-pyls
          lsp-python-ms lsp-rust lsp-serenata lsp-solargraph lsp-terraform lsp-verilog lsp-vetur


### PR DESCRIPTION
Hi,

Changes:
- **defgroup** to server name `lsp-scry`

Issues:
- Scry server will not run with the Linux binary provided the project.
- Building it locally and it still won't work. (I will open an issue later after more instruction).

more:
https://github.com/crystal-lang-tools/scry/releases

