### PR TITLE
Bugfix/xref syntax highlighting

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4481,8 +4481,7 @@ and the position respectively."
          (inhibit-field-text-motion t))
     (save-excursion
       (goto-char point)
-      (buffer-substring-no-properties (line-beginning-position)
-                                      (line-end-position)))))
+      (buffer-substring (line-beginning-position) (line-end-position)))))
 
 (lsp-defun lsp--xref-make-item (filename (&Range :start (start &as &Position :character start-char :line start-line)
                                                  :end (end &as &Position :character end-char)))


### PR DESCRIPTION
 When using xref to show all references/definitions/... of some symbol, all entries were gray, even though they had syntax highlighting in the buffer where they were defined. This was because `lsp--extract-line-from-buffer', used by lsp's xref routines, used
`buffer-substring-no-properties' to extract lines. Use `buffer-substring' instead.

If needed, I can rebase this against master.