### PR TITLE
Groovy clients to lsp-groovy.el

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -166,7 +166,7 @@
     "full-name": "Groovy",
     "server-name": "groovy-language-server",
     "server-url": "https://github.com/prominic/groovy-language-server",
-    "installation-url": "https://github.com/prominic/groovy-language-server",
+    "installation-url": "https://github.com/prominic/groovy-language-server#build",
     "debugger": "Not available"
   },
   {

--- a/lsp-clients.el
+++ b/lsp-clients.el
@@ -123,29 +123,6 @@ See instructions at https://marketplace.visualstudio.com/items?itemName=mads-har
                         (lsp-package-ensure 'bash-language-server callback error-callback))))
 
 
-;;; Groovy
-(defgroup lsp-groovy nil
-  "LSP support for Groovy, using groovy-language-server"
-  :group 'lsp-mode
-  :link '(url-link "https://github.com/prominic/groovy-language-server"))
-
-(defcustom lsp-groovy-server-file
-  (locate-user-emacs-file "groovy-language-server/groovy-language-server-all.jar")
-  "JAR file path for groovy-language-server-all.jar."
-  :group 'lsp-groovy
-  :risky t
-  :type 'file)
-
-(defun lsp-groovy--lsp-command ()
-  "Generate LSP startup command."
-  `("java" "-jar" ,(expand-file-name lsp-groovy-server-file)))
-
-(lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection 'lsp-groovy--lsp-command)
-                  :major-modes '(groovy-mode)
-                  :priority -1
-                  :server-id 'groovy-ls))
-
 ;;; TypeScript/JavaScript
 
 (lsp-dependency 'javascript-typescript-langserver

--- a/lsp-groovy.el
+++ b/lsp-groovy.el
@@ -1,0 +1,54 @@
+;;; lsp-groovy.el --- description -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 emacs-lsp maintainers
+
+;; Author: emacs-lsp maintainers
+;; Keywords: lsp, groovy
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP Clients for the Groovy Programming Language.
+
+;;; Code:
+
+(require 'lsp-mode)
+(require 'f)
+
+;;; Groovy
+(defgroup lsp-groovy nil
+  "LSP support for Groovy, using groovy-language-server."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/prominic/groovy-language-server"))
+
+(defcustom lsp-groovy-server-file
+  (f-join lsp-server-install-dir "groovy-language-server-all.jar")
+  "JAR file path for groovy-language-server-all.jar."
+  :group 'lsp-groovy
+  :risky t
+  :type 'file)
+
+(defun lsp-groovy--lsp-command ()
+  "Generate LSP startup command."
+  `("java" "-jar" ,(expand-file-name lsp-groovy-server-file)))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection 'lsp-groovy--lsp-command)
+                  :major-modes '(groovy-mode)
+                  :priority -1
+                  :server-id 'groovy-ls))
+
+(provide 'lsp-groovy)
+;;; lsp-groovy.el ends here

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -349,7 +349,7 @@ unless overridden by a more specific face association."
 
 (defcustom lsp-client-packages
   '(ccls lsp-clients lsp-clojure lsp-crystal lsp-csharp lsp-css lsp-dart lsp-dockerfile lsp-elm
-         lsp-erlang lsp-eslint lsp-fsharp lsp-gdscript lsp-go lsp-haskell lsp-haxe
+         lsp-erlang lsp-eslint lsp-fsharp lsp-gdscript lsp-go lsp-groovy lsp-haskell lsp-haxe
          lsp-intelephense lsp-java lsp-json lsp-lua lsp-metals lsp-perl lsp-pwsh lsp-pyls
          lsp-python-ms lsp-rust lsp-serenata lsp-solargraph lsp-terraform lsp-verilog lsp-vetur
          lsp-vhdl lsp-xml lsp-yaml lsp-sqls lsp-svelte)


### PR DESCRIPTION
Hi,

Changes:
- use `lsp-server-install-dir`
- `installation-url:` to point to build part of README

LOG:
`Command "java -jar /home/elxbarbosa/.config/emacs/.cache/lsp/groovy-language-server-all.jar" is present on the path.`
