### PR TITLE
lsp--build-workspace-configuration-response: Use ht-get instead of ht-get*

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5952,7 +5952,9 @@ PARAMS are the `workspace/configuration' request params"
                        (path-parts-len (length path-parts)))
                  (cond
                   ((<= path-parts-len 1)
-                   (apply 'ht-get* `(,(lsp-configuration-section section?) ,@path-parts)))
+                   (ht-get (lsp-configuration-section section?)
+                           (car-safe path-parts)
+                           (ht-create)))
                   ((> path-parts-len 1)
                    (when-let ((section (lsp-configuration-section path-without-last))
                               (keys path-parts))


### PR DESCRIPTION
This is easier to read, but also, at the time of writing, the latest
version of `ht.el` has changes that make `ht-get*` behave differently from
before.

Closes #2359.


----

#