### PR TITLE
lsp-csharp: handle interop notifications

### DIFF
--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -247,7 +247,7 @@ using the `textDocument/references' request."
     (message "No references found")))
 
 (lsp-defun lsp-csharp--handle-os-error (_workspace (&omnisharp:ErrorMessage :file-name :text))
-  "Handle the 'o#/error' (interop) notification with PARAMS by displaying a message with lsp-warn."
+  "Handle the 'o#/error' (interop) notification by displaying a message with lsp-warn."
   (lsp-warn "%s: %s" file-name text))
 
 (lsp-register-client

--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -256,6 +256,15 @@ using the `textDocument/references' request."
                   :major-modes '(csharp-mode)
                   :server-id 'csharp
                   :action-handlers (ht ("omnisharp/client/findReferences" 'lsp-csharp--action-client-find-references))
+                  :notification-handlers (ht ("o#/projectadded" 'ignore)
+                                             ("o#/projectchanged" 'ignore)
+                                             ("o#/projectremoved" 'ignore)
+                                             ("o#/packagerestorestarted" 'ignore)
+                                             ("o#/packagerestorefinished" 'ignore)
+                                             ("o#/unresolveddependencies" 'ignore)
+                                             ("o#/error" 'ignore)
+                                             ("o#/projectconfiguration" 'ignore)
+                                             ("o#/projectdiagnosticstatus" 'ignore))
                   :download-server-fn
                   (lambda (_client callback error-callback _update?)
                     (condition-case err

--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -246,6 +246,11 @@ using the `textDocument/references' request."
       (lsp-show-xrefs (lsp--locations-to-xref-items locations-found) nil t)
     (message "No references found")))
 
+(defun lsp-csharp--handle-os-error (_workspace params)
+  "Handle the 'o#/error' (interop) notification with PARAMS by displaying a message with lsp-warn."
+  (-let (((&hash "FileName" filename "Text" text) params))
+    (lsp-warn "%s: %s" filename text)))
+
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection
                                    #'lsp-csharp--language-server-command
@@ -262,7 +267,7 @@ using the `textDocument/references' request."
                                              ("o#/packagerestorestarted" 'ignore)
                                              ("o#/packagerestorefinished" 'ignore)
                                              ("o#/unresolveddependencies" 'ignore)
-                                             ("o#/error" 'ignore)
+                                             ("o#/error" 'lsp-csharp--handle-os-error)
                                              ("o#/projectconfiguration" 'ignore)
                                              ("o#/projectdiagnosticstatus" 'ignore))
                   :download-server-fn

--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -246,10 +246,9 @@ using the `textDocument/references' request."
       (lsp-show-xrefs (lsp--locations-to-xref-items locations-found) nil t)
     (message "No references found")))
 
-(defun lsp-csharp--handle-os-error (_workspace params)
+(lsp-defun lsp-csharp--handle-os-error (_workspace (&omnisharp:ErrorMessage :file-name :text))
   "Handle the 'o#/error' (interop) notification with PARAMS by displaying a message with lsp-warn."
-  (-let (((&omnisharp:ErrorMessage :file-name :text) params))
-    (lsp-warn "%s: %s" file-name text)))
+  (lsp-warn "%s: %s" file-name text))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection

--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -248,8 +248,8 @@ using the `textDocument/references' request."
 
 (defun lsp-csharp--handle-os-error (_workspace params)
   "Handle the 'o#/error' (interop) notification with PARAMS by displaying a message with lsp-warn."
-  (-let (((&hash "FileName" filename "Text" text) params))
-    (lsp-warn "%s: %s" filename text)))
+  (-let (((&omnisharp:ErrorMessage :file-name :text) params))
+    (lsp-warn "%s: %s" file-name text)))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -267,6 +267,8 @@ See `-let' for a description of the destructuring mechanism."
 
 (lsp-interface (pwsh:ScriptRegion (:StartLineNumber :EndLineNumber :StartColumnNumber :EndColumnNumber :Text) nil))
 
+(lsp-interface (omnisharp:ErrorMessage (:Text :FileName :Line :Column)))
+
 (lsp-interface (rls:Cmd (:args :binary :env :cwd) nil))
 
 (defconst lsp/rust-analyzer-inlay-hint-kind-type-hint "TypeHint")


### PR DESCRIPTION
This adds handlers for '#o/XXX' notifications that have been added recently to facilitate omnisharp clients transitioning from custom to LSP protocol (see https://github.com/OmniSharp/omnisharp-roslyn/pull/1911). 

The events are ignored by default, except for 'o#/error' which may help resolving issues when projects are not being properly loaded (this may have helped to diagnose #2188)