### PR TITLE
Address #2279 - add switch-to-other for clangd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
             - name: Install LLVM and Clang
               uses: KyleMayes/install-llvm-action@v1
               with:
-                 version: "10.0"
+                 version: "11.0"
                  directory: ${{ runner.temp }}/llvm
 
             - name: Check clangd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Setup cmake
               uses: jwlawson/actions-setup-cmake@v1.4
               with:
-                 cmake-version: '3.0.x'
+                 cmake-version: '3.5.x'
 
             - name: Check cmake
               run: "cmake --version"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,13 @@ jobs:
               with:
                  cmake-version: '2.8.x'
 
+            - name: Check cmake
+              run: "cmake --version"
+
             - name: Install LLVM and Clang
               uses: KyleMayes/install-llvm-action@v1
               with:
-                 version: "9.0"
+                 version: "10.0"
                  directory: ${{ runner.temp }}/llvm
 
             - name: Check clangd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Setup cmake
               uses: jwlawson/actions-setup-cmake@v1.4
               with:
-                 cmake-version: '2.8.x'
+                 cmake-version: '3.0.x'
 
             - name: Check cmake
               run: "cmake --version"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,20 @@ jobs:
               with:
                   version: 0.8.4
 
+            - name: Setup cmake
+              uses: jwlawson/actions-setup-cmake@v1.4
+              with:
+                 cmake-version: '2.8.x'
+
+            - name: Install LLVM and Clang
+              uses: KyleMayes/install-llvm-action@v1
+              with:
+                 version: "9.0"
+                 directory: ${{ runner.temp }}/llvm
+
+            - name: Check clangd
+              run: "which clangd"
+
             - name: Install depedencies
               run: "pip3 install python-language-server"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Setup cmake
               uses: jwlawson/actions-setup-cmake@v1.4
               with:
-                 cmake-version: '3.5.x'
+                 cmake-version: '3.18.x'
 
             - name: Check cmake
               run: "cmake --version"

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,7 @@ unix-compile:
 
 prepare_cpp_project:
 	@echo "Setting up Sample C++ project with CMake and clangd"
-	cd test/fixtures/SampleCppProject/
-	mkdir -p build && cd build/
-	cmake ..
+	cd test/fixtures/SampleCppProject/ && mkdir -p build && cd build/ && cmake ..
 
 windows-compile:
 	@echo "Compiling..."

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ unix-compile:
 
 prepare_cpp_project:
 	@echo "Setting up Sample C++ project with CMake and clangd"
-	cd test/fixtures/SampleCppProject/ && mkdir -p build && cd build/ && cmake .. && ls -alh
+	cd test/fixtures/SampleCppProject/ && mkdir -p build && cd build/ && cmake ..
 
 windows-compile:
 	@echo "Compiling..."

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ unix-compile:
 
 prepare_cpp_project:
 	@echo "Setting up Sample C++ project with CMake and clangd"
-	cd test/fixtures/SampleCppProject/ && mkdir -p build && cd build/ && cmake ..
+	cd test/fixtures/SampleCppProject/ && mkdir -p build && cd build/ && cmake .. && ls -alh
 
 windows-compile:
 	@echo "Compiling..."

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ unix-build:
 	$(CASK) install
 
 # TODO: add 'checkdoc' and 'lint' here when they pass
-unix-ci: clean unix-build unix-compile unix-test
+unix-ci: clean unix-build unix-compile prepare_cpp_project unix-test
 
 windows-ci: CASK=
 windows-ci: clean windows-compile windows-test
@@ -42,6 +42,12 @@ unix-compile:
 		-L . -L clients \
 		--eval '(setq byte-compile-error-on-warn t)' \
 		-f batch-byte-compile $(LSP-FILES)
+
+prepare_cpp_project:
+	@echo "Setting up Sample C++ project with CMake and clangd"
+	cd test/fixtures/SampleCppProject/
+	mkdir -p build && cd build/
+	cmake ..
 
 windows-compile:
 	@echo "Compiling..."
@@ -100,5 +106,7 @@ local-webpage: docs
 
 clean:
 	rm -rf .cask *.elc clients/*.elc
+	rm -rf test/fixtures/SampleCppProject/build test/fixtures/SampleCppProject/.cache
+
 
 .PHONY: all unix-build	 ci unix-compile windows-compile checkdoc lint unix-test windows-test docs local-webpage clean

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -235,18 +235,28 @@ returned to avoid that the echo area grows uncomfortably."
         (car (s-lines (lsp--render-element contents)))))))
 
 
+(defun lsp-clangd-to-other ()
+  "Open the corresponding header/source file."
+  (if-let ((other-fname
+            (with-lsp-workspace (lsp-find-workspace 'clangd)
+              ;; TODO define an extension with lsp-interace
+              ;; similar to rust-analyzer on lines 278-292 in
+              ;; lsp-protocol.el
+              (lsp-send-request (lsp-make-request
+                                 "textDocument/switchSourceHeader"
+                                 (lsp--text-document-identifier))))
+            ))
+      other-fname
+    (lsp--info "This file doesn't have a corresponding file")
+    nil))
 ;; Running this in "/home/petr_tik/Coding/rr/src/AutoRemoteSyscalls.cc"
-(with-lsp-workspace (lsp-find-workspace 'clangd)
-                             (lsp-send-request (lsp-make-request
-                                                "textDocument/switchSourceHeader"
-                                                (lsp--text-document-identifier))))
 ;; returns this a URI
 ;; "file:///home/petr_tik/Coding/rr/src/AutoRemoteSyscalls.h"
-;; running in a file with a companion - returns nil
+;; running in a file without a companion - returns nil
 
-;; (url-generic-parse-url "file:///home/petr_tik/Coding/rr/src/AutoRemoteSyscalls.h")
+;;
 ;; returns a structure that we can access
-
+;; (url-generic-parse-url "file:///home/petr_tik/Coding/rr/src/AutoRemoteSyscalls.h")
 
 (provide 'lsp-clangd)
 ;;; lsp-clangd.el ends here

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -237,7 +237,10 @@ returned to avoid that the echo area grows uncomfortably."
 
 (defun lsp-clangd-to-other ()
   "Open the corresponding header/source file."
+  (interactive)
   (if-let ((other-fname
+            ;; find-workspace might be too brittle if users make their own lsp IDs
+            ;; eg. clangd-remote
             (with-lsp-workspace (lsp-find-workspace 'clangd)
               ;; TODO define an extension with lsp-interace
               ;; similar to rust-analyzer on lines 278-292 in
@@ -246,7 +249,7 @@ returned to avoid that the echo area grows uncomfortably."
                                  "textDocument/switchSourceHeader"
                                  (lsp--text-document-identifier))))
             ))
-      ;; TODO use lsp-goto-location instead
+      ;; TODO maybe worth using lsp-goto-location instead
       (find-file (lsp--uri-to-path other-fname))
     (lsp--info "This file doesn't have a corresponding file")
     nil))

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -236,25 +236,17 @@ returned to avoid that the echo area grows uncomfortably."
 
 
 (defun lsp-clangd-to-other (&optional arg)
-  "Open the corresponding header/source file or return nil.
+  "Open the corresponding header/source file.
 
 If called with ARG universal argument, the file will open in the other window."
   (interactive "P")
-  (if-let ((other-fname
-            ;; find-workspace might be too brittle if users make their own lsp IDs
-            ;; eg. clangd-remote
-              ;; TODO define an extension with lsp-interace
-              ;; similar to rust-analyzer on lines 278-292 in
-              ;; lsp-protocol.el
-              (lsp-send-request (lsp-make-request
-                                 "textDocument/switchSourceHeader"
-                                 (lsp--text-document-identifier)))))
-      ;; TODO maybe worth using lsp-goto-location instead
+  (if-let ((other-fname (lsp-send-request (lsp-make-request
+                                           "textDocument/switchSourceHeader"
+                                           (lsp--text-document-identifier)))))
       (if arg
           (find-file-other-window (lsp--uri-to-path other-fname))
-          (find-file (lsp--uri-to-path other-fname)))
-    (lsp--info "This file doesn't have a corresponding file")
-    nil))
+        (find-file (lsp--uri-to-path other-fname)))
+    (lsp--info "This file doesn't have a corresponding file")))
 
 (provide 'lsp-clangd)
 ;;; lsp-clangd.el ends here

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -246,17 +246,10 @@ returned to avoid that the echo area grows uncomfortably."
                                  "textDocument/switchSourceHeader"
                                  (lsp--text-document-identifier))))
             ))
-      other-fname
+      ;; TODO use lsp-goto-location instead
+      (find-file (lsp--uri-to-path other-fname))
     (lsp--info "This file doesn't have a corresponding file")
     nil))
-;; Running this in "/home/petr_tik/Coding/rr/src/AutoRemoteSyscalls.cc"
-;; returns this a URI
-;; "file:///home/petr_tik/Coding/rr/src/AutoRemoteSyscalls.h"
-;; running in a file without a companion - returns nil
-
-;;
-;; returns a structure that we can access
-;; (url-generic-parse-url "file:///home/petr_tik/Coding/rr/src/AutoRemoteSyscalls.h")
 
 (provide 'lsp-clangd)
 ;;; lsp-clangd.el ends here

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -235,5 +235,18 @@ returned to avoid that the echo area grows uncomfortably."
         (car (s-lines (lsp--render-element contents)))))))
 
 
+;; Running this in "/home/petr_tik/Coding/rr/src/AutoRemoteSyscalls.cc"
+(with-lsp-workspace (lsp-find-workspace 'clangd)
+                             (lsp-send-request (lsp-make-request
+                                                "textDocument/switchSourceHeader"
+                                                (lsp--text-document-identifier))))
+;; returns this a URI
+;; "file:///home/petr_tik/Coding/rr/src/AutoRemoteSyscalls.h"
+;; running in a file with a companion - returns nil
+
+;; (url-generic-parse-url "file:///home/petr_tik/Coding/rr/src/AutoRemoteSyscalls.h")
+;; returns a structure that we can access
+
+
 (provide 'lsp-clangd)
 ;;; lsp-clangd.el ends here

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -235,22 +235,24 @@ returned to avoid that the echo area grows uncomfortably."
         (car (s-lines (lsp--render-element contents)))))))
 
 
-(defun lsp-clangd-to-other ()
-  "Open the corresponding header/source file."
-  (interactive)
+(defun lsp-clangd-to-other (&optional arg)
+  "Open the corresponding header/source file or return nil.
+
+If called with ARG universal argument, the file will open in the other window."
+  (interactive "P")
   (if-let ((other-fname
             ;; find-workspace might be too brittle if users make their own lsp IDs
             ;; eg. clangd-remote
-            (with-lsp-workspace (lsp-find-workspace 'clangd)
               ;; TODO define an extension with lsp-interace
               ;; similar to rust-analyzer on lines 278-292 in
               ;; lsp-protocol.el
               (lsp-send-request (lsp-make-request
                                  "textDocument/switchSourceHeader"
-                                 (lsp--text-document-identifier))))
-            ))
+                                 (lsp--text-document-identifier)))))
       ;; TODO maybe worth using lsp-goto-location instead
-      (find-file (lsp--uri-to-path other-fname))
+      (if arg
+          (find-file-other-window (lsp--uri-to-path other-fname))
+          (find-file (lsp--uri-to-path other-fname)))
     (lsp--info "This file doesn't have a corresponding file")
     nil))
 

--- a/test/fixtures/SampleCppProject/CMakeLists.txt
+++ b/test/fixtures/SampleCppProject/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 project(test)

--- a/test/fixtures/SampleCppProject/CMakeLists.txt
+++ b/test/fixtures/SampleCppProject/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 2.8)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 project(test)

--- a/test/fixtures/SampleCppProject/CMakeLists.txt
+++ b/test/fixtures/SampleCppProject/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.16)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+project(test)
+
+add_subdirectory(src)

--- a/test/fixtures/SampleCppProject/CMakeLists.txt
+++ b/test/fixtures/SampleCppProject/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 project(test)

--- a/test/fixtures/SampleCppProject/src/CMakeLists.txt
+++ b/test/fixtures/SampleCppProject/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_executable(test_binary main.cpp)
+add_executable(test_binary main.cpp individual_file.cpp)

--- a/test/fixtures/SampleCppProject/src/CMakeLists.txt
+++ b/test/fixtures/SampleCppProject/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_executable(test_binary main.cpp)

--- a/test/fixtures/SampleCppProject/src/individual_file.cpp
+++ b/test/fixtures/SampleCppProject/src/individual_file.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+
+void check_bigger(int left, int right) {
+  if (left < right) {
+    std::cout << left << " is smaller than " << right << "\n";
+  } else {
+    std::cout << left << " at least as big as " << right << "\n";
+  }
+}

--- a/test/fixtures/SampleCppProject/src/main.cpp
+++ b/test/fixtures/SampleCppProject/src/main.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+#include "main.h"
+
+using namespace std;
+
+int multiply_by_seventeen(int param) {
+    return param * 17;
+}
+
+int main(int argc, char *argv[]) {
+    cout << "Wagwan world!" << "\n";
+
+    return 0;
+}

--- a/test/fixtures/SampleCppProject/src/main.cpp
+++ b/test/fixtures/SampleCppProject/src/main.cpp
@@ -3,12 +3,17 @@
 
 using namespace std;
 
+// defined in individual_file.cpp
+void check_bigger(int left, int right);
+
 int multiply_by_seventeen(int param) {
     return param * 17;
 }
 
 int main(int argc, char *argv[]) {
     cout << "Wagwan world!" << "\n";
+
+    check_bigger(10, 25);
 
     return 0;
 }

--- a/test/fixtures/SampleCppProject/src/main.h
+++ b/test/fixtures/SampleCppProject/src/main.h
@@ -1,0 +1,1 @@
+int multiply_by_seventeen(int param);

--- a/test/lsp-clangd-test.el
+++ b/test/lsp-clangd-test.el
@@ -87,6 +87,7 @@ and starts lsp. After the test BODY runs - tidy up."
      ;; initialise the workspace
      (setq lsp-log-io t)
      (lsp)
+     (message "The test body will start in %s" (buffer-file-name))
      ;; run our test body
      ,@body
 

--- a/test/lsp-clangd-test.el
+++ b/test/lsp-clangd-test.el
@@ -103,7 +103,6 @@ and starts lsp. After the test BODY runs - tidy up."
      (find-file (f-join lsp-test-location "fixtures/SampleCppProject/src/main.cpp"))
      ;; initialise the workspace
      (lsp)
-     (lsp-describe-session)
      ;; run our test body
      ,@body
 

--- a/test/lsp-clangd-test.el
+++ b/test/lsp-clangd-test.el
@@ -85,6 +85,7 @@ and starts lsp. After the test BODY runs - tidy up."
      (lsp-workspace-folders-add (f-join lsp-test-location "fixtures/SampleCppProject/"))
      (find-file (f-join lsp-test-location "fixtures/SampleCppProject/src/main.cpp"))
      ;; initialise the workspace
+     (setq lsp-log-io t)
      (lsp)
      ;; run our test body
      ,@body
@@ -117,6 +118,7 @@ and starts lsp. After the test BODY runs - tidy up."
   (lsp-in-sample-cpp-project
    (find-file (f-join lsp-test-location "fixtures/SampleCppProject/src/individual_file.cpp"))
    (should (string= (buffer-name) "individual_file.cpp"))
+   (lsp-clangd-to-other)
    (should (string= (buffer-name) "individual_file.cpp"))))
 
 ;;; lsp-clangd-test.el ends here

--- a/test/lsp-clangd-test.el
+++ b/test/lsp-clangd-test.el
@@ -139,7 +139,7 @@ and starts lsp. After the test BODY runs - tidy up."
   (lsp-in-sample-cpp-project
    (find-file (f-join lsp-test-location "fixtures/SampleCppProject/src/individual_file.cpp"))
    (should (string= (buffer-name) "individual_file.cpp"))
-   (lsp-clangd-to-other)
+   (should (= (lsp-clangd-to-other) nil))
    (should (string= (buffer-name) "individual_file.cpp"))))
 
 ;;; lsp-clangd-test.el ends here

--- a/test/lsp-clangd-test.el
+++ b/test/lsp-clangd-test.el
@@ -23,24 +23,7 @@
 
 (require 'ert)
 (require 'lsp-clangd)
-
-;; TODO move to a common/shared test-utils.el
-(defconst lsp-test-location (file-name-directory (or load-file-name buffer-file-name)))
-
-;; TODO move to a common/shared test-utils.el
-(defun lsp-test--wait-for (form &optional d)
-  (--doto (or d (deferred:new #'identity))
-    (run-with-timer
-     0.001 nil
-     (lambda ()
-       (if-let ((result (eval form)))
-           (deferred:callback-post it result)
-         (lsp-test--wait-for form it))))))
-
-;; TODO move to a common/shared test-utils.el and import here and in
-;; integration-test.el
-(defmacro lsp-test-wait (form)
-  `(lsp-test--wait-for '(progn ,form)))
+(require 'lsp-integration-test)
 
 (ert-deftest lsp-clangd-extract-signature-on-hover ()
   (should (string= (lsp-clients-extract-signature-on-hover
@@ -107,9 +90,6 @@ and starts lsp. After the test BODY runs - tidy up."
      ,@body
 
      ;; lsp tidy up
-     (find-file (f-join lsp-test-location "fixtures/SampleCppProject/src/main.cpp"))
-     (save-buffer)
-     (kill-buffer)
      (lsp-workspace-folders-remove (f-join lsp-test-location "fixtures/SampleCppProject/"))
      (setq lsp-clients-clangd-args actual-clangd-args)))
 
@@ -134,11 +114,9 @@ and starts lsp. After the test BODY runs - tidy up."
    (should (string= (buffer-name) "main.cpp"))))
 
 (ert-deftest lsp-clangd-switch-to-nonexistent-other ()
-  ;; TODO add a cpp file without a corresponding header file and add it to CML
   (lsp-in-sample-cpp-project
    (find-file (f-join lsp-test-location "fixtures/SampleCppProject/src/individual_file.cpp"))
    (should (string= (buffer-name) "individual_file.cpp"))
-   (should (= (lsp-clangd-to-other) nil))
    (should (string= (buffer-name) "individual_file.cpp"))))
 
 ;;; lsp-clangd-test.el ends here

--- a/test/lsp-clangd-test.el
+++ b/test/lsp-clangd-test.el
@@ -103,7 +103,7 @@ and starts lsp. After the test BODY runs - tidy up."
      (find-file (f-join lsp-test-location "fixtures/SampleCppProject/src/main.cpp"))
      ;; initialise the workspace
      (lsp)
-
+     (lsp-describe-session)
      ;; run our test body
      ,@body
 


### PR DESCRIPTION
Made an interactive function, use the lowest cmake version that supports compile_commands.json. 

Add a cmake-based repo for intergration tests of clangd. 

Install cmake and clang(d) for unix-ci and add a makefile step for unix-ci. Experimenting with unix-ci with github actions, please let me know, if I am doing something wrong. 

