### PR TITLE
Set `lsp--symbol-bounds-of-last-highlight-invocation' when...

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4512,21 +4512,19 @@ If INCLUDE-DECLARATION is non-nil, request the server to include declarations."
   was most recently invoked.")
 
 (defun lsp--document-highlight ()
-  (unless (or (looking-at "[[:space:]\n]")
-              (not lsp-enable-symbol-highlighting)
-              (and (lsp--point-on-highlight?)
-                   (let ((curr-sym-bounds (bounds-of-thing-at-point 'symbol)))
-                     (prog1
-                         (and curr-sym-bounds
-                              (equal curr-sym-bounds
-                                     lsp--symbol-bounds-of-last-highlight-invocation))
-                       (setq lsp--symbol-bounds-of-last-highlight-invocation
-                             curr-sym-bounds)))))
-    (lsp-request-async "textDocument/documentHighlight"
-                       (lsp--text-document-position-params)
-                       #'lsp--document-highlight-callback
-                       :mode 'tick
-                       :cancel-token :highlights)))
+  (let ((curr-sym-bounds (bounds-of-thing-at-point 'symbol)))
+    (unless (or (looking-at "[[:space:]\n]")
+                (not lsp-enable-symbol-highlighting)
+                (and curr-sym-bounds
+                     (equal curr-sym-bounds
+                            lsp--symbol-bounds-of-last-highlight-invocation)))
+      (setq lsp--symbol-bounds-of-last-highlight-invocation
+            curr-sym-bounds)
+      (lsp-request-async "textDocument/documentHighlight"
+                         (lsp--text-document-position-params)
+                         #'lsp--document-highlight-callback
+                         :mode 'tick
+                         :cancel-token :highlights))))
 
 (defun lsp-describe-thing-at-point ()
   "Display the type signature and documentation of the thing at


### PR DESCRIPTION
...point isn't initially on highlighted text.

Related to #1239.