### PR TITLE
update implementation of lsp-yaml-download-schema-store-db

### DIFF
--- a/clients/lsp-yaml.el
+++ b/clients/lsp-yaml.el
@@ -171,18 +171,18 @@
   "Download the remote schema store at `lsp-yaml-schema-store-uri' into local cache.
 Set FORCE-DOWNLOADING to non-nil to force re-download the database."
   (interactive "P")
-  (or force-downloading
-      (file-exists-p lsp-yaml-schema-store-local-db)
-      (url-copy-file lsp-yaml-schema-store-uri lsp-yaml-schema-store-local-db)))
+  (when (or force-downloading (not (file-exists-p lsp-yaml-schema-store-local-db)))
+    (unless (file-directory-p (file-name-directory lsp-yaml-schema-store-local-db))
+      (mkdir (file-name-directory lsp-yaml-schema-store-local-db)))
+    (url-copy-file lsp-yaml-schema-store-uri lsp-yaml-schema-store-local-db force-downloading)))
 
 (defun lsp-yaml--get-supported-schemas ()
   "Get out the list of supported schemas."
   (when (and lsp-yaml-schema-store-enable
              (not lsp-yaml--schema-store-schemas-alist))
-    (progn
-      (lsp-yaml-download-schema-store-db)
-      (setq lsp-yaml--schema-store-schemas-alist
-            (alist-get 'schemas (json-read-file lsp-yaml-schema-store-local-db)))))
+    (lsp-yaml-download-schema-store-db)
+    (setq lsp-yaml--schema-store-schemas-alist
+          (alist-get 'schemas (json-read-file lsp-yaml-schema-store-local-db))))
   (seq-concatenate 'list (list lsp-yaml--built-in-kubernetes-schema) lsp-yaml--schema-store-schemas-alist))
 
 (defun lsp-yaml-set-buffer-schema (uri)


### PR DESCRIPTION
Trying to download the yaml schemas when the `~/.emacs.d/.cache/lsp` directory doesn't exist gets an error from `url-copy-file`. Also, it seems like there is an error in the logic of the `force-downloading` arg: if it's non-nil, the cache is never downloaded, even if the file doesn't exist locally. (The yaml client code doesn't use this argument, so currently the only way to get this behavior to to call `(lsp-yaml-download-schema-store-db t)` manually).

This PR fixes these two things: it creates the cache directory first if it doesn't already exist before downloading the schema db file, and updates the implementation to do match what the docstring describes.