### PR TITLE
Inherit header-line attributes when replacing icons background.

### DIFF
--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -84,7 +84,7 @@ caching purposes.")
                                   (plist-put
                                    (cl-copy-list
                                     (cl-rest display-image))
-                                   :background (face-attribute 'header-line :background))))
+                                   :background (face-attribute 'header-line :background nil t))))
           (replace-regexp-in-string "\s\\|\t" "" display-image)))
     ""))
 


### PR DESCRIPTION
A face can have background attribute unspecified. In this case we have
to get parent attribute to replace background correctly.