### PR TITLE
ignore variables affecting serialization in `lsp-persist`

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3443,7 +3443,9 @@ in that particular folder."
 
 (defun lsp--persist (file-name to-persist)
   "Persist TO-PERSIST in FILE-NAME."
-  (f-write-text (prin1-to-string to-persist) 'utf-8 file-name))
+  (let ((print-length nil)
+        (print-level nil))
+    (f-write-text (prin1-to-string to-persist) 'utf-8 file-name)))
 
 (defun lsp-workspace-folders-add (project-root)
   "Add PROJECT-ROOT to the list of workspace folders."


### PR DESCRIPTION
the `prin1*` (used by `lsp--persist`) family of function are affected by `print-level`, `print-length` and others (https://www.gnu.org/software/emacs/manual/html_node/elisp/Output-Variables.html). 

Without this patch, setting `print-level` to less that the length of `lsp-session` will silently corrupt `lsp-session-file` when saved. 
(in my case, I did not manually set `print-level` but my `lsp-sessions-file` ended with bare "..." as if truncated and lsp warned `Failed to parse the session Hash table data` on next emacs startup)