### PR TITLE
`lsp-render-symbol': check if :detail? is empty

### DIFF
--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -34,7 +34,7 @@
   :group 'lsp-faces)
 
 (defface lsp-lens-face
-  '((t :height 0.8 :inherit shadow))
+  '((t :inherit lsp-details-face))
   "The face used for code lens overlays."
   :group 'lsp-faces)
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6196,7 +6196,8 @@ information, for example if it doesn't support DocumentSymbols."
 If SHOW-DETAIL? is set, make use of its `:detail?' field (often
 the signature)."
   (let ((detail (and show-detail? (s-present? detail?)
-                     (propertize (concat " " detail?) 'face 'font-lock-type-face)))
+                     (propertize (concat " " (s-trim-left detail?))
+                                 'face 'lsp-lens-face)))
         (name (if deprecated?
                   (propertize name 'face 'lsp-face-semhl-deprecated) name)))
     (concat name detail)))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6195,7 +6195,8 @@ information, for example if it doesn't support DocumentSymbols."
 Things like line numbers, signatures, ... are considered
 additional information. Often, additional faces are defined that
 inherit from this face by default, like `lsp-signature-face', and
-they may be customized for finer control.")
+they may be customized for finer control."
+  :group 'lsp-faces)
 
 (defface lsp-signature-face '((t :inherit lsp-details-face))
   "Used to display signatures in `imenu', ...."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6190,7 +6190,14 @@ information, for example if it doesn't support DocumentSymbols."
   :group 'lsp-imenu
   :type 'boolean)
 
-(defface lsp-signature-face '((t :height 0.8 :inherit shadow))
+(defface lsp-details-face '((t :height 0.8 :inherit shadow))
+  "Used to display additional information troughout `lsp'.
+Things like line numbers, signatures, ... are considered
+additional information. Often, additional faces are defined that
+inherit from this face by default, like `lsp-signature-face', and
+they may be customized for finer control.")
+
+(defface lsp-signature-face '((t :inherit lsp-details-face))
   "Used to display signatures in `imenu', ...."
   :group 'lsp-faces)
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6196,7 +6196,7 @@ information, for example if it doesn't support DocumentSymbols."
 If SHOW-DETAIL? is set, make use of its `:detail?' field (often
 the signature)."
   (let ((detail (and show-detail? (s-present? detail?)
-                     (propertize (concat ": " detail?) 'face 'font-lock-type-face)))
+                     (propertize (concat " " detail?) 'face 'font-lock-type-face)))
         (name (if deprecated?
                   (propertize name 'face 'lsp-face-semhl-deprecated) name)))
     (concat name detail)))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6195,11 +6195,11 @@ information, for example if it doesn't support DocumentSymbols."
   "Render INPUT0, an `&DocumentSymbol', to a string.
 If SHOW-DETAIL? is set, make use of its `:detail?' field (often
 the signature)."
-  (let ((base (or (and show-detail? detail?
-                       (not (string-empty-p detail?)) detail?)
-                  name)))
-    (if deprecated? (propertize base 'face 'lsp-face-semhl-deprecated)
-      base)))
+  (let ((detail (and show-detail? detail? (not (string-empty-p detail?))
+                     (propertize (concat ": " detail?) 'face 'font-lock-type-face)))
+        (name (if deprecated?
+                  (propertize name 'face 'lsp-face-semhl-deprecated) name)))
+    (concat name detail)))
 
 (lsp-defun lsp--symbol-to-imenu-elem ((sym &as &SymbolInformation :name :container-name?))
   "Convert SYM to imenu element.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6195,7 +6195,7 @@ information, for example if it doesn't support DocumentSymbols."
   "Render INPUT0, an `&DocumentSymbol', to a string.
 If SHOW-DETAIL? is set, make use of its `:detail?' field (often
 the signature)."
-  (let ((detail (and show-detail? detail? (not (string-empty-p detail?))
+  (let ((detail (and show-detail? (s-present? detail?)
                      (propertize (concat ": " detail?) 'face 'font-lock-type-face)))
         (name (if deprecated?
                   (propertize name 'face 'lsp-face-semhl-deprecated) name)))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6190,6 +6190,10 @@ information, for example if it doesn't support DocumentSymbols."
   :group 'lsp-imenu
   :type 'boolean)
 
+(defface lsp-signature-face '((t :height 0.8 :inherit shadow))
+  "Used to display signatures in `imenu', ...."
+  :group 'lsp-faces)
+
 (lsp-defun lsp-render-symbol ((&DocumentSymbol :name :detail? :deprecated?)
                               show-detail?)
   "Render INPUT0, an `&DocumentSymbol', to a string.
@@ -6197,7 +6201,7 @@ If SHOW-DETAIL? is set, make use of its `:detail?' field (often
 the signature)."
   (let ((detail (and show-detail? (s-present? detail?)
                      (propertize (concat " " (s-trim-left detail?))
-                                 'face 'lsp-lens-face)))
+                                 'face 'lsp-signature-face)))
         (name (if deprecated?
                   (propertize name 'face 'lsp-face-semhl-deprecated) name)))
     (concat name detail)))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6195,7 +6195,9 @@ information, for example if it doesn't support DocumentSymbols."
   "Render INPUT0, an `&DocumentSymbol', to a string.
 If SHOW-DETAIL? is set, make use of its `:detail?' field (often
 the signature)."
-  (let ((base (or (and show-detail? detail?) detail? name)))
+  (let ((base (or (and show-detail? detail?
+                       (not (string-empty-p detail?)) detail?)
+                  name)))
     (if deprecated? (propertize base 'face 'lsp-face-semhl-deprecated)
       base)))
 


### PR DESCRIPTION
Some language servers apparently send an empty detail? field, causing
strange output.

Fixes #2311.