### PR TITLE
lsp-rust: support rust-analyzer.showReference lens

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -635,8 +635,6 @@ them with `crate` or the crate name they refer to."
 (lsp-defun lsp-rust--analyzer-run-single ((&Command :arguments?))
   (lsp-rust-analyzer-run (lsp-seq-first arguments?)))
 
-;; `lsp-interface' is unsuitable for ShowReference destructuring, as that code
-;; action yields an array of three elements, not a map.
 (lsp-defun lsp-rust--analyzer-show-references
   ((&Command :title :arguments? [_uri _filepos references]))
   (lsp-show-xrefs (lsp--locations-to-xref-items references) nil

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -295,7 +295,7 @@ PARAMS progress report notification data."
         (lsp-workspace-status nil workspace)
       (lsp-workspace-status (format "%s - %s" title (or message? "")) workspace))))
 
-(cl-defmethod lsp-execute-command (_server (_command (eql rls.run)) params)
+(lsp-defun lsp-rust--rls-run ((&Command :arguments? params))
   (-let* (((&rls:Cmd :env :binary :args :cwd) (lsp-seq-first params))
           (default-directory (or cwd (lsp-workspace-root) default-directory) ))
     (compile
@@ -635,6 +635,13 @@ them with `crate` or the crate name they refer to."
 (lsp-defun lsp-rust--analyzer-run-single ((&Command :arguments?))
   (lsp-rust-analyzer-run (lsp-seq-first arguments?)))
 
+;; `lsp-interface' is unsuitable for ShowReference destructuring, as that code
+;; action yields an array of three elements, not a map.
+(lsp-defun lsp-rust--analyzer-show-references
+  ((&Command :title :arguments? [_uri _filepos references]))
+  (lsp-show-xrefs (lsp--locations-to-xref-items references) nil
+                  (s-contains-p "reference" title)))
+
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection
@@ -648,7 +655,8 @@ them with `crate` or the crate name they refer to."
   :priority (if (eq lsp-rust-server 'rust-analyzer) 1 -1)
   :initialization-options 'lsp-rust-analyzer--make-init-options
   :notification-handlers (ht<-alist lsp-rust-notification-handlers)
-  :action-handlers (ht ("rust-analyzer.runSingle" #'lsp-rust--analyzer-run-single))
+  :action-handlers (ht ("rust-analyzer.runSingle" #'lsp-rust--analyzer-run-single)
+                       ("rust-analyzer.showReferences" #'lsp-rust--analyzer-show-references))
   :library-folders-fn (lambda (_workspace) lsp-rust-library-directories)
   :after-open-fn (lambda ()
                    (when lsp-rust-analyzer-server-display-inlay-hints

--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -144,7 +144,9 @@ See `lsp-lens--schedule-refresh' for details."
     (define-key [mouse-1] (lsp-lens--create-interactive-command command))))
 
 (defun lsp-lens--create-interactive-command (command?)
-  "Create an interactive COMMAND? for the lens."
+  "Create an interactive COMMAND? for the lens.
+COMMAND? shall be an `&Command' (e.g. `&CodeLens' :command?) and
+mustn't be nil."
   (if (functionp (lsp:command-command command?))
       (lsp:command-command command?)
     (lambda ()

--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -145,16 +145,11 @@ See `lsp-lens--schedule-refresh' for details."
 
 (defun lsp-lens--create-interactive-command (command?)
   "Create an interactive COMMAND? for the lens."
-  (let ((server-id (->> (lsp-workspaces)
-                        (cl-first)
-                        (or lsp--cur-workspace)
-                        (lsp--workspace-client)
-                        (lsp--client-server-id))))
-    (if (functionp (lsp:command-command command?))
-        (lsp:command-command command?)
-      (lambda ()
-        (interactive)
-        (lsp--execute-command command?)))))
+  (if (functionp (lsp:command-command command?))
+      (lsp:command-command command?)
+    (lambda ()
+      (interactive)
+      (lsp--execute-command command?))))
 
 (defun lsp-lens--display (lenses)
   "Show LENSES."

--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -154,9 +154,7 @@ See `lsp-lens--schedule-refresh' for details."
         (lsp:command-command command?)
       (lambda ()
         (interactive)
-        (lsp-execute-command server-id
-                             (intern (lsp:command-command command?))
-                             (lsp:command-arguments? command?))))))
+        (lsp--execute-command command?)))))
 
 (defun lsp-lens--display (lenses)
   "Show LENSES."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5209,17 +5209,6 @@ It will filter by KIND if non nil."
       (funcall action-handler action)
     (lsp--send-execute-command command arguments?)))
 
-(defun lsp-execute-command (_server command arguments)
-  "Execute code action COMMAND with ARGUMENTS?.
-Note that this function can now longer be overloaded using
-`cl-defmethod', because that proved to be a liability. Use the
-:action-handlers argument of `make-lsp-client' instead."
-  (lsp--execute-command
-   (lsp-make-command :command (symbol-name command)
-                     :arguments? arguments)))
-(make-obsolete 'lsp-execute-command "use `lsp--execute-command' instead."
-               "7.1.0")
-
 (lsp-defun lsp-execute-code-action ((action &as &CodeAction :command? :edit?))
   "Execute code action ACTION.
 If ACTION is not set it will be selected from `lsp-code-actions-at-point'.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5209,7 +5209,7 @@ It will filter by KIND if non nil."
       (funcall action-handler action)
     (lsp--send-execute-command command arguments?)))
 
-(defun lsp-execute-command (_ command arguments)
+(defun lsp-execute-command (_server command arguments)
   "Execute code action COMMAND with ARGUMENTS?.
 Note that this function can now longer be overloaded using
 `cl-defmethod', because that proved to be a liability. Use the
@@ -5217,7 +5217,8 @@ Note that this function can now longer be overloaded using
   (lsp--execute-command
    (lsp-make-command :command (symbol-name command)
                      :arguments? arguments)))
-(make-obsolete #'lsp-execute-command #'lsp--execute-command "7.1.0")
+(make-obsolete 'lsp-execute-command "use `lsp--execute-command' instead."
+               "7.1.0")
 
 (lsp-defun lsp-execute-code-action ((action &as &CodeAction :command? :edit?))
   "Execute code action ACTION.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5215,7 +5215,8 @@ It will filter by KIND if non nil."
                         (lsp--workspace-client)
                         (lsp--client-server-id))))
     (condition-case nil
-        (lsp-execute-command server-id (intern command) arguments?)
+        (with-no-warnings
+          (lsp-execute-command server-id (intern command) arguments?))
       (cl-no-applicable-method
        (if-let ((action-handler (lsp--find-action-handler command)))
            (funcall action-handler action)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -969,7 +969,8 @@ calling `remove-overlays'.")
 (defvar-local lsp--virtual-buffer-point-max nil)
 
 (cl-defgeneric lsp-execute-command (server command arguments)
-  "Ask SERVER to execute COMMAND with ARGUMENTS.")
+  "Ask SERVER to execute COMMAND with ARGUMENTS."
+  (declare (obsolete "use `make-lsp-client' with :action-handlers instead." "7.1.0")))
 
 (defun lsp-elt (sequence n)
   "Return Nth element of SEQUENCE or nil if N is out of range."
@@ -5214,8 +5215,7 @@ It will filter by KIND if non nil."
                         (lsp--workspace-client)
                         (lsp--client-server-id))))
     (condition-case nil
-        (prog1 (lsp-execute-command server-id (intern command) arguments?)
-          (lsp--warn "`lsp-execute-command' is deprecated"))
+        (lsp-execute-command server-id (intern command) arguments?)
       (cl-no-applicable-method
        (if-let ((action-handler (lsp--find-action-handler command)))
            (funcall action-handler action)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5209,6 +5209,16 @@ It will filter by KIND if non nil."
       (funcall action-handler action)
     (lsp--send-execute-command command arguments?)))
 
+(defun lsp-execute-command (_ command arguments)
+  "Execute code action COMMAND with ARGUMENTS?.
+Note that this function can now longer be overloaded using
+`cl-defmethod', because that proved to be a liability. Use the
+:action-handlers argument of `make-lsp-client' instead."
+  (lsp--execute-command
+   (lsp-make-command :command (symbol-name command)
+                     :arguments? arguments)))
+(make-obsolete #'lsp-execute-command #'lsp--execute-command "7.1.0")
+
 (lsp-defun lsp-execute-code-action ((action &as &CodeAction :command? :edit?))
   "Execute code action ACTION.
 If ACTION is not set it will be selected from `lsp-code-actions-at-point'.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -968,9 +968,6 @@ calling `remove-overlays'.")
 
 (defvar-local lsp--virtual-buffer-point-max nil)
 
-(cl-defgeneric lsp-execute-command (server command arguments)
-  "Ask SERVER to execute COMMAND with ARGUMENTS.")
-
 (defun lsp-elt (sequence n)
   "Return Nth element of SEQUENCE or nil if N is out of range."
   (cond
@@ -5740,7 +5737,7 @@ REFERENCES? t when METHOD returns references."
     (lsp-request "workspace/executeCommand" params)))
 
 (defun lsp--send-execute-command (command &optional args)
-  "Execute workspace COMMAND with ARGS showing error if command is not mapped client-side."
+  "Create and send a 'workspace/executeCommand' message having command COMMAND and optional ARGS."
   (condition-case-unless-debug err
       (lsp-workspace-command-execute command args)
     (error


### PR DESCRIPTION
Add a rust-analyzer specific :action-handler for the showReference lens,
which leverages `lsp-show-xrefs'. Refactor: eliminate
`lsp-execute-command', because it caused the :title to be lost, which is
needed to distinguish between the "references" or "implementations"
variants of that lens.

Defining a new `lsp-interface' to destructure
"rust-analyzer.showReference" was impossible, as the former doesn't
support destructuring lists (the :arguments? paramter is a special,
3-element list.).