### PR TITLE
ESlint server shouldn't launch for JSON files

### DIFF
--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -267,7 +267,7 @@ source.fixAll code action."
   :activation-fn (lambda (filename &optional _)
                    (when lsp-eslint-enable
                      (or (string-match-p (rx (one-or-more anything) "."
-                                             (or "ts" "js" "jsx" "tsx" "html" "vue")eol)
+                                             (or "ts" "js" "jsx" "tsx" "html" "vue")eos)
                                          filename)
                          (derived-mode-p 'js-mode 'js2-mode 'typescript-mode 'html-mode))))
   :priority -1

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -267,7 +267,7 @@ source.fixAll code action."
   :activation-fn (lambda (filename &optional _)
                    (when lsp-eslint-enable
                      (or (string-match-p (rx (one-or-more anything) "."
-                                             (or "ts" "js" "jsx" "tsx" "html" "vue"))
+                                             (or "ts" "js" "jsx" "tsx" "html" "vue")eol)
                                          filename)
                          (derived-mode-p 'js-mode 'js2-mode 'typescript-mode 'html-mode))))
   :priority -1


### PR DESCRIPTION
JSON has its own server. ESlint server produces warnings and I'm not sure if it generally works with pure JSON.
Also, the resolution should be the EOL by default for non-temporary files.