### PR TITLE
lsp--parser-on-message: run in next cycle for correct profiler report

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6129,7 +6129,7 @@ deserialization.")
                                            (split-string
                                             (substring chunk
                                                        (or (string-match-p "Content-Length" chunk)
-                                                           (error "Unable to find Content-Length header."))
+                                                           (error "Unable to find Content-Length header"))
                                                        body-sep-pos)
                                             "\r\n")))
                       body-received 0
@@ -6159,14 +6159,18 @@ deserialization.")
                                                          body-length nil
                                                          body-received nil
                                                          body nil)))) 'utf-8)))
-                (lsp--parser-on-message
-                 (condition-case err
-                     (lsp--read-json lsp-parsed-message)
-                   (error
-                    (lsp-warn "Failed to parse the following chunk:\n'''\n%s\n'''\nwith message %s"
-                              (concat leftovers input)
-                              err)))
-                 workspace)))))))))
+                (run-at-time
+                 0 nil
+                 (lambda (msg)
+                   (lsp--parser-on-message
+                    (condition-case err
+                        (lsp--read-json msg)
+                      (error
+                       (lsp-warn "Failed to parse the following chunk:\n'''\n%s\n'''\nwith message %s"
+                                 (concat leftovers input)
+                                 err)))
+                    workspace))
+                 lsp-parsed-message)))))))))
 
 (defvar-local lsp--line-col-to-point-hash-table nil
   "Hash table with keys (line . col) and values that are either point positions


### PR DESCRIPTION
Run `lsp--parser-on-message` in the next event loop cycle so the profiler will correctly report CPU usage of sync request function.

Without this, profile report may look like follow, which is kind of wrong since the `lsp--parser-on-message` which is run to accept output in the sync request is counted as sync request CPU.
![image](https://user-images.githubusercontent.com/2631472/93076407-43373000-f6c2-11ea-9a13-022976b9a9e2.png)

With this change, the CPU is properly reported
![image](https://user-images.githubusercontent.com/2631472/93077195-7201d600-f6c3-11ea-9f35-12a2fcdbf16c.png)
