### PR TITLE
[headerline] Fix all-the-icons support

### DIFF
--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -76,16 +76,17 @@ caching purposes.")
 
 (defun lsp-headerline--fix-image-background (image)
   "Fix IMAGE background if it is a file otherwise return as an icon."
-  (if (and image (get-text-property 0 'display image))
-      (propertize " " 'display
-                  (cl-list* 'image
-                            (plist-put
-                             (cl-copy-list
-                              (cl-rest (get-text-property
-                                        0 'display
-                                        image)))
-                             :background (face-attribute 'header-line :background))))
-    (replace-regexp-in-string "\s\\|\t" "" (or image ""))))
+  (if image
+      (let ((display-image (get-text-property 0 'display image)))
+        (if (listp display-image)
+            (propertize " " 'display
+                        (cl-list* 'image
+                                  (plist-put
+                                   (cl-copy-list
+                                    (cl-rest display-image))
+                                   :background (face-attribute 'header-line :background))))
+          (replace-regexp-in-string "\s\\|\t" "" display-image)))
+    ""))
 
 (defun lsp-headerline--filename-with-icon (file-path)
   "Return the filename from FILE-PATH with the extension related icon."


### PR DESCRIPTION
I realized headerline icon is not working for some extensions like `.edn` that uses all-the-icons.

Before:
```elisp
(lsp-headerline--fix-image-background (lsp-treemacs-get-icon "edn")) =>

Debugger entered--Lisp error: (wrong-type-argument listp #("  \11" 2 3 (rear-nonsticky t display (raise 0.0) font-lock-face (:family "all-the-icons" :height 1.2 :inherit all-the-icons-blue) face (:family "all-the-icons" :height 1.2 :inherit all-the-icons-blue))))
  cl-rest(#("  \11" 2 3 (rear-nonsticky t display (raise 0.0) font-lock-face (:family "all-the-icons" :height 1.2 :inherit all-the-icons-blue) face (:family "all-the-icons" :height 1.2 :inherit all-the-icons-blue))))
  (cl-copy-list (cl-rest (get-text-property 0 'display image)))
  (plist-put (cl-copy-list (cl-rest (get-text-property 0 'display image))) :background (face-attribute 'header-line :background))
  (cons 'image (plist-put (cl-copy-list (cl-rest (get-text-property 0 'display image))) :background (face-attribute 'header-line :background)))
  (propertize " " 'display (cons 'image (plist-put (cl-copy-list (cl-rest (get-text-property 0 'display image))) :background (face-attribute 'header-line :background))))
  (if (and image (get-text-property 0 'display image)) (propertize " " 'display (cons 'image (plist-put (cl-copy-list (cl-rest (get-text-property 0 'display image))) :background (face-attribute 'header-line :background)))) (replace-regexp-in-string " \\|\11" "" (or image "")))
  lsp-headerline--fix-image-background(#(" " 0 1 (display #("  \11" 2 3 (rear-nonsticky t display (raise 0.0) font-lock-face (:family "all-the-icons" :height 1.2 :inherit all-the-icons-blue) face (:family "all-the-icons" :height 1.2 :inherit all-the-icons-blue))))))
```

Now this works:
```elisp
(lsp-headerline--fix-image-background (lsp-treemacs-get-icon "edn")) => all-the-icons icon
(lsp-headerline--fix-image-background (lsp-treemacs-get-icon "clj")) => image icon
```

![image](https://user-images.githubusercontent.com/7820865/95404374-371e4700-08eb-11eb-818c-793421db61a3.png)
![image](https://user-images.githubusercontent.com/7820865/95404379-3c7b9180-08eb-11eb-9379-146510f88e7e.png)
