### PR TITLE
Fix typo in troubleshooting.md

### DIFF
--- a/docs/page/troubleshooting.md
+++ b/docs/page/troubleshooting.md
@@ -7,7 +7,7 @@ Troubleshooting
   - Look for `lsp-mode` variable to customize server path. Usually, you may find the variable by doing:
       <kbd>M-x</kbd> `customize-group` <kbd>RET</kbd> `lsp-LANGUAGE-SERVER-ID`.
 - Set `lsp-log-io` to `t` to inspect communication between client and the server. Use `lsp-workspace-show-log` to switch to the corresponding log buffer.
-- `lsp-describe-session` will show the current projects roots + the started severs and allows inspecting the server capabilities:
+- `lsp-describe-session` will show the current projects roots + the started servers and allows inspecting the server capabilities:
 
     ![Describe session](../examples/describe.png)
 - If you manage your Emacs packages with the built-in `package.el`, we recommend the following procedure to update your packages:


### PR DESCRIPTION
Hi :)

I just stumbled upon a little typo inside the troubleshooting guide.