### PR TITLE
Add lsp-file-watch-ignored entry for .vscode

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -498,6 +498,7 @@ the server has requested that."
                                     "[/\\\\]\\.metals$"
                                     "[/\\\\]target$"
                                     "[/\\\\]\\.ccls-cache$"
+                                    "[/\\\\]\\.vscode$"
                                     ;; Autotools output
                                     "[/\\\\]\\.deps$"
                                     "[/\\\\]build-aux$"


### PR DESCRIPTION
Other references to .vscode in the project to take into consideration:

```
./clients/lsp-javascript.el:89:         :location \"<path>.vscode/extensions/visualstudioexptteam.vscodeintellicode-1.1.9/\"))"
./clients/lsp-rf.el:35:(defcustom lsp-rf-language-server-start-command '("~/.nvm/versions/node/v9.11.2/bin/node" "~/.vscode/extensions/tomiturtiainen.rf-intellisense-2.8.0/server/server.js")
./clients/lsp-rf.el:50:(defcustom lsp-rf-language-server-dir "~/.vscode/extensions/tomiturtiainen.rf-intellisense-2.8.0/server/library-docs/"
./clients/lsp-perl.el:69:  "A vector of directories to ignore.  Defaults to `[\".vscode\" \".git\" \".svn\"]' if nil."
```