### PR TITLE
lsp-lua.el: Fix lua-lsp connection commands are unchangable

### DIFF
--- a/clients/lsp-lua.el
+++ b/clients/lsp-lua.el
@@ -71,7 +71,7 @@
 
 (lsp-register-client
  (make-lsp-client
-  :new-connection (lsp-stdio-connection lsp-clients-emmy-lua-command
+  :new-connection (lsp-stdio-connection (lambda () lsp-clients-emmy-lua-command)
                                         #'lsp-clients-emmy-lua-test)
   :major-modes '(lua-mode)
   :server-id 'emmy-lua
@@ -363,7 +363,7 @@ The following example shows loaded files in `C:/lua` and `../lib` ,exclude `../l
 
 (lsp-register-client
  (make-lsp-client
-  :new-connection (lsp-stdio-connection lsp-clients-lua-language-server-command
+  :new-connection (lsp-stdio-connection (lambda () lsp-clients-lua-language-server-command)
                                         #'lsp-clients-lua-language-server-test)
   :major-modes '(lua-mode)
   :priority -2
@@ -397,7 +397,7 @@ The following example shows loaded files in `C:/lua` and `../lib` ,exclude `../l
 
 (lsp-register-client
  (make-lsp-client
-  :new-connection (lsp-stdio-connection lsp-clients-lua-lsp-server-install-dir
+  :new-connection (lsp-stdio-connection (lambda () lsp-clients-lua-lsp-server-install-dir)
                                         #'lsp-clients-lua-lsp-test)
   :major-modes '(lua-mode)
   :priority -3


### PR DESCRIPTION
Currently the commands for lua-lsp is inited once, while it should sensitive for custom settings changes and applied in new-connection.
Here I just follow python-lsp, wrapping the commands into lambda function for :new-connection, then lua-lsp will work as expect when customer change the lsp-commands.
Python lsp-pyls: https://github.com/emacs-lsp/lsp-mode/blob/d788a13b26289d3bd88dc07f3e2e9c3c3d1fdf9d/clients/lsp-pyls.el#L473-L474.