### PR TITLE
Mark lsp-solargraph-use-bundler as safe if booleanp

### DIFF
--- a/clients/lsp-solargraph.el
+++ b/clients/lsp-solargraph.el
@@ -106,6 +106,7 @@
 (defcustom lsp-solargraph-use-bundler nil
   "Run solargraph under bundler"
   :type 'boolean
+  :safe #'booleanp
   :group 'lsp-solargraph
   :package-version '(lsp-mode . "6.1"))
 


### PR DESCRIPTION
Wanting to use bundler or not is very likely to be project-specific and is something you would want to set in a .dir-locals.el.