### PR TITLE
Add optional blacklist for lsp-diagnostics-mode

### DIFF
--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -62,6 +62,11 @@ on top the flycheck face for that error level."
   :type '(repeat list)
   :group 'lsp-mode)
 
+(defcustom lsp-diagnostics-disabled-modes nil
+  "A list of major models for which `lsp-diagnostics-mode' should be disabled."
+  :type '(repeat symbol)
+  :group 'lsp-mode)
+
 ;; Flycheck integration
 
 (declare-function flycheck-mode "ext:flycheck")
@@ -271,7 +276,8 @@ See https://github.com/emacs-lsp/lsp-mode."
 ;;;###autoload
 (defun lsp-diagnostics--enable ()
   "Enable LSP checker support."
-  (when (member lsp-diagnostics-provider '(:auto :none :flycheck :flymake t nil))
+  (when (and (member lsp-diagnostics-provider '(:auto :none :flycheck :flymake t nil))
+             (not (member major-mode lsp-diagnostics-disabled-modes)))
     (lsp-diagnostics-mode 1)))
 
 (defun lsp-diagnostics--disable ()

--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -65,7 +65,8 @@ on top the flycheck face for that error level."
 (defcustom lsp-diagnostics-disabled-modes nil
   "A list of major models for which `lsp-diagnostics-mode' should be disabled."
   :type '(repeat symbol)
-  :group 'lsp-mode)
+  :group 'lsp-mode
+  :package-version '(lsp-mode . "7.1"))
 
 ;; Flycheck integration
 


### PR DESCRIPTION
Currently lsp-diagnostics is an all-or-nothing setting. There are some LSP servers that advertise support for diagnostics but don't really do much except checking for syntax errors, in those cases it's probably better to turn lsp-diagnostics off just for those modes and let the user set up flycheck or flymake with the appropriate linters themselves.