### PR TITLE
ci-windows: remove (provide 'windows-boostrap) and cleanup after test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ unix-test:
 
 windows-test:
 	@$(EMACS) -Q --batch \
+		-l test/windows-bootstrap.el \
 		-L . -L clients \
 		$(LOAD-TEST-FILES) \
 		--eval "(ert-run-tests-batch-and-exit \

--- a/test/windows-bootstrap.el
+++ b/test/windows-bootstrap.el
@@ -23,13 +23,24 @@
 
 (require 'package)
 
-(let* ((pkgs '(dash dash-functional f lv ht spinner markdown-mode deferred ert-runner)))
-  (add-to-list 'package-archives '("melpa" . "http://melpa.org/packages/") t)
+
+(setq user-emacs-directory (expand-file-name (make-temp-name ".emacs.d")
+                                             "~")
+      package-user-dir (expand-file-name (make-temp-name "tmp-elpa")
+                                         user-emacs-directory))
+
+(let* ((package-archives '(("melpa" . "https://melpa.org/packages/")
+                           ("gnu" . "https://elpa.gnu.org/packages/")))
+       (pkgs '(dash dash-functional f lv ht spinner markdown-mode deferred)))
   (package-initialize)
+  (package-refresh-contents)
 
-  (when (cl-find-if-not 'package-installed-p pkgs)
-    (package-refresh-contents)
-    (mapc 'package-install pkgs)))
+  (mapc (lambda (pkg)
+          (unless (package-installed-p pkg)
+            (package-install pkg)))
+        pkgs)
 
-(provide 'windows-bootstrap)
+  (add-hook 'kill-emacs-hook
+            `(lambda () (delete-directory ,user-emacs-directory t))))
+
 ;;; windows-bootstrap.el ends here


### PR DESCRIPTION
Remove `(provide 'windows-boostrap)` since test utilities shouldn't provide any feature (to avoid conflicting).
Also, set `user-emacs-directory` and `package-user-dir` to auto generated, auto cleanup folder so we can run it locally without affecting current emacs installation folder.