### PR TITLE
lsp-fsharp--project-list: correctly parse response

### DIFF
--- a/clients/lsp-fsharp.el
+++ b/clients/lsp-fsharp.el
@@ -233,11 +233,10 @@ disable if `--backgorund-service-enabled' is not used"
                                 `(:directory ,(lsp-workspace-root)
                                              :deep 10
                                              :excludedDirs ["paket-files" ".git" "packages" "node_modules"])))
-         (data (json-read-from-string (lsp-get response :content)))
-         (found (cdr (assq 'Found (cdr (assq 'Data data)))))
-         (directory (car (seq-filter (lambda (d) (equal "directory" (cdr (assq 'Type d)))) found))))
-    (cdr (assq 'Fsprojs (cdr (assq 'Data directory))))))
-
+         (data (lsp--read-json (lsp-get response :content)))
+         (found (-> data (lsp-get :Data) (lsp-get :Found)))
+         (directory (seq-find (lambda (d) (equal "directory" (lsp-get d :Type))) found)))
+    (-> directory (lsp-get :Data) (lsp-get :Fsprojs))))
 
 ;;;###autoload
 (defun lsp-fsharp--workspace-load (projects)


### PR DESCRIPTION
The response is parsed using old json function (slow) and expecting an `alist`. However a new change in `lsp--start-workspace` let-bind that to `hash-table`. We should fix `lsp-fsharp` to use native json parser when possible and using `lsp-get` primitive.

This also root fix #2288 