### PR TITLE
Auto detect macos clangd

### DIFF
--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -178,14 +178,6 @@ This must be set only once after loading the clang client.")
   :risky t
   :type '(repeat string))
 
-(defun lsp-clients--clangd-darwin-executable-find (executable &rest args)
-  (when-let* ((executable-path (executable-find executable))
-              (clangd-path
-               (with-temp-buffer
-                 (when (zerop (apply 'call-process executable-path nil t nil args))
-                   (buffer-substring-no-properties (point-min) (point-max))))))
-    (string-trim clangd-path)))
-
 (defun lsp-clients--clangd-command ()
   "Generate the language server startup command."
   (unless lsp-clients--clangd-default-executable
@@ -194,8 +186,8 @@ This must be set only once after loading the clang client.")
                       (-map (lambda (version)
                               (concat "clangd" version))
                             '("" "-12" "-11" "-10" "-9" "-8" "-7" "-6")))
-              (lsp-clients--clangd-darwin-executable-find "xcodebuild" "-find-executable" "clangd")
-              (lsp-clients--clangd-darwin-executable-find "xcrun" "--find" "clangd"))))
+              (lsp-clients-executable-find "xcodebuild" "-find-executable" "clangd")
+              (lsp-clients-executable-find "xcrun" "--find" "clangd"))))
 
   `(,(or lsp-clients-clangd-executable lsp-clients--clangd-default-executable "clangd")
     ,@lsp-clients-clangd-args))

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -177,14 +177,24 @@ This must be set only once after loading the clang client.")
   :risky t
   :type '(repeat string))
 
+(defun lsp-clients--clangd-darwin-executable-find (executable &rest args)
+  (when-let* ((executable-path (executable-find executable))
+              (clangd-path
+               (with-temp-buffer
+                 (when (zerop (apply 'call-process executable-path nil t nil args))
+                   (buffer-substring-no-properties (point-min) (point-max))))))
+    (string-trim clangd-path)))
+
 (defun lsp-clients--clangd-command ()
   "Generate the language server startup command."
   (unless lsp-clients--clangd-default-executable
     (setq lsp-clients--clangd-default-executable
-          (-first #'executable-find
-                  (-map (lambda (version)
-                          (concat "clangd" version))
-                        '("" "-12" "-11" "-10" "-9" "-8" "-7" "-6")))))
+          (or (-first #'executable-find
+                      (-map (lambda (version)
+                              (concat "clangd" version))
+                            '("" "-12" "-11" "-10" "-9" "-8" "-7" "-6")))
+              (lsp-clients--clangd-darwin-executable-find "xcodebuild" "-find-executable" "clangd")
+              (lsp-clients--clangd-darwin-executable-find "xcrun" "--find" "clangd"))))
 
   `(,(or lsp-clients-clangd-executable lsp-clients--clangd-default-executable "clangd")
     ,@lsp-clients-clangd-args))

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -165,7 +165,8 @@ available in your path to use. Otherwise the system will try to
 find a suitable one. Set this variable before loading lsp."
   :group 'lsp-clangd
   :risky t
-  :type 'file)
+  :type '(choice (file :tag "Path")
+                 (const :tag "Auto" nil)))
 
 (defvar lsp-clients--clangd-default-executable nil
   "Clang default executable full path when found.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1525,7 +1525,8 @@ BODY should never return `t' value."
 
 FIND-COMMAND is the executable finder that searches for the
 actual language server executable. ARGS is a list of arguments to
-give to FIND-COMMAND to find the language server.
+give to FIND-COMMAND to find the language server. Returns the
+output of FIND-COMMAND if it exits successfully, nil otherwise.
 
 Typical uses includes finding an executable by invoking 'find' in
 a project, finding LLVM commands on macOS with 'xcrun', or

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1525,10 +1525,10 @@ BODY should never return `t' value."
 
 FIND-COMMAND is the executable finder that searches for the
 actual language server executable. ARGS is a list of arguments to
-give to FIND-COMMAND to find the language server. Returns the
+give to FIND-COMMAND to find the language server.  Returns the
 output of FIND-COMMAND if it exits successfully, nil otherwise.
 
-Typical uses includes finding an executable by invoking 'find' in
+Typical uses include finding an executable by invoking 'find' in
 a project, finding LLVM commands on macOS with 'xcrun', or
 looking up project-specific language servers for projects written
 in the various dynamic languages, e.g. 'nvm', 'pyenv' and 'rbenv'

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1520,6 +1520,25 @@ BODY should never return `t' value."
   download-in-progress?
   buffers)
 
+(defun lsp-clients-executable-find (find-command &rest args)
+  "Finds an executable by invoking a search command.
+
+FIND-COMMAND is the executable finder that searches for the
+actual language server executable. ARGS is a list of arguments to
+give to FIND-COMMAND to find the language server.
+
+Typical uses includes finding an executable by invoking `find' in
+a project, finding LLVM commands on macOS with `xcrun', or
+looking up project-specific language servers for projects written
+in the various dynamic languages, e.g. `nvm', `pyenv' and
+`rbenv' etc."
+  (when-let* ((find-command-path (executable-find find-command))
+              (executable-path
+               (with-temp-buffer
+                 (when (zerop (apply 'call-process find-command-path nil t nil args))
+                   (buffer-substring-no-properties (point-min) (point-max))))))
+    (string-trim executable-path)))
+
 (defvar lsp--already-widened nil)
 
 (defmacro lsp-save-restriction-and-excursion (&rest form)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1527,11 +1527,11 @@ FIND-COMMAND is the executable finder that searches for the
 actual language server executable. ARGS is a list of arguments to
 give to FIND-COMMAND to find the language server.
 
-Typical uses includes finding an executable by invoking `find' in
-a project, finding LLVM commands on macOS with `xcrun', or
+Typical uses includes finding an executable by invoking 'find' in
+a project, finding LLVM commands on macOS with 'xcrun', or
 looking up project-specific language servers for projects written
-in the various dynamic languages, e.g. `nvm', `pyenv' and
-`rbenv' etc."
+in the various dynamic languages, e.g. 'nvm', 'pyenv' and 'rbenv'
+etc."
   (when-let* ((find-command-path (executable-find find-command))
               (executable-path
                (with-temp-buffer


### PR DESCRIPTION
Allow LSP to pick up the clangd that comes with Xcode or Developer Command Line Tools automatically without having the user to install LLVM with Homebrew or MacPorts.