### PR TITLE
fix broken for submition #daaa291

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4525,7 +4525,7 @@ type Location, LocationLink, Location[] or LocationLink[]."
                    (or (lsp-location? fst)
                        (lsp-location-link? fst))))
             (append locations nil)
-          (list locations)))
+          (when locations (list locations))))
 
   (cl-labels ((get-xrefs-in-file
                (file-locs)


### PR DESCRIPTION
There is an warning message after daaa291
> Warning (lsp-mode): Failed to process xref entry for filename ’’: Read error: is a directory ..."
>
The root cause is, when the parameter `locations` is `nil`, the original code
https://github.com/emacs-lsp/lsp-mode/commit/daaa291263b62057a1b320952f5baaa2f47082c4#diff-413c3dbb8dc902306ccb23932847ff082352d6123fd5668ea89b24cd8ebcbedbL4521-L4524 
will get `nil` for `locations`, but the change
https://github.com/emacs-lsp/lsp-mode/commit/daaa291263b62057a1b320952f5baaa2f47082c4#diff-413c3dbb8dc902306ccb23932847ff082352d6123fd5668ea89b24cd8ebcbedbR4520-R4528 
will get `(nil)` for `locations`.
The fix will keep `locations` is `nil`.