### PR TITLE
Fix mouse-3 error when dap is not present

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2630,7 +2630,9 @@ an Elisp regexp."
      "---"
      ("Debug"
       :active (bound-and-true-p dap-ui-mode)
-      :filter ,(lambda (_) (nthcdr 3 dap-ui-menu-items)))))
+      :filter ,(lambda (_)
+                 (and (boundp 'dap-ui-menu-items)
+                      (nthcdr 3 dap-ui-menu-items))))))
   "Menu for lsp-mode.")
 
 (defalias 'make-lsp-client 'make-lsp--client)


### PR DESCRIPTION
Previously, the menu filter function assumes that dap is loaded in its
filter function.



I am seeing this error when ever I use mouse-3 which rather limits the
use of lsp-mode.

```
Debugger entered--Lisp error: (void-variable dap-ui-menu-items)
  (nthcdr 3 dap-ui-menu-items)
  (closure (lsp-mode-menu cl-struct-lsp--folding-range-tags cl-struct-lsp-watch-tags cl-struct-lsp--client-tags lsp--log-lines dap-ui-menu-items dap-auto-configure-mode t) (_) (nthcdr 3 dap-ui-menu-items))(nil)
  #f(compiled-function (menu) #<bytecode 0x157d65067591>)(nil)
  x-popup-menu((mouse-9 (#<window 3 on main.rs> 386 (226 . 462) 297753800 nil 386 (20 . 18) nil (226 . 48) (11 . 23))) (keymap (Go\ to\ definition menu-item "Go to definition" lsp-find-definition :enable (lsp--find-workspaces-for "textDocument/definition")) (Find\ references menu-item "Find references" lsp-find-references :enable (lsp--find-workspaces-for "textDocument/references")) (Find\ implementations menu-item "Find implementations" lsp-find-implementation :enable (lsp--find-workspaces-for "textDocument/implementation")) (Find\ declarations menu-item "Find declarations" lsp-find-declaration :enable (lsp--find-workspaces-for "textDocument/declaration")) (Go\ to\ type\ declaration menu-item "Go to type declaration" lsp-find-type-definition :enable (lsp--find-workspaces-for "textDocument/typeDefinition")) (nil menu-item "--") (Describe menu-item "Describe" lsp-describe-thing-at-point) (Code\ action menu-item "Code action" lsp-execute-code-action) (Format menu-item "Format" lsp-format-buffer) (Highlight\ references menu-item "Highlight references" lsp-document-highlight) (Rename menu-item "Rename" lsp-rename :enable (or (lsp--capability :renameProvider) (lsp--registered-capability "textDocument/rename"))) (nil-11 menu-item "--") (Session menu-item "Session" (keymap "Session" (View\ logs menu-item "View logs" lsp-workspace-show-log) (Describe menu-item "Describe" lsp-describe-session) (Shutdown menu-item "Shutdown" lsp-shutdown-workspace) (Restart menu-item "Restart" lsp-restart-workspace))) (Workspace\ Folders menu-item "Workspace Folders" (keymap "Workspace Folders" (Add menu-item "Add" lsp-workspace-folders-add) (Remove menu-item "Remove" lsp-workspace-folders-remove) (Open menu-item "Open" lsp-workspace-folders-open))) (Toggle\ features menu-item "Toggle features" (keymap "Toggle features" (Lenses menu-item "Lenses" lsp-lens-mode) (Headerline\ breadcrumb menu-item "Headerline breadcrumb" lsp-headerline-breadcrumb-mode) (Modeline\ code\ actions menu-item "Modeline code actions" lsp-modeline-code-actions-mode) (Modeline\ diagnostics menu-item "Modeline diagnostics" lsp-modeline-diagnostics-mode))) (nil-15 menu-item "---") (Debug menu-item "Debug" nil :filter #f(compiled-function (menu) #<bytecode 0x157d65067591>) :enable (bound-and-true-p dap-ui-mode))))
  (let* ((ec (event-start event)) (choice (x-popup-menu event lsp-mode-menu)) (action (lookup-key lsp-mode-menu (apply 'vector choice)))) (select-window (posn-window ec)) (if (and (region-active-p) (eq action 'lsp-execute-code-action)) nil (goto-char (posn-point ec))) (run-with-idle-timer 0.001 nil #'(lambda nil (let (--cl-check--) (setq --cl-check-- #'(lambda ... ...)) (if choice (progn (call-interactively action)))))))
  lsp-mouse-click((mouse-9 (#<window 3 on main.rs> 386 (226 . 462) 297753800 nil 386 (20 . 18) nil (226 . 48) (11 . 23))))
  funcall-interactively(lsp-mouse-click (mouse-9 (#<window 3 on main.rs> 386 (226 . 462) 297753800 nil 386 (20 . 18) nil (226 . 48) (11 . 23))))
  call-interactively(lsp-mouse-click nil nil)
  command-execute(lsp-mouse-click)
```

I am a bit confused since this is a main entry point, and I can't see
why everyone is not hitting this very early, unless everyone has
dap-mode installed.


This fix is simple enough, although the `defvar` earlier in the file
could also be set to define to nil.


