### PR TITLE
Log Serenata progress messages to the log instead

### DIFF
--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -341,7 +341,7 @@ already present."
   :priority -2
   :notification-handlers (ht ("serenata/didProgressIndexing"
                               (lambda (_server data)
-                                (lsp--info "%s" (lsp:serenata-did-progress-indexing-info data)))))
+                                (lsp-log "%s" (lsp:serenata-did-progress-indexing-info data)))))
 
   :initialization-options #'lsp-serenata-init-options
   :initialized-fn (lambda (workspace)


### PR DESCRIPTION
Sorry for not following up on #1847, but, you know, life happened.

#1864 didn't quite fix the problem. Instead of a lot of notices, it takes over the echo area, which makes it next to impossible to do anything while it's scanning.

I tried it on a Drupal 8 installation, which happened  to include multiple copies in a build directory, which, apart from rendering Emacs useless in the process, managed to make my laptop unresponsive and ended up crashing Serenata (I would probably have had to hard reboot it, if that didn't happen). Which is probably not related to the issue at hand, but not being able to control Emacs didn't help.

This PR simply directs the progress messages to the lsp-log buffer instead, which fixes the problem. I've switched from felixbeckers (unmaintaned) language server to Serenata now.

A prettier solution would be having a mode-line item that shows scanning progress, when scanning. But I guess Serenata isn't the only language server that could use that?