### PR TITLE
lsp-doctor: better detection for company-capf in multi-backends

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7773,7 +7773,9 @@ This avoids overloading the server with many files when starting Emacs."
   (lsp--doctor
    "Checking for Native JSON support" (functionp 'json-serialize)
    "Checking emacs version has `read-process-output-max'" (boundp 'read-process-output-max)
-   "Using company-capf" (-contains? company-backends 'company-capf)
+   "Using company-capf" (--find (or (equal it 'company-capf)
+                                    (and (listp it) (-contains? it 'company-capf)))
+                                company-backends)
    "Check emacs supports `read-process-output-max'" (boundp 'read-process-output-max)
    "Check `read-process-output-max' default has been changed from 4k"
    (and (boundp 'read-process-output-max)


### PR DESCRIPTION
As title, `company-capf` can be inside a list.