### PR TITLE
Add the ability to run elixir tests from test lenses

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -11,6 +11,7 @@
   * Automatically download [[https://github.com/eclipse/lemminx][XML language server Lemminx]]
   * Add Vala support.
   * Add [[https://github.com/sorbet/sorbet][Sorbet Language Server]] for typechecking Ruby code.
+  * Add Elixir test lenses support.
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/clients/lsp-elixir.el
+++ b/clients/lsp-elixir.el
@@ -129,7 +129,8 @@ finding the executable with `exec-path'."
       "mix test --exclude test --include "
       test-command
       " "
-      file-path))
+      file-path
+      " --no-color"))
     file-path))
 
 (lsp-register-custom-settings

--- a/clients/lsp-elixir.el
+++ b/clients/lsp-elixir.el
@@ -100,6 +100,38 @@ finding the executable with `exec-path'."
   :group 'lsp-elixir
   :type 'file)
 
+(defcustom lsp-elixir-enable-test-lenses t
+  "Suggest Tests."
+  :type 'boolean
+  :group 'lsp-elixir
+  :package-version '(lsp-mode . "7.1"))
+
+(defun lsp-elixir--build-test-command (argument)
+  "Builds the test command from the ARGUMENT."
+  (let ((test-name (gethash "testName" argument))
+        (module (gethash "module" argument))
+        (describe (gethash "describe" argument)))
+    (cond (module (concat "\"" "module:" module "\""))
+          ((not test-name) (concat "\"" "describe:" describe "\""))
+          (describe (concat "\"" "test:test " describe " " test-name "\"" ))
+          (t (concat "\"" "test:test " test-name "\"" )))))
+
+(lsp-defun lsp-elixir--run-test ((&Command :arguments?))
+  "Runs tests."
+  (let* ((argument (lsp-seq-first arguments?))
+         (file-path (gethash "filePath" argument))
+         (test-command (lsp-elixir--build-test-command argument)))
+    (compile
+     (concat
+      "cd "
+      (lsp-workspace-root file-path)
+      " && "
+      "mix test --exclude test --include "
+      test-command
+      " "
+      file-path))
+    file-path))
+
 (lsp-register-custom-settings
  '(("elixirLS.dialyzerEnabled" lsp-elixir-dialyzer-enabled t)
    ("elixirLS.dialyzerWarnOpts" lsp-elixir-dialyzer-warn-opts)
@@ -109,13 +141,15 @@ finding the executable with `exec-path'."
    ("elixirLS.projectDir" lsp-elixir-project-dir)
    ("elixirLS.fetchDeps" lsp-elixir-fetch-deps t)
    ("elixirLS.suggestSpecs" lsp-elixir-suggest-specs t)
-   ("elixirLS.signatureAfterComplete" lsp-elixir-signature-after-complete t)))
+   ("elixirLS.signatureAfterComplete" lsp-elixir-signature-after-complete t)
+   ("elixirLS.enableTestLenses" lsp-elixir-enable-test-lenses t)))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda () `(,lsp-clients-elixir-server-executable)))
                   :major-modes '(elixir-mode)
                   :priority -1
                   :server-id 'elixir-ls
+                  :action-handlers (ht ("elixir.lens.test.run" 'lsp-elixir--run-test))
                   :initialized-fn (lambda (workspace)
                                     (with-lsp-workspace workspace
                                       (lsp--set-configuration

--- a/clients/lsp-elixir.el
+++ b/clients/lsp-elixir.el
@@ -108,9 +108,9 @@ finding the executable with `exec-path'."
 
 (defun lsp-elixir--build-test-command (argument)
   "Builds the test command from the ARGUMENT."
-  (let ((test-name (gethash "testName" argument))
-        (module (gethash "module" argument))
-        (describe (gethash "describe" argument)))
+  (let ((test-name (lsp-get argument :testName))
+        (module (lsp-get argument :module))
+        (describe (lsp-get argument :describe)))
     (cond (module (concat "\"" "module:" module "\""))
           ((not test-name) (concat "\"" "describe:" describe "\""))
           (describe (concat "\"" "test:test " describe " " test-name "\"" ))
@@ -119,18 +119,12 @@ finding the executable with `exec-path'."
 (lsp-defun lsp-elixir--run-test ((&Command :arguments?))
   "Runs tests."
   (let* ((argument (lsp-seq-first arguments?))
-         (file-path (gethash "filePath" argument))
+         (file-path (lsp-get argument :filePath))
          (test-command (lsp-elixir--build-test-command argument)))
     (compile
-     (concat
-      "cd "
-      (lsp-workspace-root file-path)
-      " && "
-      "mix test --exclude test --include "
-      test-command
-      " "
-      file-path
-      " --no-color"))
+     (concat "cd " (lsp-workspace-root file-path) " && "
+             "mix test --exclude test --include " test-command " " file-path
+             " --no-color"))
     file-path))
 
 (lsp-register-custom-settings


### PR DESCRIPTION
Tests running code lenses are now provided by elixir-lsp https://github.com/elixir-lsp/elixir-ls/pull/389 and implemented for vscode https://github.com/elixir-lsp/vscode-elixir-ls/pull/155. 

This adds the ability to switch on elixir test lenses and will run the tests using the compile function. 

![test-lens-preview](https://user-images.githubusercontent.com/1431483/102135837-395bcf00-3e61-11eb-8fc5-4abbbf9b79b5.gif)
