### PR TITLE
lsp-completion: push case mismatch items to near next rank

### DIFF
--- a/test/lsp-completion-test.el
+++ b/test/lsp-completion-test.el
@@ -49,32 +49,35 @@
              '("hash-map"
                "as-definition"
                "as-def"
-               "aS-selection"
+               "As-selection"
                "To-as-expected"
                "amused"
                "subclass-1"
                "superand-sort")
              '("as-definition"    ; Prefix match
                "as-def"           ; Also prefix match (stable)
+               "As-selection"     ; case mismatch, rank lower to near next rank
                "hash-map"         ; middle match
                "amused"           ; partial match with prefix match
                "To-as-expected"   ; more in middle match
                "subclass-1"       ; more in middle match
                "superand-sort"    ; partial match without prefix match
-               "aS-selection"     ; case mismatch
                ))
+    (do-test "f"
+             '("f" "foo" "Foo" "aFoo" "afoo")
+             '("f" "foo" "Foo" "afoo" "aFoo"))
+    (do-test "foo"
+             '("foo" "afoo" "aafoo" "aaafoo" "Foo" "aFoo" "aaFoo" "aaaFoo")
+             '("foo" "Foo" "afoo" "aFoo" "aafoo" "aaFoo" "aaafoo" "aaaFoo"))
     (do-test "F"
-             '("F" "foo" "Foo")
-             '("F" "Foo" "foo"))
+             '("F" "foo" "Foo" "aFoo" "afoo")
+             '("F" "Foo" "foo" "aFoo" "afoo"))
     (do-test "Fo"
              '("Fo" "daFo" "safo")
              '("Fo" "daFo" "safo"))
     (do-test "F"
              '("F" "daFo" "safo")
-             '("F" "daFo" "safo"))
-    (do-test "foo"
-             '("foo" "afoo" "aafoo" "aaafoo")
-             '("foo" "afoo" "aafoo" "aaafoo"))))
+             '("F" "daFo" "safo"))))
 
 (provide 'lsp-completion-test)
 ;;; lsp-completion-test.el ends here


### PR DESCRIPTION
Implement what's proposed in https://github.com/emacs-lsp/lsp-mode/issues/2229#issuecomment-705264022.
Case mismatch will be pushed to **near** next rank, i.e., lower score than the item has the same case match but higher than item has same case match but further from start.
Refer to test cases to see how's the ranking now.