### PR TITLE
[lsp-json] Change executable path for system-installed server

### DIFF
--- a/clients/lsp-json.el
+++ b/clients/lsp-json.el
@@ -99,7 +99,7 @@
                   (list callback))))
 
 (lsp-dependency 'vscode-json-languageserver
-                '(:system "vscode-json-languageserver")
+                '(:system "json-languageserver")
                 '(:npm :package "vscode-json-languageserver"
                        :path "vscode-json-languageserver"))
 


### PR DESCRIPTION
When installing the server via Nix, this seems to be the correct path. I'm not sure if other package managers have this as their path, though.