### PR TITLE
Update projectLoadingStart message in angular ls

### DIFF
--- a/clients/lsp-angular.el
+++ b/clients/lsp-angular.el
@@ -64,8 +64,8 @@
                                         (lsp-workspace-root)
                                         (file-exists-p (f-join (lsp-workspace-root) "angular.json"))))
                   :priority -1
-                  :notification-handlers (ht ("angular-language-service/projectLoadingStart" #'lsp-client--angular-start-loading)
-                                             ("angular-language-service/projectLoadingFinish" #'lsp-client--angular-finished-loading))
+                  :notification-handlers (ht ("angular/projectLoadingStart" #'lsp-client--angular-start-loading)
+                                             ("angular/projectLoadingFinish" #'lsp-client--angular-finished-loading))
                   :add-on? t
                   :server-id 'angular-ls))
 


### PR DESCRIPTION
`angular-language-service` new sends these messages prefixed with just `angular` instead of `angular-language-service`,
so warnings pop up about this not being a known message.

Here I just replaced that prefix, and now the warnings disappear.