### PR TITLE
Add Nix support in lsp-nix

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -3,6 +3,7 @@
   * Safe renamed ~lsp-diagnose~ to ~lsp-doctor~.
   * Add ~lsp-modeline-code-actions-segments~ for a better customization.
   * Add [[https://github.com/sumneko/lua-language-server][Lua Language Server]], [[https://github.com/Alloyed/lua-lsp][Lua-LSP]] and improve EmmyLua.
+  * Add support for the rnix-lsp server.
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -279,6 +279,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "nix",
+    "full-name": "Nix",
+    "server-name": "rnix-lsp",
+    "server-url": "https://github.com/nix-community/rnix-lsp",
+    "installation": "nix-env -i rnix-lsp",
+    "debugger": "Not available"
+  },
+  {
     "name": "ocaml",
     "full-name": "OCaml",
     "server-name": "ocaml-language-server",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -352,7 +352,7 @@ unless overridden by a more specific face association."
          lsp-crystal lsp-csharp lsp-css lsp-dart lsp-dhall lsp-dockerfile lsp-elm
          lsp-elixir lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript lsp-go
          lsp-hack lsp-groovy lsp-haskell lsp-haxe lsp-java lsp-javascript lsp-json
-         lsp-kotlin lsp-lua lsp-nim lsp-metals lsp-ocaml lsp-perl lsp-php lsp-pwsh
+         lsp-kotlin lsp-lua lsp-nim lsp-metals lsp-nix lsp-ocaml lsp-perl lsp-php lsp-pwsh
          lsp-pyls lsp-python-ms lsp-purescript lsp-r lsp-rf lsp-rust lsp-solargraph
          lsp-tex lsp-terraform lsp-verilog lsp-vetur lsp-vhdl lsp-vimscript lsp-xml
          lsp-yaml lsp-sqls lsp-svelte)
@@ -874,7 +874,8 @@ Changes take effect only when a new session is started."
                                         (purescript-mode . "purescript")
                                         (gdscript-mode . "gdscript")
                                         (perl-mode . "perl")
-                                        (robot-mode . "robot"))
+                                        (robot-mode . "robot")
+                                        (nix-mode . "nix"))
   "Language id configuration.")
 
 (defvar lsp--last-active-workspaces nil

--- a/lsp-nix.el
+++ b/lsp-nix.el
@@ -1,0 +1,43 @@
+;;; lsp-nix.el --- lsp-mode nix integration    -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 lsp-mode maintainers
+
+;; Author: Seong Yong-ju <sei40kr@gmail.com>
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Client for the rnix language server.
+
+;;; Code:
+
+(defgroup lsp-nix nil
+  "LSP support for Nix, using rnix-lsp."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/nix-community/rnix-lsp"))
+
+(defcustom lsp-nix-server-path "rnix-lsp"
+  "Executable path for the server."
+  :type 'string
+  :package-version '(lsp-mode . "7.1"))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-nix-server-path))
+                  :major-modes '(nix-mode)
+                  :server-id 'nix-ls))
+
+(provide 'lsp-nix)
+;;; lsp-nix.el ends here

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
     - Kotlin: page/lsp-kotlin.md
     - MSSQL: https://emacs-lsp.github.io/lsp-mssql
     - Nim: page/lsp-nim.md
+    - Nix: page/lsp-nix.md
     - OCaml (ocaml): page/lsp-ocaml.md
     - OCaml (icaml-lsp): page/lsp-ocalm-lsp-server.md
     - Pascal/Object Pascal: page/lsp-pascal.md


### PR DESCRIPTION
Since we're in the middle of a migration, and since he has not yet responded to the request to rebase, I modified @sei40kr's commit from #2027 to resolve the conflict and instead move the client to a `lsp-nix.el` file.

I **think** he is properly attributed in the commit. If not, I can close the PR.