### PR TITLE
fix(eslint): only check for location when first command is node

### DIFF
--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -236,7 +236,7 @@ source.fixAll code action."
     (let* ((command-name (f-base (f-filename (cl-first lsp-eslint-server-command))))
            (first-argument (cl-second lsp-eslint-server-command))
            (first-argument-exist (and first-argument (file-exists-p first-argument))))
-     (if (equal command-name "node") first-argument-exist (not (not (executable-find (cl-first lsp-eslint-server-command))))))))
+     (if (equal command-name "node") first-argument-exist (executable-find (cl-first lsp-eslint-server-command))))))
   :activation-fn (lambda (filename &optional _)
                    (or (string-match-p (rx (one-or-more anything) "."
                                            (or "ts" "js" "jsx" "tsx" "html" "vue"))

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -234,7 +234,7 @@ source.fixAll code action."
    (lambda () lsp-eslint-server-command)
    (lambda ()
      (or
-      (not (string-equal (cl-first lsp-eslint-server-command) "node"))
+      (not (equal (f-base (f-filename (cl-first lsp-eslint-server-command))) "node")) ;; if first command is not node then assume it's good
       (and (cl-second lsp-eslint-server-command)
            (file-exists-p (cl-second lsp-eslint-server-command))))))
   :activation-fn (lambda (filename &optional _)

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -233,10 +233,10 @@ source.fixAll code action."
   (lsp-stdio-connection
    (lambda () lsp-eslint-server-command)
    (lambda ()
-     (or
-      (not (equal (f-base (f-filename (cl-first lsp-eslint-server-command))) "node")) ;; if first command is not node then assume it's good
-      (and (cl-second lsp-eslint-server-command)
-           (file-exists-p (cl-second lsp-eslint-server-command))))))
+    (let ((command-name (f-base (f-filename (cl-first lsp-eslint-server-command))))
+          (first-argument (cl-second lsp-eslint-server-command))
+          (first-argument-exist (and first-argument (file-exists-p first-argument))))
+     (if (equal command-name "node") first-argument-exist t))))
   :activation-fn (lambda (filename &optional _)
                    (or (string-match-p (rx (one-or-more anything) "."
                                            (or "ts" "js" "jsx" "tsx" "html" "vue"))

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -233,7 +233,7 @@ source.fixAll code action."
   (lsp-stdio-connection
    (lambda () lsp-eslint-server-command)
    (lambda ()
-    (let ((command-name (f-base (f-filename (cl-first lsp-eslint-server-command))))
+    (let* ((command-name (f-base (f-filename (cl-first lsp-eslint-server-command))))
           (first-argument (cl-second lsp-eslint-server-command))
           (first-argument-exist (and first-argument (file-exists-p first-argument))))
      (if (equal command-name "node") first-argument-exist t))))

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -234,9 +234,9 @@ source.fixAll code action."
    (lambda () lsp-eslint-server-command)
    (lambda ()
     (let* ((command-name (f-base (f-filename (cl-first lsp-eslint-server-command))))
-          (first-argument (cl-second lsp-eslint-server-command))
-          (first-argument-exist (and first-argument (file-exists-p first-argument))))
-     (if (equal command-name "node") first-argument-exist t))))
+           (first-argument (cl-second lsp-eslint-server-command))
+           (first-argument-exist (and first-argument (file-exists-p first-argument))))
+     (if (equal command-name "node") first-argument-exist (not (not (executable-find (cl-first lsp-eslint-server-command))))))))
   :activation-fn (lambda (filename &optional _)
                    (or (string-match-p (rx (one-or-more anything) "."
                                            (or "ts" "js" "jsx" "tsx" "html" "vue"))

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -233,8 +233,10 @@ source.fixAll code action."
   (lsp-stdio-connection
    (lambda () lsp-eslint-server-command)
    (lambda ()
-     (and (cl-second lsp-eslint-server-command)
-          (file-exists-p (cl-second lsp-eslint-server-command)))))
+     (or
+      (not (string-equal (cl-first lsp-eslint-server-command) "node"))
+      (and (cl-second lsp-eslint-server-command)
+           (file-exists-p (cl-second lsp-eslint-server-command))))))
   :activation-fn (lambda (filename &optional _)
                    (or (string-match-p (rx (one-or-more anything) "."
                                            (or "ts" "js" "jsx" "tsx" "html" "vue"))


### PR DESCRIPTION
If the command is not in the form of `node path/to/eslint/server` it shouldn't check for the second argument to exist. eg
I'm using a fork of the vscode eslint server which is just an executable https://github.com/danielpza/vscode-eslint-server.