### PR TITLE
`lsp-avy-lens': don't error if no lens is selected

### DIFF
--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -408,7 +408,7 @@ CALLBACK - callback for the lenses."
                        (--map (overlay-put it 'before-string
                                            (overlay-get it 'lsp-original))
                               lsp-lens--overlays))))))
-      (funcall-interactively action))))
+      (when action (funcall-interactively action)))))
 
 (provide 'lsp-lens)
 ;;; lsp-lens.el ends here


### PR DESCRIPTION
`avy-process` can return nil if the user cancels (e.g. by pressing ESC).
In that case, `funcall-interactively` calling the result would throw an
error. Guard the `funcall-interactively`, removing the error.

The relevant part in `avy-process` is "(eq res 'abort) nil".

To reproduce:
0. `M-x toggle-debug-on-error`
1. Open an `lsp`-managed file with a server that supports lenses and has at least one lens
2. `M-x lsp-avy-lens`
3. `ESC`
-> observe that a `wrong type argument commandp, nil` error is thrown, which is fixed by my PR, if following these reproduction steps again.