### PR TITLE
Add trailing space to separate modeline diagnostics

### DIFF
--- a/lsp-modeline.el
+++ b/lsp-modeline.el
@@ -139,7 +139,7 @@
                                                         (lsp-execute-code-action (lsp--select-action actions))))))
                          built-string)
     (unless (string= "" built-string)
-      (concat " " built-string))))
+      (concat built-string " "))))
 
 (defun lsp--modeline-update-code-actions (actions)
   "Update modeline with new code ACTIONS."
@@ -252,7 +252,7 @@ The `:global' workspace is global one.")
   (cl-labels ((calc-modeline ()
                              (let ((str (lsp-modeline-diagnostics-statistics)))
                                (if (string-empty-p str) ""
-                                 (concat " " str)))))
+                                 (concat str " ")))))
     (setq lsp-modeline--diagnostics-string
           (cl-case lsp-modeline-diagnostics-scope
             (:file (or lsp-modeline--diagnostics-string


### PR DESCRIPTION
Our mode-line strings are added via `add-to-list` with `APPEND` set to nil,
so that means they are always placed at the beginning of `global-mode-string`.
It's a good idea to put things at the beginning to increase the chance that
users see the diagnostics count even in small frames or with a lot of minor modes.

However, if we want to play nice with the rest of things that can be part of `global-mode-string`
(like `display-time-mode`), then we need to append, and not prepend, a space after
our mode-line string.

This fixes a problem where the diagnostics string may overlap with things like
`display-time-mode'.

<img width="162" alt="Screenshot 2020-08-19 at 14 38 48" src="https://user-images.githubusercontent.com/1573717/90685579-4b8a7f80-e26a-11ea-8364-18667706d37b.png">
