### PR TITLE
Enable completion-in-comments for gopls.

### DIFF
--- a/lsp-go.el
+++ b/lsp-go.el
@@ -226,8 +226,8 @@ $GOPATH/pkg/mod along with the value of
                   :language-id "go"
                   :priority 0
                   :server-id 'gopls
+                  :completion-in-comments? t
                   :library-folders-fn #'lsp-go--library-default-directories))
 
 (provide 'lsp-go)
 ;;; lsp-go.el ends here
-


### PR DESCRIPTION
gopls now supports useful completions in comments on master (see
https://golang.org/cl/249639).

This shouldn't impact users using stable gopls because gopls
previously suppressed all completions within comments.