### PR TITLE
[bug] - Fix Rename file workspace edits

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3791,6 +3791,7 @@ interface TextDocumentEdit {
                 (when buf
                   (lsp-with-current-buffer buf
                     (set-buffer-modified-p nil)
+                    (setq lsp-buffer-uri nil)
                     (set-visited-file-name new-file-name)
                     (lsp)))))
     (_ (let ((file-name (->> edit


### PR DESCRIPTION
While I was implementing https://github.com/snoe/clojure-lsp/pull/183, I realized that lsp-mode was sending `did-open` request with the old file-name, with this fix,  the `(lsp--buffer-uri)` will send the correct new file name on `did-open` requests.