### PR TITLE
Add support for Steep (Ruby type checker)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -13,6 +13,7 @@
   * Add [[https://github.com/sorbet/sorbet][Sorbet Language Server]] for typechecking Ruby code.
   * Add Elixir test lenses support.
   * Enable headerline breadcrumb by default
+  * Add [[https://github.com/soutaro/steep][Steep Language Server]] for typechecking Ruby code.
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/clients/lsp-steep.el
+++ b/clients/lsp-steep.el
@@ -1,0 +1,65 @@
+;;; lsp-steep.el --- lsp-mode for Steep  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020  Masafumi Koba
+
+;; Author: Masafumi Koba <ybiquitous@gmail.com>
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP client for Steep which is a Ruby type checker.
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-steep nil
+  "LSP support for Steep, using the Steep language server."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/soutaro/steep"))
+
+(defcustom lsp-steep-log-level "warn"
+  "Log level of Steep."
+  :type '(choice
+          (const "fatal")
+          (const "error")
+          (const "warn")
+          (const "info")
+          (const "debug"))
+  :group 'lsp-steep)
+
+(defcustom lsp-steep-use-bundler t
+  "Run Steep using Bunder."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'lsp-steep)
+
+(defun lsp-steep--build-command ()
+  "Build a command to start the Steep language server."
+  (append
+    (if lsp-steep-use-bundler '("bundle" "exec"))
+    '("steep" "langserver")
+    (list (concat "--log-level=" lsp-steep-log-level))))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection #'lsp-steep--build-command)
+  :major-modes '(ruby-mode enh-ruby-mode)
+  :priority -3
+  :server-id 'steep-ls))
+
+(provide 'lsp-steep)
+;;; lsp-steep.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -485,6 +485,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "steep",
+    "full-name": "Ruby (Steep)",
+    "server-name": "steep",
+    "server-url": "https://github.com/soutaro/steep",
+    "installation": "gem install steep",
+    "debugger": "Not available"
+  },
+  {
     "name": "svelte",
     "full-name": "Svelte",
     "server-name": "svelteserver",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -355,7 +355,7 @@ unless overridden by a more specific face association."
          lsp-kotlin lsp-lua lsp-nim lsp-nix lsp-metals lsp-ocaml lsp-perl lsp-php lsp-pwsh
          lsp-pyls lsp-python-ms lsp-purescript lsp-r lsp-rf lsp-rust lsp-solargraph lsp-sorbet
          lsp-tex lsp-terraform lsp-vala lsp-verilog lsp-vetur lsp-vhdl lsp-vimscript lsp-xml
-         lsp-yaml lsp-sqls lsp-svelte)
+         lsp-yaml lsp-sqls lsp-svelte lsp-steep)
   "List of the clients to be automatically required."
   :group 'lsp-mode
   :type '(repeat symbol))


### PR DESCRIPTION
[Steep](https://github.com/soutaro/steep) is a Ruby static type checker created by soutaro who is a Ruby committer and the main developer of [RBS](https://github.com/ruby/rbs).

Steep has its own language server implementation and he has created the VSCode extension for Steep.
See <https://github.com/soutaro/steep#ides>.