### PR TITLE
Add `lsp-rust-analyzer-rust-src-path` to lsp-rust

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -11,6 +11,7 @@
   * Automatically download [[https://github.com/eclipse/lemminx][XML language server Lemminx]]
   * Add Vala support.
   * Add [[https://github.com/sorbet/sorbet][Sorbet Language Server]] for typechecking Ruby code.
+  * Added ~lsp-rust-analyzer-rust-src-path~
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -491,6 +491,12 @@ The command should include `--message=format=json` or similar option."
   :group 'lsp-rust
   :package-version '(lsp-mode . "7.1.0"))
 
+(defcustom lsp-rust-analyzer-rust-src-path nil
+  "The location of the rust-src component or checkout of the rust standard library source. The location should should contain a `core' directory."
+  :type 'string
+  :group 'lsp-rust
+  :package-version '(lsp-mode . "7.1.0"))
+
 (defun lsp-rust-analyzer--make-init-options ()
   "Init options for rust-analyzer"
   `(:diagnostics (:enable ,(lsp-json-bool lsp-rust-analyzer-diagnostics-enable)
@@ -629,6 +635,8 @@ The command should include `--message=format=json` or similar option."
                             "rust-analyzer")
                        ,@(cl-rest lsp-rust-analyzer-server-args))))
   :major-modes '(rust-mode rustic-mode)
+  :environment-fn (lambda ()
+                    '(("RUST_SRC_PATH" . lsp-rust-analyzer-rust-src-path)))
   :priority (if (eq lsp-rust-server 'rust-analyzer) 1 -1)
   :initialization-options 'lsp-rust-analyzer--make-init-options
   :notification-handlers (ht<-alist lsp-rust-notification-handlers)


### PR DESCRIPTION
`lsp-rust-analyzer-rust-src-path` allows users to hint to the the rust-analyzer
client where it can find the standard library if they have installed it through
a means other than `rustup`.