### PR TITLE
`lsp-rename`: improve UI

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5689,6 +5689,12 @@ language server as the initial input of a new-name prompt."
 Renaming can be done using `lsp-rename'."
   :group 'lsp-faces)
 
+(defface lsp-rename-placeholder-face '((t :inherit font-lock-variable-name-face))
+  "Face used to display the rename placeholder in.
+When calling `lsp-rename' interactively, this will be the face of
+the new name."
+  :group 'lsp-faces)
+
 (defvar lsp--rename-history '()
   "History for `lsp--read-rename'.")
 
@@ -5709,6 +5715,7 @@ relied upon."
           ;; Do the `buffer-substring' first to not include `lsp-face-rename'
           (rename-me (buffer-substring start end))
           (placeholder (or placeholder? rename-me))
+          (placeholder (propertize placeholder 'face 'lsp-rename-placeholder-face))
 
           overlay)
     ;; We need unwind protect, as the user might cancel here, causing the

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5675,9 +5675,11 @@ renaming is supported but cannot be done at point."
 
 (defun lsp-rename (newname)
   "Rename the symbol (and all references to it) under point to NEWNAME."
-  (interactive (list (-when-let ((symbol . placeholder) (lsp--get-symbol-to-rename))
-                       (read-string (format "Rename %s to: " symbol) placeholder nil symbol))))
-  (unless newname (user-error "`lsp-rename' is invalid here"))
+  (interactive
+   (-if-let ((symbol . placeholder) (lsp--get-symbol-to-rename))
+       (list (read-string (format "Rename %s to: " symbol)
+                          placeholder nil symbol))
+     (user-error "`lsp-rename' is invalid here")))
   (when-let ((edits (lsp-request "textDocument/rename"
                                  `( :textDocument ,(lsp--text-document-identifier)
                                     :position ,(lsp--cur-position)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5715,8 +5715,9 @@ relied upon."
     ;; overlay to linger.
     (unwind-protect
         (progn
-          (setq overlay (-doto (make-overlay start end)
-                          (overlay-put 'face 'lsp-face-rename)))
+          (setq overlay (make-overlay start end))
+          (overlay-put overlay 'face 'lsp-face-rename)
+
           (read-string (format "Rename %s to: " rename-me) placeholder
                        'lsp--rename-history))
       (and overlay (delete-overlay overlay)))))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5654,31 +5654,65 @@ perform the request synchronously."
            (lsp-request "workspace/symbol" `(:query ,pattern))))
 
 (defun lsp--get-symbol-to-rename ()
-  "Get symbol to rename and placeholder at point.
-Returns a cons (SYMBOL-TO-RENAME . PLACEHOLDER). Returns nil if
-renaming is supported but cannot be done at point."
+  "Get a symbol to rename and placeholder at point.
+Returns a cons ((START . END) . PLACEHOLDER?), and nil if
+renaming is generally supported but cannot be done at point.
+START and END are the bounds of the identifiers being renamed,
+while PLACEHOLDER?, is either nil or a string suggested by the
+language server as the initial input of a new-name prompt."
   (unless (lsp-feature? "textDocument/rename")
     (error "The connected server(s) doesn't support renaming"))
   (if (lsp-feature? "textDocument/prepareRename")
       (when-let ((response
                   (lsp-request "textDocument/prepareRename"
                                (lsp--text-document-position-params))))
-        (-let* (((start . end) (lsp--range-to-region
-                                (if (lsp-range? response)
-                                    response
-                                  (lsp:prepare-rename-result-range response))))
-                (symbol (buffer-substring start end))
-                (placeholder (lsp:prepare-rename-result-placeholder response)))
-          (cons symbol (or placeholder symbol))))
-    (when-let ((symbol (thing-at-point 'symbol)))
-      (cons symbol symbol))))
+        (let* ((bounds (lsp--range-to-region
+                        (if (lsp-range? response)
+                            response
+                          (lsp:prepare-rename-result-range response))))
+               (placeholder (lsp:prepare-rename-result-placeholder response)))
+          (cons bounds placeholder)))
+    (when-let ((bounds (bounds-of-thing-at-point 'symbol)))
+      (cons bounds nil))))
+
+(defface lsp-face-rename '((t :inherit highlight))
+  "Face used to highlight the identifier being renamed.
+Renaming can be done using `lsp-rename'.")
+
+(defvar lsp--rename-history '()
+  "History for `lsp--read-rename'.")
+
+(defun lsp--read-rename (at-point)
+  "Read a new name for a `lsp-rename' at `point' from the user.
+AT-POINT shall be a structure as returned by
+`lsp--get-symbol-to-rename'.
+
+Returns a string, which should be the new name for the identifier
+at point. If renaming cannot be done at point (as determined from
+AT-POINT), throw a `user-error'.
+
+This function is for use in `lsp-rename' only, and shall not be
+relied upon."
+  (unless at-point
+    (user-error "`lsp-rename' is invalid here"))
+  (-let* ((((start . end) . placeholder?) at-point)
+          ;; Do the `buffer-substring' first to not include `lsp-face-rename'
+          (rename-me (buffer-substring start end))
+          (placeholder (or placeholder? rename-me)))
+    ;; We need unwind protect, as the user might cancel here, causing the
+    ;; overlay to linger.
+    (unwind-protect
+        (progn
+          (-doto (make-overlay start end)
+            (overlay-put 'face 'lsp-face-rename)
+            (overlay-put 'lsp-rename t))
+          (read-string (format "Rename %s to: " rename-me) placeholder
+                       'lsp--rename-history))
+      (lsp--remove-overlays 'lsp-rename))))
 
 (defun lsp-rename (newname)
   "Rename the symbol (and all references to it) under point to NEWNAME."
-  (interactive (list (-when-let ((symbol . placeholder) (lsp--get-symbol-to-rename))
-                       (read-string (format "Rename %s to: " symbol) placeholder nil symbol))))
-  (unless newname
-    (user-error "`lsp-rename' is invalid here"))
+  (interactive (list (lsp--read-rename (lsp--get-symbol-to-rename))))
   (when-let ((edits (lsp-request "textDocument/rename"
                                  `( :textDocument ,(lsp--text-document-identifier)
                                     :position ,(lsp--cur-position)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5655,7 +5655,8 @@ perform the request synchronously."
 
 (defun lsp--get-symbol-to-rename ()
   "Get symbol to rename and placeholder at point.
-Returns a cons (SYMBOL-TO-RENAME . PLACEHOLDER)."
+Returns a cons (SYMBOL-TO-RENAME . PLACEHOLDER). Returns nil if
+renaming is supported but cannot be done at point."
   (unless (lsp-feature? "textDocument/rename")
     (error "The connected server(s) doesn't support renaming"))
   (if (lsp-feature? "textDocument/prepareRename")
@@ -5669,7 +5670,7 @@ Returns a cons (SYMBOL-TO-RENAME . PLACEHOLDER)."
                 (symbol (buffer-substring start end))
                 (placeholder (lsp:prepare-rename-result-placeholder response)))
           (cons symbol (or placeholder symbol))))
-    (let ((sym (thing-at-point 'symbol)))
+    (when-let ((sym (thing-at-point 'symbol)))
       (cons sym sym))))
 
 (defun lsp-rename (newname)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5700,17 +5700,18 @@ relied upon."
   (-let* ((((start . end) . placeholder?) at-point)
           ;; Do the `buffer-substring' first to not include `lsp-face-rename'
           (rename-me (buffer-substring start end))
-          (placeholder (or placeholder? rename-me)))
+          (placeholder (or placeholder? rename-me))
+
+          overlay)
     ;; We need unwind protect, as the user might cancel here, causing the
     ;; overlay to linger.
     (unwind-protect
         (progn
-          (-doto (make-overlay start end)
-            (overlay-put 'face 'lsp-face-rename)
-            (overlay-put 'lsp--read-rename t))
+          (setq overlay (-doto (make-overlay start end)
+                          (overlay-put 'face 'lsp-face-rename)))
           (read-string (format "Rename %s to: " rename-me) placeholder
                        'lsp--rename-history))
-      (lsp--remove-overlays 'lsp--read-rename))))
+      (and overlay (delete-overlay overlay)))))
 
 (defun lsp-rename (newname)
   "Rename the symbol (and all references to it) under point to NEWNAME."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5679,7 +5679,8 @@ language server as the initial input of a new-name prompt."
 
 (defface lsp-face-rename '((t :inherit highlight))
   "Face used to highlight the identifier being renamed.
-Renaming can be done using `lsp-rename'.")
+Renaming can be done using `lsp-rename'."
+  :group 'lsp-faces)
 
 (defvar lsp--rename-history '()
   "History for `lsp--read-rename'.")

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5670,16 +5670,15 @@ renaming is supported but cannot be done at point."
                 (symbol (buffer-substring start end))
                 (placeholder (lsp:prepare-rename-result-placeholder response)))
           (cons symbol (or placeholder symbol))))
-    (when-let ((sym (thing-at-point 'symbol)))
-      (cons sym sym))))
+    (when-let ((symbol (thing-at-point 'symbol)))
+      (cons symbol symbol))))
 
 (defun lsp-rename (newname)
   "Rename the symbol (and all references to it) under point to NEWNAME."
-  (interactive
-   (-if-let ((symbol . placeholder) (lsp--get-symbol-to-rename))
-       (list (read-string (format "Rename %s to: " symbol)
-                          placeholder nil symbol))
-     (user-error "`lsp-rename' is invalid here")))
+  (interactive (list (-when-let ((symbol . placeholder) (lsp--get-symbol-to-rename))
+                       (read-string (format "Rename %s to: " symbol) placeholder nil symbol))))
+  (unless newname
+    (user-error "`lsp-rename' is invalid here"))
   (when-let ((edits (lsp-request "textDocument/rename"
                                  `( :textDocument ,(lsp--text-document-identifier)
                                     :position ,(lsp--cur-position)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5684,7 +5684,7 @@ language server as the initial input of a new-name prompt."
     (when-let ((bounds (bounds-of-thing-at-point 'symbol)))
       (cons bounds nil))))
 
-(defface lsp-face-rename '((t :inherit highlight))
+(defface lsp-face-rename '((t :underline t))
   "Face used to highlight the identifier being renamed.
 Renaming can be done using `lsp-rename'."
   :group 'lsp-faces)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1191,19 +1191,6 @@ Deprecated. Use `lsp-repeatable-vector' instead. "
   "Display lsp error message with FORMAT with ARGS."
   (message "%s :: %s" (propertize "LSP" 'face 'error) (apply #'format format args)))
 
-(defun lsp--fatal-error (format &rest args)
-  "Show an lsp error message using `error'.
-FORMAT is the `format' format to use, while ARGS provides the
-fields to it."
-  (error "%s :: %s" (propertize "LSP" 'face 'error)
-         (apply #'format format args)))
-
-(defun lsp--user-error (format &rest args)
-  "Like `lsp--fatal-error', but with `user-error'.
-FORMAT and ARGS are the same."
-  (user-error "%s :: %s" (propertize "LSP" 'face 'error)
-              (apply #'format format args)))
-
 (defun lsp--eldoc-message (&optional msg)
   "Show MSG in eldoc."
   (setq lsp--eldoc-saved-message msg)
@@ -5670,7 +5657,7 @@ perform the request synchronously."
   "Get symbol to rename and placeholder at point.
 Returns a cons (SYMBOL-TO-RENAME . PLACEHOLDER)."
   (unless (lsp-feature? "textDocument/rename")
-    (lsp--fatal-error "The connected server(s) doesn't support renaming"))
+    (error "The connected server(s) doesn't support renaming"))
   (if (lsp-feature? "textDocument/prepareRename")
       (when-let ((response
                   (lsp-request "textDocument/prepareRename"
@@ -5689,8 +5676,7 @@ Returns a cons (SYMBOL-TO-RENAME . PLACEHOLDER)."
   "Rename the symbol (and all references to it) under point to NEWNAME."
   (interactive (list (-when-let ((symbol . placeholder) (lsp--get-symbol-to-rename))
                        (read-string (format "Rename %s to: " symbol) placeholder nil symbol))))
-  (unless newname
-    (lsp--user-error "A rename is not valid at this position"))
+  (unless newname (user-error "`lsp-rename' is invalid here"))
   (when-let ((edits (lsp-request "textDocument/rename"
                                  `( :textDocument ,(lsp--text-document-identifier)
                                     :position ,(lsp--cur-position)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5670,7 +5670,9 @@ language server as the initial input of a new-name prompt."
                         (if (lsp-range? response)
                             response
                           (lsp:prepare-rename-result-range response))))
-               (placeholder (lsp:prepare-rename-result-placeholder response)))
+               (placeholder
+                (and (not (lsp-range? response))
+                     (lsp:prepare-rename-result-placeholder response))))
           (cons bounds placeholder)))
     (when-let ((bounds (bounds-of-thing-at-point 'symbol)))
       (cons bounds nil))))
@@ -5705,10 +5707,10 @@ relied upon."
         (progn
           (-doto (make-overlay start end)
             (overlay-put 'face 'lsp-face-rename)
-            (overlay-put 'lsp-rename t))
+            (overlay-put 'lsp--read-rename t))
           (read-string (format "Rename %s to: " rename-me) placeholder
                        'lsp--rename-history))
-      (lsp--remove-overlays 'lsp-rename))))
+      (lsp--remove-overlays 'lsp--read-rename))))
 
 (defun lsp-rename (newname)
   "Rename the symbol (and all references to it) under point to NEWNAME."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5653,6 +5653,13 @@ perform the request synchronously."
   (seq-map #'lsp--symbol-information-to-xref
            (lsp-request "workspace/symbol" `(:query ,pattern))))
 
+(defcustom lsp-rename-use-prepare t
+  "Whether `lsp-rename' should do a prepareRename first.
+For some language servers, textDocument/prepareRename might be
+too slow, in which case this variable may be set to nil.
+`lsp-rename' will then use `thing-at-point' `symbol' to determine
+the symbol to rename at point.")
+
 (defun lsp--get-symbol-to-rename ()
   "Get a symbol to rename and placeholder at point.
 Returns a cons ((START . END) . PLACEHOLDER?), and nil if
@@ -5662,7 +5669,7 @@ while PLACEHOLDER?, is either nil or a string suggested by the
 language server as the initial input of a new-name prompt."
   (unless (lsp-feature? "textDocument/rename")
     (error "The connected server(s) doesn't support renaming"))
-  (if (lsp-feature? "textDocument/prepareRename")
+  (if (and lsp-rename-use-prepare (lsp-feature? "textDocument/prepareRename"))
       (when-let ((response
                   (lsp-request "textDocument/prepareRename"
                                (lsp--text-document-position-params))))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5695,7 +5695,7 @@ When calling `lsp-rename' interactively, this will be the face of
 the new name."
   :group 'lsp-faces)
 
-(defvar lsp--rename-history '()
+(defvar lsp-rename-history '()
   "History for `lsp--read-rename'.")
 
 (defun lsp--read-rename (at-point)
@@ -5726,7 +5726,7 @@ relied upon."
           (overlay-put overlay 'face 'lsp-face-rename)
 
           (read-string (format "Rename %s to: " rename-me) placeholder
-                       'lsp--rename-history))
+                       'lsp-rename-history))
       (and overlay (delete-overlay overlay)))))
 
 (defun lsp-rename (newname)


### PR DESCRIPTION
`lsp-rename` doesn't check whether renaming is supported first. Do that,
throwing an error otherwise.

Fixes #2314.