### PR TITLE
Centralize SymbolInformation rendering

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6205,7 +6205,7 @@ the signature)."
 Handle :deprecated?. If SEPARATOR is non-nil, the
 symbol's (optional) parent, SEPARATOR and the symbol itself are
 concatenated."
-  (when (and separator container-name?)
+  (when (and separator container-name? (not (string-empty-p container-name?)))
     (setq name (concat name separator container-name?)))
   (if deprecated? (propertize name 'face 'lsp-face-semhl-deprecated) name))
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6199,7 +6199,17 @@ the signature)."
     (if deprecated? (propertize base 'face 'lsp-face-semhl-deprecated)
       base)))
 
-(lsp-defun lsp--symbol-to-imenu-elem ((sym &as &SymbolInformation :name :container-name?))
+(lsp-defun lsp-render-symbol-information ((&SymbolInformation :name :deprecated? :container-name?)
+                                          separator)
+  "Render a piece of SymbolInformation.
+Handle :deprecated?. If SEPARATOR is non-nil, the
+symbol's (optional) parent, SEPARATOR and the symbol itself are
+concatenated."
+  (when (and separator container-name?)
+    (setq name (concat name separator container-name?)))
+  (if deprecated? (propertize name 'face 'lsp-face-semhl-deprecated) name))
+
+(defun lsp--symbol-to-imenu-elem (sym)
   "Convert SYM to imenu element.
 
 SYM is a SymbolInformation message.
@@ -6207,9 +6217,9 @@ SYM is a SymbolInformation message.
 Return a cons cell (full-name . start-point)."
   (let ((start-point (ht-get lsp--line-col-to-point-hash-table
                              (lsp--get-line-and-col sym))))
-    (cons (if (and lsp-imenu-show-container-name container-name?)
-              (concat container-name? lsp-imenu-container-name-separator name)
-            name)
+    (cons (lsp-render-symbol-information
+           sym (and lsp-imenu-show-container-name
+                    lsp-imenu-container-name-separator))
           start-point)))
 
 (lsp-defun lsp--symbol-to-hierarchical-imenu-elem ((sym &as &DocumentSymbol :children?))


### PR DESCRIPTION
In various different parts of `lsp`, where SymbolInformation has to be
rendered (lsp-ivy, lsp-treemacs, lsp-imenu), only the :name is shown as
a string. This is insufficient, as other information is then ignore
displayed (currently only :deprecated?).

Add a function, `lsp-render-symbol-information`, which behaves similar
to `lsp-render-symbol`. Use it in `lsp--imenu-create-non-hierarchical`
index.