### PR TITLE
Extend clangd with switch to header/source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,21 @@ jobs:
               with:
                   version: 0.8.4
 
+            - name: Setup cmake
+              uses: jwlawson/actions-setup-cmake@v1.4
+              with:
+                 cmake-version: '3.18.x'
+
+            - name: Check cmake
+              run: "cmake --version"
+
             - name: Install depedencies
-              run: "pip3 install python-language-server"
+              run: |
+                   pip3 install python-language-server
+                   sudo apt-get install clangd-9
+
+            - name: Check clangd
+              run: "clangd-9 --version"
 
             - name: Run tests
               run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,12 +39,19 @@ jobs:
             - name: Check cmake
               run: "cmake --version"
 
-            - name: Install depedencies
+            - name: Install depedencies on Linux
+              if: runner.os == 'Linux'
               run: |
                    pip3 install python-language-server
                    sudo apt-get install clangd-9
 
+            - name: Install deps on macOS
+              if: runner.os == 'macOS'
+              run: |
+                   pip3 install python-language-server
+
             - name: Check clangd
+              if: runner.os == 'Linux'
               run: "clangd-9 --version"
 
             - name: Run tests

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -20,6 +20,7 @@
   * Add ~lsp-headerline-breadcrumb-icons-enable~ to disable breadcrumb icons.
   * Add ActionScript support.
   * Add ~iedit~ integration (=documentHighlights=)
+  * Add an interactive =lsp-clangd-find-other-file= method that uses the clangd extension to return the corresponding header/cpp file from cpp/header file respectively.
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ unix-build:
 	$(CASK) install
 
 # TODO: add 'checkdoc' and 'lint' here when they pass
-unix-ci: clean unix-build unix-compile unix-test
+unix-ci: clean unix-build unix-compile prepare_cpp_project unix-test
 
 windows-ci: CASK=
 windows-ci: clean windows-compile windows-test
@@ -42,6 +42,10 @@ unix-compile:
 		-L . -L clients \
 		--eval '(setq byte-compile-error-on-warn t)' \
 		-f batch-byte-compile $(LSP-FILES)
+
+prepare_cpp_project:
+	@echo "Setting up Sample C++ project with CMake and clangd"
+	cd test/fixtures/SampleCppProject/ && mkdir -p build && cd build/ && cmake ..
 
 windows-compile:
 	@echo "Compiling..."
@@ -100,5 +104,7 @@ local-webpage: docs
 
 clean:
 	rm -rf .cask *.elc clients/*.elc
+	rm -rf test/fixtures/SampleCppProject/build test/fixtures/SampleCppProject/.cache
+
 
 .PHONY: all unix-build	 ci unix-compile windows-compile checkdoc lint unix-test windows-test docs local-webpage clean

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -242,8 +242,8 @@ returned to avoid that the echo area grows uncomfortably."
          (lsp-cpp-flycheck-clang-tidy-error-explainer e))
         (t (flycheck-error-message e))))
 
-(defun lsp-clangd-to-other (&optional arg)
-  "Open the corresponding header/source file.
+(defun lsp-clangd-find-other-file (&optional arg)
+  "Switch between the corresponding C/C++ header and source file.
 
 If called with ARG universal argument, the file will open in the other window."
   (interactive "P")

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -242,5 +242,21 @@ returned to avoid that the echo area grows uncomfortably."
          (lsp-cpp-flycheck-clang-tidy-error-explainer e))
         (t (flycheck-error-message e))))
 
+(defun lsp-clangd-to-other ()
+  "Open the corresponding header/source file."
+  (if-let ((other-fname
+            (with-lsp-workspace (lsp-find-workspace 'clangd)
+              ;; TODO define an extension with lsp-interace
+              ;; similar to rust-analyzer on lines 278-292 in
+              ;; lsp-protocol.el
+              (lsp-send-request (lsp-make-request
+                                 "textDocument/switchSourceHeader"
+                                 (lsp--text-document-identifier))))
+            ))
+      ;; TODO use lsp-goto-location instead
+      (find-file (lsp--uri-to-path other-fname))
+    (lsp--info "This file doesn't have a corresponding file")
+    nil))
+
 (provide 'lsp-clangd)
 ;;; lsp-clangd.el ends here

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -242,18 +242,20 @@ returned to avoid that the echo area grows uncomfortably."
          (lsp-cpp-flycheck-clang-tidy-error-explainer e))
         (t (flycheck-error-message e))))
 
-(defun lsp-clangd-find-other-file (&optional arg)
-  "Switch between the corresponding C/C++ header and source file.
+(defun lsp-clangd-find-other-file (&optional new-window)
+  "Switch between the corresponding C/C++ source and header file.
+If NEW-WINDOW (interactively the prefix argument) is non-nil,
+open in a new window.
 
-If called with ARG universal argument, the file will open in the other window."
+Only works with clangd."
   (interactive "P")
-  (if-let ((other-fname (lsp-send-request (lsp-make-request
-                                           "textDocument/switchSourceHeader"
-                                           (lsp--text-document-identifier)))))
-      (if arg
-          (find-file-other-window (lsp--uri-to-path other-fname))
-        (find-file (lsp--uri-to-path other-fname)))
-    (lsp--info "This file doesn't have a corresponding file")))
+  (let ((other (lsp-send-request (lsp-make-request
+                                  "textDocument/switchSourceHeader"
+                                  (lsp--text-document-identifier)))))
+    (unless (s-present? other)
+      (user-error "Could not find other file"))
+    (funcall (if new-window #'find-file-other-window #'find-file)
+             (lsp--uri-to-path other))))
 
 (provide 'lsp-clangd)
 ;;; lsp-clangd.el ends here

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -242,21 +242,18 @@ returned to avoid that the echo area grows uncomfortably."
          (lsp-cpp-flycheck-clang-tidy-error-explainer e))
         (t (flycheck-error-message e))))
 
-(defun lsp-clangd-to-other ()
-  "Open the corresponding header/source file."
-  (if-let ((other-fname
-            (with-lsp-workspace (lsp-find-workspace 'clangd)
-              ;; TODO define an extension with lsp-interace
-              ;; similar to rust-analyzer on lines 278-292 in
-              ;; lsp-protocol.el
-              (lsp-send-request (lsp-make-request
-                                 "textDocument/switchSourceHeader"
-                                 (lsp--text-document-identifier))))
-            ))
-      ;; TODO use lsp-goto-location instead
-      (find-file (lsp--uri-to-path other-fname))
-    (lsp--info "This file doesn't have a corresponding file")
-    nil))
+(defun lsp-clangd-to-other (&optional arg)
+  "Open the corresponding header/source file.
+
+If called with ARG universal argument, the file will open in the other window."
+  (interactive "P")
+  (if-let ((other-fname (lsp-send-request (lsp-make-request
+                                           "textDocument/switchSourceHeader"
+                                           (lsp--text-document-identifier)))))
+      (if arg
+          (find-file-other-window (lsp--uri-to-path other-fname))
+        (find-file (lsp--uri-to-path other-fname)))
+    (lsp--info "This file doesn't have a corresponding file")))
 
 (provide 'lsp-clangd)
 ;;; lsp-clangd.el ends here

--- a/test/fixtures/SampleCppProject/CMakeLists.txt
+++ b/test/fixtures/SampleCppProject/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.5)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+project(test)
+
+add_subdirectory(src)

--- a/test/fixtures/SampleCppProject/src/CMakeLists.txt
+++ b/test/fixtures/SampleCppProject/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_executable(test_binary main.cpp individual_file.cpp)

--- a/test/fixtures/SampleCppProject/src/individual_file.cpp
+++ b/test/fixtures/SampleCppProject/src/individual_file.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+
+void check_bigger(int left, int right) {
+  if (left < right) {
+    std::cout << left << " is smaller than " << right << "\n";
+  } else {
+    std::cout << left << " at least as big as " << right << "\n";
+  }
+}

--- a/test/fixtures/SampleCppProject/src/main.cpp
+++ b/test/fixtures/SampleCppProject/src/main.cpp
@@ -1,0 +1,19 @@
+#include <iostream>
+#include "main.h"
+
+using namespace std;
+
+// defined in individual_file.cpp
+void check_bigger(int left, int right);
+
+int multiply_by_seventeen(int param) {
+    return param * 17;
+}
+
+int main(int argc, char *argv[]) {
+    cout << "Wagwan world!" << "\n";
+
+    check_bigger(10, 25);
+
+    return 0;
+}

--- a/test/fixtures/SampleCppProject/src/main.h
+++ b/test/fixtures/SampleCppProject/src/main.h
@@ -1,0 +1,1 @@
+int multiply_by_seventeen(int param);

--- a/test/lsp-clangd-test.el
+++ b/test/lsp-clangd-test.el
@@ -23,6 +23,7 @@
 
 (require 'ert)
 (require 'lsp-clangd)
+(require 'lsp-integration-test)
 
 (ert-deftest lsp-clangd-extract-signature-on-hover ()
   (should (string= (lsp-clients-extract-signature-on-hover
@@ -61,5 +62,95 @@
                   int p,
                   int k);")
     (should (string= (lsp-clangd-join-region (point-min) (point-max)) "void foo(int n, int p, int k);"))))
+
+
+;;;
+;;; Integration tests with the sample project
+;;;
+
+(defmacro lsp-in-sample-cpp-project (&rest body)
+  "Creates a macro to wrap test BODY with.
+
+Add the fixtures/SampleCppProject to lsp-workspaces, opens the main.cpp file
+and starts lsp. After the test BODY runs - tidy up."
+  `(progn
+     ;; lsp setup
+     ;; save to temp
+     (setq actual-clangd-args lsp-clients-clangd-args)
+     ;; HACK until https://github.com/emacs-lsp/lsp-mode/issues/2278 lands
+     ;; or we might keep it forever
+     (setq lsp-clients-clangd-args '("--compile-commands-dir=build/" "--log=verbose"))
+
+     ;; snippet complains in logs
+     (setq lsp-enable-snippet nil)
+     (lsp-workspace-folders-add (f-join lsp-test-location "fixtures/SampleCppProject/"))
+     (find-file (f-join lsp-test-location "fixtures/SampleCppProject/src/main.cpp"))
+     ;; initialise the workspace
+     (setq lsp-diagnostic-package :none)
+     (setq lsp-log-io t)
+
+     (lsp)
+     (sleep-for 2)
+
+     (message "The test body will start in %s" (buffer-file-name))
+     ;; run our test body
+     ,@body
+
+     ;; lsp tidy up
+     (find-file (f-join lsp-test-location "fixtures/SampleCppProject/src/main.cpp"))
+     (lsp-workspace-folders-remove (f-join lsp-test-location "fixtures/SampleCppProject/"))
+     (setq lsp-clients-clangd-args actual-clangd-args)))
+
+(ert-deftest lsp-clangd-initialised-workspace ()
+  :tags '(no-win)
+  (lsp-in-sample-cpp-project
+   (->
+    ;; now check that the workspace has started
+    (lsp-test-wait (eq 'initialized
+                       (lsp--workspace-status (cl-first (lsp-workspaces)))))
+   (deferred:sync!))
+   ))
+
+(ert-deftest lsp-clangd-switch-to-other-from-cpp ()
+  :tags '(no-win)
+  (lsp-in-sample-cpp-project
+   (->
+    (lsp-test-wait (eq 'initialized
+                       (lsp--workspace-status (cl-first (lsp-workspaces)))))
+
+    (deferred::nextc
+      (should (string= (buffer-name) "main.cpp"))
+      (lsp-clangd-to-other)
+      (should (string= (buffer-name) "main.h"))
+      (lsp)
+      ;; give enough time for clangd to respond for main.h
+      ;; otherwise will get errors like
+      ;; The connected server(s) does not support
+      ;; method textDocument/switchSourceHeader.
+      (sleep-for 1)
+      (lsp-clangd-to-other)
+
+      (should (string= (buffer-name) "main.cpp")))
+
+    (deferred:sync!))))
+
+(ert-deftest lsp-clangd-switch-to-nonexistent-other ()
+  :tags '(no-win)
+  (lsp-in-sample-cpp-project
+   (->
+    (lsp-test-wait (eq 'initialized
+                       (lsp--workspace-status (cl-first (lsp-workspaces)))))
+
+    (deferred::nextc
+      (find-file (f-join lsp-test-location "fixtures/SampleCppProject/src/individual_file.cpp"))
+      (should (string= (buffer-name) "individual_file.cpp"))
+      ;; after opening a new buffer - need to make sure we are in the same lsp session
+      (lsp)
+      (sleep-for 1)
+      (lsp-clangd-to-other)
+
+      (should (string= (buffer-name) "individual_file.cpp")))
+
+    (deferred:sync!))))
 
 ;;; lsp-clangd-test.el ends here

--- a/test/lsp-clangd-test.el
+++ b/test/lsp-clangd-test.el
@@ -102,7 +102,7 @@ and starts lsp. After the test BODY runs - tidy up."
      (setq lsp-clients-clangd-args actual-clangd-args)))
 
 (ert-deftest lsp-clangd-initialised-workspace ()
-  :tags '(no-win)
+  (skip-unless (memq system-type '(gnu/linux)))
   (lsp-in-sample-cpp-project
    (->
     ;; now check that the workspace has started
@@ -112,7 +112,7 @@ and starts lsp. After the test BODY runs - tidy up."
    ))
 
 (ert-deftest lsp-clangd-switch-to-other-from-cpp ()
-  :tags '(no-win)
+  (skip-unless (memq system-type '(gnu/linux)))
   (lsp-in-sample-cpp-project
    (->
     (lsp-test-wait (eq 'initialized
@@ -135,7 +135,7 @@ and starts lsp. After the test BODY runs - tidy up."
     (deferred:sync!))))
 
 (ert-deftest lsp-clangd-switch-to-nonexistent-other ()
-  :tags '(no-win)
+  (skip-unless (memq system-type '(gnu/linux)))
   (lsp-in-sample-cpp-project
    (->
     (lsp-test-wait (eq 'initialized
@@ -147,7 +147,7 @@ and starts lsp. After the test BODY runs - tidy up."
       ;; after opening a new buffer - need to make sure we are in the same lsp session
       (lsp)
       (sleep-for 1)
-      (lsp-clangd-find-other-file)
+      (should-error (lsp-clangd-find-other-file) :type 'user-error)
 
       (should (string= (buffer-name) "individual_file.cpp")))
 

--- a/test/lsp-clangd-test.el
+++ b/test/lsp-clangd-test.el
@@ -120,7 +120,7 @@ and starts lsp. After the test BODY runs - tidy up."
 
     (deferred::nextc
       (should (string= (buffer-name) "main.cpp"))
-      (lsp-clangd-to-other)
+      (lsp-clangd-find-other-file)
       (should (string= (buffer-name) "main.h"))
       (lsp)
       ;; give enough time for clangd to respond for main.h
@@ -128,7 +128,7 @@ and starts lsp. After the test BODY runs - tidy up."
       ;; The connected server(s) does not support
       ;; method textDocument/switchSourceHeader.
       (sleep-for 1)
-      (lsp-clangd-to-other)
+      (lsp-clangd-find-other-file)
 
       (should (string= (buffer-name) "main.cpp")))
 
@@ -147,7 +147,7 @@ and starts lsp. After the test BODY runs - tidy up."
       ;; after opening a new buffer - need to make sure we are in the same lsp session
       (lsp)
       (sleep-for 1)
-      (lsp-clangd-to-other)
+      (lsp-clangd-find-other-file)
 
       (should (string= (buffer-name) "individual_file.cpp")))
 

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -32,5 +32,10 @@
 
 (add-to-list 'load-path
              (file-name-as-directory (f-parent (f-parent (f-this-file)))))
+;; Add test/ directory to load path to enable each of the test files
+;; to 'require the other test files in test/
+;; useful when sharing utilities
+(add-to-list 'load-path
+             (file-name-as-directory (f-parent (f-this-file))))
 
 ;;; test-helper.el ends here


### PR DESCRIPTION
Address #2279 

Made an interactive function to switch to header/source.

Add a cmake-based repo for intergration tests of clangd. Currently Linux-only, since I don't have a Windows machine at home. 

I am not sure if async functions that fail inside deferred::nextc show up as errors in CI logs. Even if followed by deferred:sync! 

Follow up to #2279, which I closed to sort out the CI without spamming the upstream and reviewers. 