### PR TITLE
Add lsp-nix to the list of lsp-client-packages

### DIFF
--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -24,6 +24,8 @@
 
 ;;; Code:
 
+(require 'lsp-mode)
+
 (defgroup lsp-nix nil
   "LSP support for Nix, using rnix-lsp."
   :group 'lsp-mode
@@ -31,6 +33,7 @@
 
 (defcustom lsp-nix-server-path "rnix-lsp"
   "Executable path for the server."
+  :group 'lsp-nix
   :type 'string
   :package-version '(lsp-mode . "7.1"))
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -352,7 +352,7 @@ unless overridden by a more specific face association."
          lsp-crystal lsp-csharp lsp-css lsp-dart lsp-dhall lsp-dockerfile lsp-elm
          lsp-elixir lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript lsp-go
          lsp-hack lsp-groovy lsp-haskell lsp-haxe lsp-java lsp-javascript lsp-json
-         lsp-kotlin lsp-lua lsp-nim lsp-metals lsp-ocaml lsp-perl lsp-php lsp-pwsh
+         lsp-kotlin lsp-lua lsp-nim lsp-nix lsp-metals lsp-ocaml lsp-perl lsp-php lsp-pwsh
          lsp-pyls lsp-python-ms lsp-purescript lsp-r lsp-rf lsp-rust lsp-solargraph
          lsp-tex lsp-terraform lsp-verilog lsp-vetur lsp-vhdl lsp-vimscript lsp-xml
          lsp-yaml lsp-sqls lsp-svelte)


### PR DESCRIPTION
#2115 added Nix support, but it is not on the list of clients that are automatically required. This PR fixes it. Also made cosmetic changes to make `lsp-nix.el` more consistent with other clients.