### PR TITLE
`lsp-avy-lens': don't `error' for no lenses

### DIFF
--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -376,7 +376,8 @@ CALLBACK - callback for the lenses."
   (unless lsp-lens--overlays
     (user-error "No lenses in current buffer"))
   (let* ((avy-action 'identity)
-         (actions (avy-process
+         (action (cl-third
+                  (avy-process
                    (-mapcat
                     (lambda (overlay)
                       (-map-indexed
@@ -406,8 +407,8 @@ CALLBACK - callback for the lenses."
                    (lambda ()
                      (--map (overlay-put it 'before-string
                                          (overlay-get it 'lsp-original))
-                            lsp-lens--overlays)))))
-    (when actions (funcall-interactively (cl-third actions)))))
+                            lsp-lens--overlays))))))
+    (when action (funcall-interactively action))))
 
 (provide 'lsp-lens)
 ;;; lsp-lens.el ends here

--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -391,7 +391,7 @@ CALLBACK - callback for the lenses."
                             (str (propertize (string (car (last path)))
                                              'face 'avy-lead-face))
                             (old-str (overlay-get ov 'before-string))
-                            (old-str-tokens (s-split "\|" old-str))
+                            (old-str-tokens (s-split "|" old-str))
                             (old-token (seq-elt old-str-tokens index))
                             (tokens `(,@(-take index old-str-tokens)
                                       ,(-if-let ((_ prefix suffix)

--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -375,9 +375,10 @@ CALLBACK - callback for the lenses."
   (interactive)
   (if (not lsp-lens-mode)
       (user-error "`lsp-lens-mode' not active")
+    (unless lsp-lens--overlays
+      (user-error "No lenses in current buffer"))
     (let* ((avy-action 'identity)
-           (action (cl-third
-                    (avy-process
+           (actions (avy-process
                      (-mapcat
                       (lambda (overlay)
                         (-map-indexed
@@ -407,8 +408,8 @@ CALLBACK - callback for the lenses."
                      (lambda ()
                        (--map (overlay-put it 'before-string
                                            (overlay-get it 'lsp-original))
-                              lsp-lens--overlays))))))
-      (when action (funcall-interactively action)))))
+                              lsp-lens--overlays)))))
+      (when actions (funcall-interactively (cl-third actions))))))
 
 (provide 'lsp-lens)
 ;;; lsp-lens.el ends here

--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -373,43 +373,41 @@ CALLBACK - callback for the lenses."
 (defun lsp-avy-lens ()
   "Click lsp lens using `avy' package."
   (interactive)
-  (if (not lsp-lens-mode)
-      (user-error "`lsp-lens-mode' not active")
-    (unless lsp-lens--overlays
-      (user-error "No lenses in current buffer"))
-    (let* ((avy-action 'identity)
-           (actions (avy-process
-                     (-mapcat
-                      (lambda (overlay)
-                        (-map-indexed
-                         (lambda (index lens-token)
-                           (list overlay index
-                                 (get-text-property 0 'action lens-token)))
-                         (overlay-get overlay 'lsp--metadata)))
-                      lsp-lens--overlays)
-                     (-lambda (path ((ov index) . _win))
-                       (let* ((path (mapcar #'avy--key-to-char path))
-                              (str (propertize (string (car (last path)))
-                                               'face 'avy-lead-face))
-                              (old-str (overlay-get ov 'before-string))
-                              (old-str-tokens (s-split "\|" old-str))
-                              (old-token (seq-elt old-str-tokens index))
-                              (tokens `(,@(-take index old-str-tokens)
-                                        ,(-if-let ((_ prefix suffix)
-                                                   (s-match "\\(^[[:space:]]+\\)\\(.*\\)" old-token))
-                                             (concat prefix str suffix)
-                                           (concat str old-token))
-                                        ,@(-drop (1+ index) old-str-tokens)))
-                              (new-str (s-join (propertize "|" 'face 'lsp-lens-face) tokens))
-                              (new-str (if (s-ends-with? "\n" new-str)
-                                           new-str
-                                         (concat new-str "\n"))))
-                         (overlay-put ov 'before-string new-str)))
-                     (lambda ()
-                       (--map (overlay-put it 'before-string
-                                           (overlay-get it 'lsp-original))
-                              lsp-lens--overlays)))))
-      (when actions (funcall-interactively (cl-third actions))))))
+  (unless lsp-lens--overlays
+    (user-error "No lenses in current buffer"))
+  (let* ((avy-action 'identity)
+         (actions (avy-process
+                   (-mapcat
+                    (lambda (overlay)
+                      (-map-indexed
+                       (lambda (index lens-token)
+                         (list overlay index
+                               (get-text-property 0 'action lens-token)))
+                       (overlay-get overlay 'lsp--metadata)))
+                    lsp-lens--overlays)
+                   (-lambda (path ((ov index) . _win))
+                     (let* ((path (mapcar #'avy--key-to-char path))
+                            (str (propertize (string (car (last path)))
+                                             'face 'avy-lead-face))
+                            (old-str (overlay-get ov 'before-string))
+                            (old-str-tokens (s-split "\|" old-str))
+                            (old-token (seq-elt old-str-tokens index))
+                            (tokens `(,@(-take index old-str-tokens)
+                                      ,(-if-let ((_ prefix suffix)
+                                                 (s-match "\\(^[[:space:]]+\\)\\(.*\\)" old-token))
+                                           (concat prefix str suffix)
+                                         (concat str old-token))
+                                      ,@(-drop (1+ index) old-str-tokens)))
+                            (new-str (s-join (propertize "|" 'face 'lsp-lens-face) tokens))
+                            (new-str (if (s-ends-with? "\n" new-str)
+                                         new-str
+                                       (concat new-str "\n"))))
+                       (overlay-put ov 'before-string new-str)))
+                   (lambda ()
+                     (--map (overlay-put it 'before-string
+                                         (overlay-get it 'lsp-original))
+                            lsp-lens--overlays)))))
+    (when actions (funcall-interactively (cl-third actions)))))
 
 (provide 'lsp-lens)
 ;;; lsp-lens.el ends here


### PR DESCRIPTION
If there are no elements, `avy-process` returns t, causing
`funcall-interactively` to error. Before continuing to that function,
check if there are lenses, only then calling `avy`. If there are none,
`user-error` out.

Replacing the guard from the previous commit with `consp' was also an
option, but that would yield a less intuitive "zero candidates" message
instead.

Don't worry, this bug wasn't introduced by my previous PR; `avy-process` can also return t if there are no candidates, so we should guard against zero lenses, too.