### PR TITLE
Handle missing config subsections correctly

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5882,10 +5882,20 @@ PARAMS are the `workspace/configuration' request params"
                        (path-without-last (s-join "." (-slice path-parts 0 -1)))
                        (path-parts-len (length path-parts)))
                  (cond
+                  ;; We use `ignore-errors' because `ht-get*' throws
+                  ;; an error if a nested hash table doesn't exist.
+                  ;; For example, if we are asked to provide
+                  ;; configuration for section "foo.bar" but we don't
+                  ;; have a section "foo", then we'd get an error.
+                  ;; `ignore-errors' is arguably a bit of a hack
+                  ;; because `ht-get*' doesn't support nil punning,
+                  ;; but it's easy.
                   ((<= path-parts-len 1)
-                   (apply 'ht-get* `(,(lsp-configuration-section section?) ,@path-parts)))
+                   (ignore-errors
+                     (apply 'ht-get* `(,(lsp-configuration-section section?) ,@path-parts))))
                   ((> path-parts-len 1)
-                   (apply 'ht-get* `(,(lsp-configuration-section path-without-last) ,@path-parts)))))))
+                   (ignore-errors
+                     (apply 'ht-get* `(,(lsp-configuration-section path-without-last) ,@path-parts))))))))
        (apply #'vector)))
 
 (defun lsp--send-request-response (workspace recv-time request response)


### PR DESCRIPTION
I encountered a problem recently with gopls. I have a project whose top-level directory is named `go.git`. Apparently, gopls tries to allow a sort of per-project configuration by requesting a project-specific configuration section in the `workspace/configuration` message. It looks like this:

```
[Trace - 10:15:01 AM] Received request 'workspace/configuration - (2).
Params: {
  "items": [
    {
      "section": "gopls",
      "scopeUri": "file:///path/to/go.git"
    },
    {
      "section": "gopls-go.git",
      "scopeUri": "file:///path/to/go.git"
    }
  ]
}
```

Unfortunately, lsp-mode interprets `gopls-go.git` as a nested configuration section due to the period, a feature added in https://github.com/emacs-lsp/lsp-mode/pull/2015. I don't know whether this is a bug in lsp-mode or a bug in gopls, but it wouldn't be a problem if it weren't for something that definitely _is_ a bug in lsp-mode: when `lsp--build-workspace-configuration-response` tries to look up a nested configuration sub-section that doesn't exist (i.e. `foo.bar` where `foo` doesn't exist), it throws an error due to the behavior of `ht-get*` (see the code comment). This causes gopls to hang, presumably because it never gets a response to `workspace/configuration`.

This pull request is a simple workaround to the problem by wrapping the `ht-get*` calls in `ignore-errors`. A more robust solution would be to implement a custom `ht-get*` that handles nil punning correctly.

If you don't have gopls set up locally, you can also see this behavior [on an online sandbox](https://riju.codes/go#debug):

![image](https://user-images.githubusercontent.com/69264599/96288953-13b56500-0f99-11eb-8a2b-3d62be5a9c1b.png)

Note that the project URI is spliced into the configuration with no escaping or sanitization at all. I guess the whole URI is used in this case, rather than just the directory name, because of some difference between the initialization messages sent by the online sandbox versus `lsp-mode`.
