### PR TITLE
[feature] Add hooks to run after text edit

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Release 7.1
+  * Add ~lsp-auto-save-changed-buffers~ which save the changed buffers after any text edit operation by lsp-mode.
   * Safe renamed ~lsp-diagnose~ to ~lsp-doctor~.
   * Add ~lsp-modeline-code-actions-segments~ for a better customization.
   * Add [[https://github.com/sumneko/lua-language-server][Lua Language Server]], [[https://github.com/Alloyed/lua-lsp][Lua-LSP]] and improve EmmyLua.

--- a/clients/lsp-css.el
+++ b/clients/lsp-css.el
@@ -231,7 +231,7 @@ server."
 ;;; CSS
 (lsp-defun lsp-css--apply-code-action ((&Command :arguments?))
   "Apply ACTION as workspace edit command."
-  (lsp--apply-text-edits (cl-caddr arguments?)))
+  (lsp--apply-text-edits (cl-caddr arguments?) 'code-action))
 
 (lsp-dependency 'css-languageserver
                 '(:system "css-languageserver")

--- a/clients/lsp-pwsh.el
+++ b/clients/lsp-pwsh.el
@@ -272,7 +272,7 @@ Must not nil.")
              (edits `[,(lsp-make-text-edit :range (lsp-make-range :start start-position
                                                                   :end end-position)
                                            :newText text)]))
-      (lsp--apply-text-edits edits)
+      (lsp--apply-text-edits edits 'code-action)
     (lsp-send-execute-command command arguments?)))
 
 (lsp-defun lsp-pwsh--show-code-action-document ((&Command :arguments?))

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -586,7 +586,7 @@ The command should include `--message=format=json` or similar option."
                                       (lsp--region-to-range (region-beginning) (region-end))
                                     (lsp--region-to-range (point) (point))))))
          (result (lsp-send-request (lsp-make-request "experimental/joinLines" params))))
-    (lsp--apply-text-edits result)))
+    (lsp--apply-text-edits result 'code-action)))
 
 (defcustom lsp-rust-analyzer-download-url
   (format "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/%s"

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -530,7 +530,7 @@ Others: CANDIDATES"
         (when lsp-completion-enable-additional-text-edit
           (if (or (get-text-property 0 'lsp-completion-resolved candidate)
                   additional-text-edits?)
-              (lsp--apply-text-edits additional-text-edits?)
+              (lsp--apply-text-edits additional-text-edits? 'completion)
             (-let [(callback cleanup-fn) (lsp--create-apply-text-edits-handlers)]
               (lsp-completion--resolve-async
                item

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -664,6 +664,13 @@ If this is set to nil, `eldoc' will show only the symbol information."
   :type 'boolean
   :group 'lsp-mode)
 
+(defcustom lsp-auto-save-changed-buffers nil
+  "If non-nil, `lsp-mode' will save the buffer after apply text edits.
+Useful for multiple file changes like `lsp-rename`"
+  :type 'boolean
+  :group 'lsp-mode
+  :package-version '(lsp-mode . "7.1"))
+
 (defcustom lsp-modeline-code-actions-enable t
   "Whether to show code actions on modeline."
   :type 'boolean
@@ -4056,7 +4063,9 @@ LSP server result."
                            (-when-let ((&SnippetTextEdit :range (&RangeToPoint :start)
                                                          :insert-text-format? :new-text) edit)
                              (when (eq insert-text-format? lsp/insert-text-format-snippet)
-                               (lsp--expand-snippet new-text start (+ start (length new-text)))))))))
+                               (lsp--expand-snippet new-text start (+ start (length new-text))))))
+                         (when lsp-auto-save-changed-buffers
+                           (save-buffer)))))
           (undo-amalgamate-change-group change-group)
           (progress-reporter-done reporter))))))
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -664,7 +664,7 @@ If this is set to nil, `eldoc' will show only the symbol information."
   :type 'boolean
   :group 'lsp-mode)
 
-(defcustom lsp-text-edit-applied-hook nil
+(defcustom lsp-after-apply-edits-hook nil
   "Hooks to run when text edit is applied.
 It contains the operation source."
   :type 'hook
@@ -3854,8 +3854,7 @@ in that particular folder."
 (defun lsp--apply-workspace-edit (workspace-edit &optional operation)
   "Apply the WorkspaceEdit object WORKSPACE-EDIT.
 OPERATION is symbol representing the source of this text edit."
-  (let ((document-changes? (lsp:workspace-edit-document-changes? workspace-edit))
-        (changes? (lsp:workspace-edit-changes? workspace-edit)))
+  (-let (((&WorkspaceEdit :document-changes? :changes?) workspace-edit))
     (if-let ((document-changes (seq-reverse document-changes?)))
         (progn
           (lsp--check-document-changes-version document-changes)
@@ -4069,7 +4068,7 @@ OPERATION is symbol representing the source of this text edit."
                                                          :insert-text-format? :new-text) edit)
                              (when (eq insert-text-format? lsp/insert-text-format-snippet)
                                (lsp--expand-snippet new-text start (+ start (length new-text))))))
-                         (run-hook-with-args 'lsp-text-edit-applied-hook operation))))
+                         (run-hook-with-args 'lsp-after-apply-edits-hook operation))))
           (undo-amalgamate-change-group change-group)
           (progress-reporter-done reporter))))))
 

--- a/test/lsp-methods-test.el
+++ b/test/lsp-methods-test.el
@@ -206,7 +206,8 @@ private void extracted() {
          (actual (with-temp-buffer
                    (insert input)
                    (lsp--apply-text-edits
-                    (lsp--read-json lsp-methods-test--changes))
+                    (lsp--read-json lsp-methods-test--changes)
+                    'test)
                    (buffer-string))))
     (should (string= actual expected))))
 
@@ -217,7 +218,8 @@ private void extracted() {
      (lsp-make-workspace-edit
       :document-changes?
       `[,(lsp-make-create-file :uri (lsp--path-to-uri new-file-name)
-                               :kind "create")]))
+                               :kind "create")])
+     'test)
     (should (f-exists? new-file-name)))
   (let ((new-file-name (make-temp-file "should be overridden")))
     (f-write-text "should be overridden" nil new-file-name)
@@ -226,7 +228,8 @@ private void extracted() {
       :document-changes?
       `[,(lsp-make-create-file :uri (lsp--path-to-uri new-file-name)
                                :kind "create"
-                               :options? (lsp-make-create-file-options :overwrite? t))]))
+                               :options? (lsp-make-create-file-options :overwrite? t))])
+     'test)
     (should (equal (f-read-text new-file-name) "")))
   (let ((new-file-name (make-temp-file "should not be overridden")))
     (f-write-text "text" nil new-file-name)
@@ -235,7 +238,8 @@ private void extracted() {
       :document-changes?
       `[,(lsp-make-create-file :uri (lsp--path-to-uri new-file-name)
                                :kind "create"
-                               :options? (lsp-make-create-file-options :overwrite? nil))]))
+                               :options? (lsp-make-create-file-options :overwrite? nil))])
+     'test)
     (should (equal (f-read-text new-file-name) "text")))
   ;; nested file without parent dir
   (let ((new-file-name (make-temp-file "new")))
@@ -245,7 +249,8 @@ private void extracted() {
      (lsp-make-workspace-edit
       :document-changes?
       `[,(lsp-make-create-file :uri (lsp--path-to-uri new-file-name)
-                               :kind "create")]))
+                               :kind "create")])
+     'test)
     (should (f-exists? new-file-name))))
 
 (ert-deftest lsp-delete-test ()
@@ -254,7 +259,8 @@ private void extracted() {
      (lsp-make-workspace-edit
       :document-changes?
       `[,(lsp-make-delete-file :uri (lsp--path-to-uri delete-file-name)
-                               :kind "delete")]))
+                               :kind "delete")])
+     'test)
     (should-not (f-exists? delete-file-name))))
 
 (ert-deftest lsp-update-test ()
@@ -268,7 +274,8 @@ private void extracted() {
       :document-changes?
       `[,(lsp-make-rename-file :old-uri (lsp--path-to-uri old-file-name)
                                :new-uri (lsp--path-to-uri new-file-name)
-                               :kind "rename")]))
+                               :kind "rename")])
+     'test)
     (should-not (f-exists? old-file-name))
     (should (f-exists? new-file-name)))
 
@@ -284,7 +291,8 @@ private void extracted() {
       `[,(lsp-make-rename-file :old-uri (lsp--path-to-uri old-file-name)
                                :new-uri (lsp--path-to-uri new-file-name)
                                :kind "rename"
-                               :options? (lsp-make-rename-file-options :overwrite? t))]))
+                               :options? (lsp-make-rename-file-options :overwrite? t))])
+     'test)
     (should-not (f-exists? old-file-name))
     (should (f-exists? new-file-name)))
 
@@ -299,7 +307,8 @@ private void extracted() {
       :document-changes?
       `[,(lsp-make-rename-file :old-uri (lsp--path-to-uri old-file-name)
                                :new-uri (lsp--path-to-uri new-file-name)
-                               :kind "rename")]))
+                               :kind "rename")])
+     'test)
     (should-not (f-exists? old-file-name))
     (should (f-exists? new-file-name))))
 

--- a/test/lsp-methods-test.el
+++ b/test/lsp-methods-test.el
@@ -206,8 +206,7 @@ private void extracted() {
          (actual (with-temp-buffer
                    (insert input)
                    (lsp--apply-text-edits
-                    (lsp--read-json lsp-methods-test--changes)
-                    'test)
+                    (lsp--read-json lsp-methods-test--changes))
                    (buffer-string))))
     (should (string= actual expected))))
 
@@ -218,8 +217,7 @@ private void extracted() {
      (lsp-make-workspace-edit
       :document-changes?
       `[,(lsp-make-create-file :uri (lsp--path-to-uri new-file-name)
-                               :kind "create")])
-     'test)
+                               :kind "create")]))
     (should (f-exists? new-file-name)))
   (let ((new-file-name (make-temp-file "should be overridden")))
     (f-write-text "should be overridden" nil new-file-name)
@@ -228,8 +226,7 @@ private void extracted() {
       :document-changes?
       `[,(lsp-make-create-file :uri (lsp--path-to-uri new-file-name)
                                :kind "create"
-                               :options? (lsp-make-create-file-options :overwrite? t))])
-     'test)
+                               :options? (lsp-make-create-file-options :overwrite? t))]))
     (should (equal (f-read-text new-file-name) "")))
   (let ((new-file-name (make-temp-file "should not be overridden")))
     (f-write-text "text" nil new-file-name)
@@ -238,8 +235,7 @@ private void extracted() {
       :document-changes?
       `[,(lsp-make-create-file :uri (lsp--path-to-uri new-file-name)
                                :kind "create"
-                               :options? (lsp-make-create-file-options :overwrite? nil))])
-     'test)
+                               :options? (lsp-make-create-file-options :overwrite? nil))]))
     (should (equal (f-read-text new-file-name) "text")))
   ;; nested file without parent dir
   (let ((new-file-name (make-temp-file "new")))
@@ -249,8 +245,7 @@ private void extracted() {
      (lsp-make-workspace-edit
       :document-changes?
       `[,(lsp-make-create-file :uri (lsp--path-to-uri new-file-name)
-                               :kind "create")])
-     'test)
+                               :kind "create")]))
     (should (f-exists? new-file-name))))
 
 (ert-deftest lsp-delete-test ()
@@ -259,8 +254,7 @@ private void extracted() {
      (lsp-make-workspace-edit
       :document-changes?
       `[,(lsp-make-delete-file :uri (lsp--path-to-uri delete-file-name)
-                               :kind "delete")])
-     'test)
+                               :kind "delete")]))
     (should-not (f-exists? delete-file-name))))
 
 (ert-deftest lsp-update-test ()
@@ -274,8 +268,7 @@ private void extracted() {
       :document-changes?
       `[,(lsp-make-rename-file :old-uri (lsp--path-to-uri old-file-name)
                                :new-uri (lsp--path-to-uri new-file-name)
-                               :kind "rename")])
-     'test)
+                               :kind "rename")]))
     (should-not (f-exists? old-file-name))
     (should (f-exists? new-file-name)))
 
@@ -291,8 +284,7 @@ private void extracted() {
       `[,(lsp-make-rename-file :old-uri (lsp--path-to-uri old-file-name)
                                :new-uri (lsp--path-to-uri new-file-name)
                                :kind "rename"
-                               :options? (lsp-make-rename-file-options :overwrite? t))])
-     'test)
+                               :options? (lsp-make-rename-file-options :overwrite? t))]))
     (should-not (f-exists? old-file-name))
     (should (f-exists? new-file-name)))
 
@@ -307,8 +299,7 @@ private void extracted() {
       :document-changes?
       `[,(lsp-make-rename-file :old-uri (lsp--path-to-uri old-file-name)
                                :new-uri (lsp--path-to-uri new-file-name)
-                               :kind "rename")])
-     'test)
+                               :kind "rename")]))
     (should-not (f-exists? old-file-name))
     (should (f-exists? new-file-name))))
 


### PR DESCRIPTION
Every time I `lsp-rename` a symbol, I need to check other buffers and save them to make the code consistent and fix lsp errors, for that, I use this advice for months as a workaround:
```elisp
 (advice-add #'lsp-rename :after (lambda (&rest _) (projectile-save-project-buffers)))
```

It looks to me a good option to add this to `lsp-mode`, making it optional for users that wants this same behavior.

I know emacs user doesn't like things changing buffers automatically, but IMO it looks IDE like feature, also I'm adding it with the default as `false`.

This works too for formatting buffers, which is recommended for some languages like Dart