### PR TITLE
Remove temporary patch in markdown-mode for hr lines

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4663,20 +4663,6 @@ Stolen from `org-copy-visible'."
   "Render markdown."
 
   (let ((markdown-enable-math nil))
-    ;; Temporary patch --- since the symbol is not rendered fine in lsp-ui
-    ;; Anything that renders full-width disturbs the width calculation
-    ;; of the resulting hover window.
-    ;; See https://github.com/emacs-lsp/lsp-ui/issues/442
-    (goto-char (point-min))
-    (while (re-search-forward
-            (rx (or
-                 (seq bol (+ "-") eol)
-                 (seq "\* \* \*" eol)
-                 (seq "\-\-\-" eol)
-                 (seq "\_\_\_" eol)))
-            nil t)
-      (replace-match ""))
-
     (goto-char (point-min))
     (while (re-search-forward
             (rx (and "\\" (group (or "\\" "`" "*" "_" ":" "/"


### PR DESCRIPTION
lsp-ui now display correctly those lines with https://github.com/emacs-lsp/lsp-ui/commit/54b0a96619b2ceaed5c7ba96c0ab450bc7aed7cc

EDIT: Note that `lsp-ui` needs this PR to display hr lines.

![image](https://user-images.githubusercontent.com/5273820/92992192-ccf8c900-f51b-11ea-9a36-0328de9b1b25.png)
