### PR TITLE
Fix not a number or marker error

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6072,12 +6072,13 @@ an alist
 
   (\"symbol-name\" . ((\"(symbol-kind)\" . start-point)
                     cons-cells-from-children))"
-  (let* ((start-point (ht-get lsp--line-col-to-point-hash-table
-                              (lsp--get-line-and-col sym))))
-    (if (seq-empty-p children?)
-        (cons name start-point)
+  (let ((filtered-children (lsp--imenu-filter-symbols children?)))
+    (if (seq-empty-p filtered-children)
+        (cons name
+              (ht-get lsp--line-col-to-point-hash-table
+                      (lsp--get-line-and-col sym)))
       (cons name
-            (lsp--imenu-create-hierarchical-index children?)))))
+            (lsp--imenu-create-hierarchical-index filtered-children)))))
 
 (lsp-defun lsp--symbol-filter ((&SymbolInformation :kind :location))
   "Determine if SYM is for the current document and is to be shown."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6110,7 +6110,7 @@ an alist
 
 (defun lsp--collect-lines-and-cols (symbols)
   "Return a sorted list ((line . col) ...) of the locations of SYMBOLS."
-  (let ((stack (lsp--imenu-filter-symbols symbols))
+  (let ((stack (mapcar 'identity symbols))
         line-col-list)
     (while stack
       (let ((sym (pop stack)))
@@ -6195,10 +6195,8 @@ Return a nested alist keyed by symbol names. e.g.
                  (\"SomeSubClass\" (\"(Class)\" . 30)
                                   (\"someSubField (Field)\" . 35))
     (\"someFunction (Function)\" . 40))"
-  (let ((symbols (lsp--imenu-filter-symbols symbols)))
-    (seq-map #'lsp--symbol-to-hierarchical-imenu-elem
-             (seq-sort #'lsp--imenu-symbol-lessp
-                       (lsp--imenu-filter-symbols symbols)))))
+  (seq-map #'lsp--symbol-to-hierarchical-imenu-elem
+           (seq-sort #'lsp--imenu-symbol-lessp symbols)))
 
 (defun lsp--imenu-symbol-lessp (sym1 sym2)
   (let* ((compare-results (mapcar (lambda (method)


### PR DESCRIPTION
There's a bug in `lsp--symbol-to-hierarchical-imenu-elem` where symbol children don't get filtered out but `lsp--collect-lines-and-cols` only returns the lines and cols of filtered children, so when `lsp--symbol-to-hierarchical-imenu-elem` traverses down to the leaves not in the `lsp--line-col-to-point-hash-table`, a `nil` is recorded in some imenu items and results in an error when selecting those.