### PR TITLE
ci: fix python-language-server installation failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
                   version: 0.8.4
 
             - name: Install depedencies
-              run: "sudo pip install python-language-server"
+              run: "pip3 install python-language-server"
 
             - name: Run tests
               run:


### PR DESCRIPTION
As in https://github.com/palantir/python-language-server/issues/863, it seems that python 3 will be required for `python-language-server`.