### PR TITLE
[lsp-rf]: Use globstar in default glob vector

### DIFF
--- a/clients/lsp-rf.el
+++ b/clients/lsp-rf.el
@@ -90,7 +90,7 @@
 (defun parse-rf-language-server-include-path-regex (vector)
   "Creates regexp to select files from workspace directory."
   (let ((globs (if (eq vector [])
-                        ["*.robot" "*.resource"]
+                        ["**/*.robot" "**/*.resource"]
                       vector)))
     (parse-rf-language-server-globs-to-regex globs)))
 


### PR DESCRIPTION
Our glob conversion wraps the produced regexps with beginning- and
end-of-string meta-characters, so this is necessary for the produced
regexps to pick anything up.


----

#