### PR TITLE
Using full remote path for tramp (fix #2251)

### DIFF
--- a/docs/page/remote.md
+++ b/docs/page/remote.md
@@ -25,6 +25,23 @@ Here it is example how you can configure python language server to work when usi
 
 _Note:_ when you do not have root privileges on the remote machine to put the language server on the path you may alter the remote path by changing `tramp-remote-path`.
 
+When providing a full path for a remote Language Server, it should be with the proper Tramp prefix. We recommend that you provide the command as a separate function so you can control different settings in a single place.
+
+```elisp
+(defun my/remote-lsp-command ()
+  "Use pyls, but only on remoteA and on a custom location"
+  (when (and (file-remote-p default-directory)
+             (s-matches? "remoteA" default-directory))
+    (concat (file-remote-p default-directory)
+            "/home/me/bin/pyls")))
+(lsp-register-client
+    (make-lsp-client :new-connection 'my/remote-lsp-command)
+                     :major-modes '(python-mode)
+                     :remote? t
+                     :server-id 'remoteA-pyls-remote))
+```
+
+
 ### Dealing with stderr
 
 With TRAMP, Emacs does not have an easy way to distinguish stdout and stderr, so when the underlying LSP process writes to stderr, it breaks the `lsp-mode` parser. As a workaround, `lsp-mode` is redirecting stderr to `/tmp/<process-name>-<id>~stderr`.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6573,11 +6573,19 @@ should return the command to start the LS server."
 LOCAL-COMMAND is either list of strings, string or function which
 returns the command to execute."
   (list :connect (lambda (filter sentinel name environment-fn)
-                   (let* ((final-command (lsp-resolve-final-function local-command))
+                   (let* ((command-and-args (lsp-resolve-final-function local-command))
+                          (remote-command ;; command to execute at remote host
+                           (file-local-name
+                            (-first-item
+                             command-and-args)))
+                          (remote-command-and-args
+                           (append
+                            (list remote-command)
+                            (rest command-and-args)))
                           ;; wrap with stty to disable converting \r to \n
                           (process-name (generate-new-buffer-name name))
                           (wrapped-command (append '("stty" "raw" ";")
-                                                   final-command
+                                                   remote-command-and-args
                                                    (list
                                                     (concat "2>"
                                                             (or (when generate-error-file-fn

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6581,7 +6581,7 @@ returns the command to execute."
                           (remote-command-and-args
                            (append
                             (list remote-command)
-                            (rest command-and-args)))
+                            (cdr command-and-args)))
                           ;; wrap with stty to disable converting \r to \n
                           (process-name (generate-new-buffer-name name))
                           (wrapped-command (append '("stty" "raw" ";")


### PR DESCRIPTION
Make "using a full path on remote hosts" consistent (by always providing tramp prefix).

I didn't find any tramp-related unit tests, so I didn't add any. Let me know if they should be added.