### PR TITLE
Bugfix/lsp lens support check

### DIFF
--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -344,8 +344,6 @@ CALLBACK - callback for the lenses."
   :lighter "Lens"
   (cond
    (lsp-lens-mode
-    (add-hook 'lsp-configure-hook #'lsp-lens--enable nil t)
-    (add-hook 'lsp-unconfigure-hook #'lsp-lens--disable nil t)
     (add-hook 'lsp-on-idle-hook #'lsp-lens--idle-function nil t)
     (add-hook 'lsp-on-change-hook (lambda () (lsp-lens--schedule-refresh t)) nil t)
     (add-hook 'after-save-hook (lambda () (lsp-lens--schedule-refresh t)) nil t)
@@ -353,8 +351,6 @@ CALLBACK - callback for the lenses."
     (lsp-lens-refresh t))
    (t
     (lsp-lens-hide)
-    (remove-hook 'lsp-configure-hook #'lsp-lens--enable t)
-    (remove-hook 'lsp-unconfigure-hook #'lsp-lens--disable t)
     (remove-hook 'lsp-on-idle-hook #'lsp-lens--idle-function t)
     (remove-hook 'lsp-on-change-hook (lambda () (lsp-lens--schedule-refresh nil)) t)
     (remove-hook 'after-save-hook (lambda () (lsp-lens--schedule-refresh t)) t)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6729,7 +6729,7 @@ returns the command to execute."
   (when lsp-modeline-workspace-status-enable
     (add-hook 'lsp-configure-hook 'lsp-modeline-workspace-status-mode))
   (when lsp-lens-enable
-    (add-hook 'lsp-configure-hook 'lsp-lens-mode))
+    (add-hook 'lsp-configure-hook 'lsp-lens--enable))
 
   ;; yas-snippet config
   (setq-local yas-inhibit-overlay-modification-protection t))


### PR DESCRIPTION
- In `lsp--auto-configure`: add `lsp--lens-enable` instead of `lsp-lens-mode`, so that the latter won't be enabled for servers that don't support lenses. Unlike stated in the commit messages, this doesn't error. The errors were either fixed for some other reason or caused by a broken environment of mine.
- `lsp-lens-mode` can now be disabled, without the lenses reappearing shortly thereafter.