### PR TITLE
Fallback default-directory when project and projectile return nil

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3373,7 +3373,8 @@ in that particular folder."
        (if (fboundp 'project-root)
            (project-root project)
          (car (with-no-warnings
-                (project-roots project))))))))
+                (project-roots project))))))
+   default-directory))
 
 (defun lsp--read-from-file (file)
   "Read FILE content."


### PR DESCRIPTION
When using `lsp-auto-guess-root`, this helps a lot when jumping source code of third party python packages and also when working on a small, dummy project with no git repository in it.

AFAIK, eglot use the same approach, too.