### PR TITLE
fuz-score: rework fuz-score algo to boost prefix match and not consider length

### DIFF
--- a/test/lsp-completion-test.el
+++ b/test/lsp-completion-test.el
@@ -34,34 +34,47 @@
               'function)))
 
 (ert-deftest lsp-completion-test-fuz-score ()
-  (let ((query "as")
-        (cands '("hashCode() : int"
-                 "asSubclass(Class<U> clazz) : Class<? extends U>")))
-    (should (equal (sort cands (lambda (l r) (> (lsp-completion--fuz-score query l)
-                                                (lsp-completion--fuz-score query r))))
-                   '("asSubclass(Class<U> clazz) : Class<? extends U>"
-                     "hashCode() : int"))))
-
-  (let ((query "as")
-        (cands '("hash-map"
-                 "as-definition"
-                 "as-def"
-                 "aS-selection"
-                 "To-as-expected"
-                 "amused"
-                 "subclass-1"
-                 "superand-sort")))
-    (should (equal (sort cands (lambda (l r) (> (lsp-completion--fuz-score query l)
-                                                (lsp-completion--fuz-score query r))))
-                   '("as-definition"    ; Prefix match
-                     "as-def"           ; Also prefix match (stable)
-                     "hash-map"         ; middle match
-                     "amused"           ; partial match with prefix match
-                     "To-as-expected"   ; more in middle match
-                     "subclass-1"       ; more in middle match
-                     "superand-sort"    ; partial match without prefix match
-                     "aS-selection"     ; case mismatch
-                     )))))
+  (cl-labels ((do-test (query cands expected)
+                       (should (equal
+                                (sort cands
+                                      (lambda (l r) (> (lsp-completion--fuz-score query l)
+                                                       (lsp-completion--fuz-score query r))))
+                                expected))))
+    (do-test "as"
+             '("hashCode() : int"
+               "asSubclass(Class<U> clazz) : Class<? extends U>")
+             '("asSubclass(Class<U> clazz) : Class<? extends U>"
+               "hashCode() : int"))
+    (do-test "as"
+             '("hash-map"
+               "as-definition"
+               "as-def"
+               "aS-selection"
+               "To-as-expected"
+               "amused"
+               "subclass-1"
+               "superand-sort")
+             '("as-definition"    ; Prefix match
+               "as-def"           ; Also prefix match (stable)
+               "hash-map"         ; middle match
+               "amused"           ; partial match with prefix match
+               "To-as-expected"   ; more in middle match
+               "subclass-1"       ; more in middle match
+               "superand-sort"    ; partial match without prefix match
+               "aS-selection"     ; case mismatch
+               ))
+    (do-test "F"
+             '("F" "foo" "Foo")
+             '("F" "Foo" "foo"))
+    (do-test "Fo"
+             '("Fo" "daFo" "safo")
+             '("Fo" "daFo" "safo"))
+    (do-test "F"
+             '("F" "daFo" "safo")
+             '("F" "daFo" "safo"))
+    (do-test "foo"
+             '("foo" "afoo" "aafoo" "aaafoo")
+             '("foo" "afoo" "aafoo" "aaafoo"))))
 
 (provide 'lsp-completion-test)
 ;;; lsp-completion-test.el ends here

--- a/test/lsp-completion-test.el
+++ b/test/lsp-completion-test.el
@@ -33,5 +33,35 @@
                            (lsp-make-completion-item :kind 3)))
               'function)))
 
+(ert-deftest lsp-completion-test-fuz-score ()
+  (let ((query "as")
+        (cands '("hashCode() : int"
+                 "asSubclass(Class<U> clazz) : Class<? extends U>")))
+    (should (equal (sort cands (lambda (l r) (> (lsp-completion--fuz-score query l)
+                                                (lsp-completion--fuz-score query r))))
+                   '("asSubclass(Class<U> clazz) : Class<? extends U>"
+                     "hashCode() : int"))))
+
+  (let ((query "as")
+        (cands '("hash-map"
+                 "as-definition"
+                 "as-def"
+                 "aS-selection"
+                 "To-as-expected"
+                 "amused"
+                 "subclass-1"
+                 "superand-sort")))
+    (should (equal (sort cands (lambda (l r) (> (lsp-completion--fuz-score query l)
+                                                (lsp-completion--fuz-score query r))))
+                   '("as-definition"    ; Prefix match
+                     "as-def"           ; Also prefix match (stable)
+                     "hash-map"         ; middle match
+                     "amused"           ; partial match with prefix match
+                     "To-as-expected"   ; more in middle match
+                     "subclass-1"       ; more in middle match
+                     "superand-sort"    ; partial match without prefix match
+                     "aS-selection"     ; case mismatch
+                     )))))
+
 (provide 'lsp-completion-test)
 ;;; lsp-completion-test.el ends here


### PR DESCRIPTION
Slightly modify the current heuristic of calculating fuzzy score.
Before: `fuz_score(str) = len(query) / ((sum(hole_score(i)) + 1) * len(str))`
After: `fuz_score(str) = len(query) / (sum(hole_score(i)) + 1)`

With the `hole_score` of the first hole is boosted to prefer the prefix match.
And also we do not consider string length anymore, thus no longer boost the score for shorter matched string.
As proposed in https://github.com/emacs-lsp/lsp-mode/issues/2195#issuecomment-698879445