### PR TITLE
remove confusing near-duplicate sentence

### DIFF
--- a/docs/tutorials/CPP-guide.md
+++ b/docs/tutorials/CPP-guide.md
@@ -30,11 +30,10 @@ production-ready language servers for `C/C++` and `Objective-C`,
 [ccls](https://github.com/MaskRay/ccls) and
 [clangd](https://clangd.llvm.org/installation.html), with `ccls`'s precursor
 `cquery` being deprecated. used by `Emacs` as provider for language specific
-features(completion, diagnostics, navigation, etc). For some of the language
+features (completion, diagnostics, navigation, etc). For some of the language
 servers `lsp-mode` ships with automatic installation scripts but there is no
 such script for installing `C/C++` language server due to their overall
-complexity. As of end of 2020 there are 2 `C/C++` language servers - `ccls` and
-`clangd` with `cquery` being deprecated. For this guide we will be using
+complexity. For this guide we will be using
 `clangd` but most of the steps here apply to `ccls` as well. `lsp-mode` is
 pre-configured and it will be able to find the language server automatically
 when it is installed on the host machine and it is present on the path. In case


### PR DESCRIPTION
already says "As of late 2020, there are 2
production-ready language servers… " earlier in paragraph