### PR TITLE
lsp-signature-auto-active: add option for activate after completion

### DIFF
--- a/docs/page/settings.md
+++ b/docs/page/settings.md
@@ -29,7 +29,7 @@ These are `lsp-mode` specific custom settings:
 - `lsp-server-trace` - Request trace mode on the language server.
 - `lsp-semantic-highlighting` - Enable experimental semantic highlighting support
 - `lsp-enable-imenu` - If non-nil, automatically enable imenu integration when server provides `textDocument/documentSymbol`.
-- `lsp-signature-auto-activate` - Auto activate signature when trigger char is pressed.
+- `lsp-signature-auto-activate` - Auto activate signature when trigger conditions are meet.
 - `lsp-signature-render-documentation` - Include signature documentation in signature help.
 - `lsp-enable-text-document-color` - Enable `textDocument/documentColor` when server supports it.
 

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -521,7 +521,8 @@ Others: TRIGGER-CHARS CANDIDATES"
                          (lsp:command-command command?)
                          err))))
 
-        (when (and lsp-signature-auto-activate
+        (when (and (or (equal lsp-signature-auto-activate t)
+                       (memq :after-completion lsp-signature-auto-activate))
                    (lsp-feature? "textDocument/signatureHelp"))
           (lsp-signature-activate))
 


### PR DESCRIPTION
Change `lsp-signature-auto-activate` to list of `(:after-completion :on-trigger-char)` so we can granularly control when to trigger signature auto activation