### PR TITLE
lsp-send-execute-command: better error message when fail to execute

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -526,12 +526,7 @@ Others: TRIGGER-CHARS CANDIDATES"
                cleanup-fn))))
 
         (when command?
-          (condition-case-unless-debug err
-              (lsp--execute-command command?)
-            (error
-             (lsp--error "Please open an issue in lsp-mode for implementing `%s'.\n\n%S"
-                         (lsp:command-command command?)
-                         err))))
+          (lsp--execute-command command?))
 
         (when (and (or (equal lsp-signature-auto-activate t)
                        (memq :after-completion lsp-signature-auto-activate))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5767,7 +5767,12 @@ REFERENCES? t when METHOD returns references."
   (let ((params (if args
                     (list :command command :arguments args)
                   (list :command command))))
-    (lsp-request "workspace/executeCommand" params)))
+    (condition-case-unless-debug err
+        (lsp-request "workspace/executeCommand" params)
+      (error
+       (lsp--error "Please open an issue in lsp-mode for implementing `%s'.\n\n%S"
+                   command
+                   err)))))
 
 (defalias 'lsp-point-to-position #'lsp--point-to-position)
 (defalias 'lsp-text-document-identifier #'lsp--text-document-identifier)


### PR DESCRIPTION
As the title, we need better error message  in case server do not provide `workspace/executeCommand` or if there's error message when executing `lsp--send-execute-command`.