### PR TITLE
Bugfix/php ls works

### DIFF
--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -39,23 +39,34 @@
   :group 'lsp-php
   :type '(repeat string))
 
-(defun lsp-php--create-connection ()
-  "Create lsp connection."
-  (lsp-stdio-connection
-   (lambda () lsp-clients-php-server-command)
-   (lambda ()
-     (if (and (cdr lsp-clients-php-server-command)
-              (eq (string-match-p "php[0-9.]*\\'" (car lsp-clients-php-server-command)) 0))
-         ;; Start with the php command and the list has more elems. Test the existence of the PHP script.
-         (let ((php-file (nth 1 lsp-clients-php-server-command)))
-           (or (file-exists-p php-file)
-               (progn
-                 (lsp-log "%s is not present." php-file)
-                 nil)))
-       t))))
+(defcustom lsp-php-memory-limit "4095M"
+  "Maximum amount of RAM php-ls should consume.
+Passed as its --meomry-limit argument."
+  :group 'lsp-php
+  :type '(integer))
+
+(defun lsp-php--get-command (port)
+  "Yield an argv to start lsp-php on PORT."
+  `(,@lsp-clients-php-server-command
+    ,(format "--tcp=127.0.0.1:%d" port)
+    ,(format "--memory-limit=%s" lsp-php-memory-limit)))
+
+(defun lsp-php--get-php-script (argv)
+  "Get the name of the PHP script run by ARGV.
+Handle the case of the first element of the latter being the php
+interpreter itself."
+  (and argv (or (and (string-match-p "php[-.0-9]*" (car argv)) (cadr argv))
+                (car argv))))
+
+(defun lsp-php--present? ()
+  "Check if 'php-ls' is installed."
+  ;; we cannot rely on the default facilities, as PHP itself may be installed
+  ;; even though php-ls is not.
+  (file-exists-p (lsp-php--get-php-script (lsp-php--get-command 0))))
 
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-php--create-connection)
+ (make-lsp-client :new-connection
+                  (lsp-tcp-server #'lsp-php--get-command #'lsp-php--present?)
                   :major-modes '(php-mode)
                   :priority -3
                   :server-id 'php-ls))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6364,83 +6364,120 @@ returned by COMMAND is available via `executable-find'"
         (file-error (setq success t))))
     port))
 
-(defun lsp-tcp-connection (command-fn)
-  "Returns a connection property list similar to `lsp-stdio-connection'.
-COMMAND-FN can only be a function that takes a single argument, a
-port number. It should return a command for launches a language server
-process listening for TCP connections on the provided port."
+(defun lsp--command-present? (command)
+  "Check if COMMAND can be started.
+COMMAND shall be a command as returned by the COMMAND-FN argument
+of the various server starting functions.
+
+It may be an argv-vector (list or vector) or a string, specifying
+a shell command."
+  (when-let ((program
+              ;; `nth' to support vectors
+              (or (and (or (listp command) (vectorp command)) (nth 0 command))
+                  (car (split-string-and-unquote command)))))
+    (if (file-remote-p default-directory)
+        (executable-find program t)
+      (executable-find program))))
+
+(defun lsp--command-fn-present? (command-fn)
+  "Make a checker-function for COMMAND-FN.
+The result is a function that, if called, checks wether
+COMMAND-FN (as defined in `lsp-tcp-connection') yields a command
+that can be executed."
+  (lambda () (lsp--command-present? (funcall command-fn 0))))
+
+(defun lsp-tcp-connection (command-fn &optional test-fn)
+  "Return an lsp connection object for TCP servers.
+COMMAND-FN will be called to start the server and shall take a
+single argument, the port, which is an int. It should return a
+command to launch the server in a way that listens on that port.
+The command should be an argv-vector (as a list).
+
+TEST-FN is a function that should yield a truthy value if and
+only if the server can be started. If this is unspecified,
+COMMAND-FN will be called with PORT=0 and its output examined."
   (cl-check-type command-fn function)
   (list
-   :connect (lambda (filter sentinel name environment-fn)
-              (let* ((host "localhost")
-                     (port (lsp--find-available-port host (cl-incf lsp--tcp-port)))
-                     (command (funcall command-fn port))
-                     (final-command (if (consp command) command (list command)))
-                     (_ (unless (executable-find (cl-first final-command))
-                          (user-error (format "Couldn't find executable %s" (cl-first final-command)))))
-                     (process-environment
-                      (lsp--compute-process-environment environment-fn))
-                     (proc (make-process :name name :connection-type 'pipe :coding 'no-conversion
-                                         :command final-command :sentinel sentinel :stderr (format "*%s::stderr*" name) :noquery t))
-                     (tcp-proc (lsp--open-network-stream host port (concat name "::tcp"))))
+   :connect
+   (lambda (filter sentinel name environment-fn)
+     (let* ((host "localhost")
+            (port (lsp--find-available-port host (cl-incf lsp--tcp-port)))
+            (command (funcall command-fn port))
+            (final-command (if (consp command) command (list command)))
+            (_ (unless (executable-find (cl-first final-command))
+                 (user-error (format "Couldn't find executable %s" (cl-first final-command)))))
+            (process-environment
+             (lsp--compute-process-environment environment-fn))
+            (proc (make-process :name name
+                                :connection-type 'pipe :coding 'no-conversion
+                                :command final-command :sentinel sentinel
+                                :stderr (format "*%s::stderr*" name) :noquery t))
+            (tcp-proc
+             (lsp--open-network-stream host port (concat name "::tcp"))))
 
-                ;; TODO: Same :noquery issue (see above)
-                (set-process-query-on-exit-flag proc nil)
-                (set-process-query-on-exit-flag tcp-proc nil)
-                (set-process-filter tcp-proc filter)
-                (cons tcp-proc proc)))
-   :test? (lambda () (executable-find (cl-first (funcall command-fn 0))))))
+       ;; TODO: Same :noquery issue (see above)
+       (set-process-query-on-exit-flag proc nil)
+       (set-process-query-on-exit-flag tcp-proc nil)
+       (set-process-filter tcp-proc filter)
+       (cons tcp-proc proc)))
+   :test? (or test-fn (lsp--command-fn-present? command-fn))))
 
 (defalias 'lsp-tcp-server 'lsp-tcp-server-command)
 
-(defun lsp-tcp-server-command (command-fn)
+(defun lsp-tcp-server-command (command-fn &optional test-fn)
   "Create tcp server connection.
-In this mode Emacs is TCP server and the language server connects
-to it. COMMAND is function with one parameter(the port) and it
-should return the command to start the LS server."
+Like `lsp-tcp-connection', but in reverse: Emacs listens for a
+connection from the language server, not the other way around.
+
+COMMAND-FN and TEST-FN behave equally."
   (cl-check-type command-fn function)
   (list
-   :connect (lambda (filter sentinel name environment-fn)
-              (let* (tcp-client-connection
-                     (tcp-server (make-network-process :name (format "*tcp-server-%s*" name)
-                                                       :buffer (format "*tcp-server-%s*" name)
-                                                       :family 'ipv4
-                                                       :service lsp--tcp-server-port
-                                                       :sentinel (lambda (proc _string)
-                                                                   (lsp-log "Language server %s is connected." name)
-                                                                   (setf tcp-client-connection proc))
-                                                       :server 't))
-                     (port (process-contact tcp-server :service))
-                     (final-command (funcall command-fn port))
-                     (process-environment
-                      (lsp--compute-process-environment environment-fn))
-                     (cmd-proc (make-process :name name
-                                             :connection-type 'pipe
-                                             :coding 'no-conversion
-                                             :command final-command
-                                             :stderr (format "*tcp-server-%s*::stderr" name)
-                                             :noquery t)))
-                (let ((retries 0))
-                  ;; wait for the client to connect (we sit-for 500 ms, so have to double lsp--tcp-server-wait-seconds)
-                  (while (and (not tcp-client-connection) (< retries (* 2 lsp--tcp-server-wait-seconds)))
-                    (lsp--info "Waiting for connection for %s, retries: %s" name retries)
-                    (sit-for 0.500)
-                    (cl-incf retries)))
+   :connect
+   (lambda (filter sentinel name environment-fn)
+     (let* (tcp-client-connection
+            (tcp-server
+             (make-network-process
+              :name (format "*tcp-server-%s*" name)
+              :buffer (format "*tcp-server-%s*" name)
+              :family 'ipv4
+              :service lsp--tcp-server-port
+              :sentinel (lambda (proc _string)
+                          (lsp-log "Language server %s is connected." name)
+                          (setf tcp-client-connection proc))
+              :server 't))
+            (port (process-contact tcp-server :service))
+            (final-command (funcall command-fn port))
+            (process-environment
+             (lsp--compute-process-environment environment-fn))
+            (cmd-proc (make-process :name name
+                                    :connection-type 'pipe
+                                    :coding 'no-conversion
+                                    :command final-command
+                                    :stderr (format "*tcp-server-%s*::stderr" name)
+                                    :noquery t)))
+       (let ((retries 0))
+         ;; wait for the client to connect (we sit-for 500 ms, so have
+         ;; to double lsp--tcp-server-wait-seconds)
+         (while (and (not tcp-client-connection) (< retries (* 2 lsp--tcp-server-wait-seconds)))
+           (lsp--info "Waiting for connection for %s, retries: %s" name retries)
+           (sit-for 0.500)
+           (cl-incf retries)))
 
-                (unless tcp-client-connection
-                  (condition-case nil (delete-process tcp-server) (error))
-                  (condition-case nil (delete-process cmd-proc) (error))
-                  (error "Failed to create connection to %s on port %s" name port))
-                (lsp--info "Successfully connected to %s" name)
+       (unless tcp-client-connection
+         (condition-case nil (delete-process tcp-server) (error))
+         (condition-case nil (delete-process cmd-proc) (error))
+         (error "Failed to create connection to %s on port %s" name port))
+       (lsp--info "Successfully connected to %s" name)
 
-                (set-process-query-on-exit-flag cmd-proc nil)
-                (set-process-query-on-exit-flag tcp-client-connection nil)
-                (set-process-query-on-exit-flag tcp-server nil)
+       (set-process-query-on-exit-flag cmd-proc nil)
+       (set-process-query-on-exit-flag tcp-client-connection nil)
+       (set-process-query-on-exit-flag tcp-server nil)
 
-                (set-process-filter tcp-client-connection filter)
-                (set-process-sentinel tcp-client-connection sentinel)
-                (cons tcp-client-connection cmd-proc)))
-   :test? (lambda () (executable-find (cl-first (funcall command-fn 0))))))
+       (set-process-filter tcp-client-connection filter)
+       (set-process-sentinel tcp-client-connection sentinel)
+       (cons tcp-client-connection cmd-proc)))
+   :test?
+   (or test-fn (lsp--command-present? command-fn))))
 
 (defun lsp-tramp-connection (local-command &optional generate-error-file-fn)
   "Create LSP stdio connection named name.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6237,8 +6237,14 @@ Return a nested alist keyed by symbol names. e.g.
   (when menu-bar-mode
     (lsp--imenu-refresh)))
 
-(defun lsp--check-command-list (command)
-  (cl-assert (seq-every-p (apply-partially #'stringp) command) nil
+(defun lsp--check-command-list (final-command)
+  "Assert that FINAL-COMMAND is correctly formatted.
+FINAL-COMMAND shall be a list of arguments to start a program,
+the first being the program itself.
+
+Currently throws an error if FINAL-COMMAND contains non-strings,
+but additional checks may be added in the future."
+  (cl-assert (seq-every-p (apply-partially #'stringp) final-command) nil
              "Invalid command list"))
 
 (defun lsp-resolve-final-function (command)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6401,8 +6401,6 @@ COMMAND-FN will be called with PORT=0 and its output examined."
             (port (lsp--find-available-port host (cl-incf lsp--tcp-port)))
             (command (funcall command-fn port))
             (final-command (lsp-resolve-tcp-function command port))
-            (_ (unless (executable-find (cl-first final-command))
-                 (user-error (format "Couldn't find executable %s" (cl-first final-command)))))
             (process-environment
              (lsp--compute-process-environment environment-fn))
             (proc (make-process :name name

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6429,7 +6429,7 @@ COMMAND-FN will be called with PORT=0 and its output examined."
 Like `lsp-tcp-connection', but in reverse: Emacs listens for a
 connection from the language server, not the other way around.
 
-COMMAND-FN and TEST-FN behave equally."
+COMMAND-FN and TEST-FN behave as there."
   (cl-check-type command-fn function)
   (list
    :connect


### PR DESCRIPTION
Make php-ls actually work now, leveraging reverse-tcp.

Refactor `lsp-tcp-connection' and `lsp-tcp-server' to support a :test-fn argument, which should fix an issue that I think I saw by @leungbk.