### PR TITLE
lsp-xml: Allow automatic download of Lemminx (LSP XML) server

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -8,6 +8,7 @@
   * Add Racket support.
   * Provided automatic installers for `lsp-clojure` (`clojure-lsp`).
   * Added ~lsp-modeline-workspace-status-mode~ and option to disable it via ~lsp-modeline-workspace-status-enable~.
+  * Automatically download [[https://github.com/eclipse/lemminx][XML language server Lemminx]]
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/clients/lsp-xml.el
+++ b/clients/lsp-xml.el
@@ -182,20 +182,32 @@ Newlines and excess whitespace are removed."
   ("xml.catalogs" lsp-xml-catalogs)
   ("xml.trace.server" lsp-xml-trace-server)))
 
-(defcustom lsp-xml-jar-file (expand-file-name
-                             (locate-user-emacs-file
-                              "org.eclipse.lsp4xml-0.3.0-uber.jar"))
+(defconst lsp-xml-jar-version "0.13.1")
+
+(defconst lsp-xml-jar-name (format "org.eclipse.lemminx-%s-uber.jar" lsp-xml-jar-version))
+
+(defcustom lsp-xml-jar-file (f-join lsp-server-install-dir "xmlls" lsp-xml-jar-name)
   "Xml server jar command."
   :type 'string
   :group 'lsp-xml
   :type 'file
   :package-version '(lsp-mode . "6.1"))
 
+(defcustom lsp-xml-jar-download-url
+  (format
+   "https://repo.eclipse.org/content/repositories/lemminx-releases/org/eclipse/lemminx/org.eclipse.lemminx/%s/%s"
+   lsp-xml-jar-version
+   lsp-xml-jar-name)
+  "Automatic download url for lsp-xml."
+  :type 'string
+  :group 'lsp-xml
+  :package-version '(lsp-mode . "7.1"))
+
 (lsp-dependency
  'xmlls
  '(:system lsp-xml-jar-file)
- `(:download :url "https://repo.eclipse.org/content/repositories/lemminx-releases/org/eclipse/lemminx/org.eclipse.lemminx/0.13.1/org.eclipse.lemminx-0.13.1-uber.jar"
-             :store-path ,(f-join lsp-server-install-dir "xmlls" "org.eclipse.lemminx.jar")))
+ `(:download :url lsp-xml-jar-download-url
+             :store-path lsp-xml-jar-file))
 
 (defcustom lsp-xml-server-command `("java" "-jar" ,lsp-xml-jar-file)
   "Xml server command."
@@ -216,7 +228,9 @@ Newlines and excess whitespace are removed."
                   :server-id 'xmlls
                   :initialized-fn (lambda (workspace)
                                     (with-lsp-workspace workspace
-                                      (lsp--set-configuration (lsp-configuration-section "xml"))))))
+                                      (lsp--set-configuration (lsp-configuration-section "xml"))))
+                  :download-server-fn (lambda (_client callback error-callback _update?)
+                                        (lsp-package-ensure 'xmlls callback error-callback))))
 
 (provide 'lsp-xml)
 ;;; lsp-xml.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -542,8 +542,8 @@
     "name": "xml",
     "full-name": "XML",
     "server-name": "lsp4xml",
-    "server-url": "https://github.com/angelozerr/lsp4xml",
-    "installation": "Download from lsp4xml releases",
+    "server-url": "https://github.com/eclipse/lemminx",
+    "installation": "Automatic by lsp-mode",
     "debugger": "Not available"
   },
   {


### PR DESCRIPTION
- Add helper constants to reduce repetition of current version.
- Store jar in `lsp-server-install-dir`