### PR TITLE
Add lsp-gunzip function to decompress gzipped files

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7201,7 +7201,7 @@ nil."
            (:gzip (concat store-path ".gz"))
            (:zip (concat store-path ".zip"))
            (`nil store-path)
-            (_ (error ":decompress must be `:gzip', `:zip' or `nil'")))))
+           (_ (error ":decompress must be `:gzip', `:zip' or `nil'")))))
     (make-thread
      (lambda ()
        (condition-case err

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7201,7 +7201,7 @@ nil."
            (:gzip (concat store-path ".gz"))
            (:zip (concat store-path ".zip"))
            (`nil store-path)
-           (_ (error ":decompress must be `gzip', `zip' or `nil'")))))
+            (_ (error ":decompress must be `:gzip', `:zip' or `nil'")))))
     (make-thread
      (lambda ()
        (condition-case err

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7198,8 +7198,8 @@ nil."
          ;; (decompress (lsp-resolve-value decompress))
          (download-path
           (pcase decompress
-           (`gzip (concat store-path ".gz"))
-           (`zip (concat store-path ".zip"))
+           (:gzip (concat store-path ".gz"))
+           (:zip (concat store-path ".zip"))
            (`nil store-path)
            (_ (error ":decompress must be `gzip', `zip' or `nil'")))))
     (make-thread
@@ -7215,8 +7215,8 @@ nil."
              (when decompress
                (lsp--info "Decompressing %s..." download-path)
                (pcase decompress
-                 (`gzip (lsp-gunzip download-path))
-                 (`zip (lsp-unzip download-path store-path)))
+                 (:gzip (lsp-gunzip download-path))
+                 (:zip (lsp-unzip download-path store-path)))
                (lsp--info "Decompressed %s..." store-path))
              (funcall callback))
          (error (funcall error-callback err)))))))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7192,19 +7192,32 @@ nil."
 
 
 ;; Download URL handling
-(cl-defun lsp-download-install (callback error-callback &key url store-path &allow-other-keys)
-  (let ((url (lsp-resolve-value url))
-        (store-path (lsp-resolve-value store-path)))
+(cl-defun lsp-download-install (callback error-callback &key url store-path decompress &allow-other-keys)
+  (let* ((url (lsp-resolve-value url))
+         (store-path (lsp-resolve-value store-path))
+         ;; (decompress (lsp-resolve-value decompress))
+         (download-path
+          (pcase decompress
+           (`gzip (concat store-path ".gz"))
+           (`zip (concat store-path ".zip"))
+           (`nil store-path)
+           (_ (error ":decompress must be `gzip', `zip' or `nil'")))))
     (make-thread
      (lambda ()
        (condition-case err
            (progn
-             (when (f-exists? store-path)
-               (f-delete store-path))
-             (lsp--info "Starting to download %s to %s..." url store-path)
-             (mkdir (f-parent store-path) t)
-             (url-copy-file url store-path)
-             (lsp--info "Finished downloading %s..." store-path)
+             (when (f-exists? download-path)
+               (f-delete download-path))
+             (lsp--info "Starting to download %s to %s..." url download-path)
+             (mkdir (f-parent download-path) t)
+             (url-copy-file url download-path)
+             (lsp--info "Finished downloading %s..." download-path)
+             (when decompress
+               (lsp--info "Decompressing %s..." download-path)
+               (pcase decompress
+                 (`gzip (lsp-gunzip download-path))
+                 (`zip (lsp-unzip download-path store-path)))
+               (lsp--info "Decompressed %s..." store-path))
              (funcall callback))
          (error (funcall error-callback err)))))))
 
@@ -7243,7 +7256,24 @@ STORE-PATH to make it executable."
   (unless lsp-unzip-script
     (error "Unable to find `unzip' or `powershell' on the path, please customize `lsp-unzip-script'"))
   (shell-command (format lsp-unzip-script zip-file dest)))
+
+;; gunzip
 
+(defconst lsp-ext-gunzip-script "gzip -d %1$s"
+  "Script to decompress a gzippped file with gzip.")
+
+(defcustom lsp-gunzip-script (cond ((executable-find "gzip") lsp-ext-gunzip-script)
+                                   (t nil))
+  "The script to decompress a gzipped file. Should be a format string with one argument for the file to be decompressed in place."
+  :group 'lsp-mode
+  :type 'string
+  :package-version '(lsp-mode . "7.1"))
+
+(defun lsp-gunzip (gz-file)
+  "Decompress file in place."
+  (unless lsp-gunzip-script
+    (error "Unable to find `gzip' on the path, please customize `lsp-gunzip-script'"))
+  (shell-command (format lsp-gunzip-script gz-file)))
 
 ;; VSCode marketplace
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -40,6 +40,7 @@
 (require 'ht)
 (require 'imenu)
 (require 'inline)
+(require 'jka-compr)
 (require 'json)
 (require 'lv)
 (require 'markdown-mode)
@@ -7215,7 +7216,8 @@ nil."
              (when decompress
                (lsp--info "Decompressing %s..." download-path)
                (pcase decompress
-                 (:gzip (lsp-gunzip download-path))
+                 (:gzip
+                  (lsp-gunzip download-path))
                  (:zip (lsp-unzip download-path store-path)))
                (lsp--info "Decompressed %s..." store-path))
              (funcall callback))
@@ -7272,7 +7274,7 @@ STORE-PATH to make it executable."
 (defun lsp-gunzip (gz-file)
   "Decompress file in place."
   (unless lsp-gunzip-script
-    (error "Unable to find `gzip' on the path, please customize `lsp-gunzip-script'"))
+    (error "Unable to find `gzip' on the path, please either customize `lsp-gunzip-script' or manually decompress %s" gz-file))
   (shell-command (format lsp-gunzip-script gz-file)))
 
 ;; VSCode marketplace


### PR DESCRIPTION
Also add the `:decompress` argument to lsp-download-install so that dependencies can decompress themselves.
My main use case is to be able to download binaries for `lsp-haskell.el`, which has the binaries compressed with gzip. This way we can use dependencies like:

```elisp
(lsp-dependency
 'haskell-language-server-wrapper
 '(:system "haskell-language-server-wrapper")
 `(:download :url ,(concat lsp-haskell-language-server-github-releases-url
			  (format "haskell-language-server-wrapper-%s.gz"
				  (lsp-haskell--github-system-type-suffix)))
	     :store-path ,(f-join lsp-server-install-dir "haskell" "haskell-language-server-wrapper")
	     :decompress :gzip
	     :set-executable? t))
```

So far I haven't add a script for windows Powershell yet, as I don't have a windows machine to test this on.