### PR TITLE
`lsp-lv-message': fix `format' errors

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4914,7 +4914,7 @@ RENDER-ALL - nil if only the signature should be rendered."
       (progn
         (setq lsp--signature-last-buffer (current-buffer))
         (let ((lv-force-update t))
-          (lv-message message)))
+          (lv-message "%s" message)))
     (lv-delete-window)))
 
 (defun lsp--handle-signature-update (signature)


### PR DESCRIPTION
`lsp-lv-message` gets the hover content passed to it directly, with no %
escaping. This function then proceeds to call `lv-message` passing it as
the format control string, causing issues when the hover string
contains % characters, as is the case when they are used in doxygen
comments sent by clangd (% is doxygen markup).

Fix this by using "%s" + MESSAGE instead.

Fixes #2368.