### PR TITLE
[headerline] Fix icon when it uses font instead of display

### DIFF
--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -143,15 +143,18 @@ caching purposes.")
 (defun lsp-headerline--fix-image-background (image)
   "Fix IMAGE background if it is a file otherwise return as an icon."
   (if image
-      (let ((display-image (get-text-property 0 'display image)))
-        (if (listp display-image)
+      (let* ((display-image (get-text-property 0 'display image)))
+        (if (and (listp display-image)
+                 (plist-member (cl-copy-list (cl-rest display-image)) :type))
             (propertize " " 'display
                         (cl-list* 'image
                                   (plist-put
                                    (cl-copy-list
                                     (cl-rest display-image))
                                    :background (face-attribute 'header-line :background nil t))))
-          (replace-regexp-in-string "\s\\|\t" "" display-image)))
+          (if (stringp display-image)
+              (replace-regexp-in-string "\s\\|\t" "" display-image)
+            (replace-regexp-in-string "\s\\|\t" "" image))))
     ""))
 
 (defun lsp-headerline--arrow-icon ()
@@ -286,7 +289,7 @@ PATH is the current folder to be checked."
 
 
 (defun lsp-headerline--face-for-path (dir)
-  "Calculate the face for PATH."
+  "Calculate the face for DIR."
   (if-let ((diags (lsp-diagnostics-stats-for (directory-file-name dir))))
       (cl-labels ((check-severity
                    (severity)
@@ -306,7 +309,7 @@ PATH is the current folder to be checked."
     'lsp-headerline-breadcrumb-path-face))
 
 (defun lsp-headerline--severity-level-for-range (range)
-  "Get the severiy level for "
+  "Get the severiy level for RANGE."
   (let ((range-severity 10))
     (mapc (-lambda ((&Diagnostic :range (&Range :start) :severity?))
             (when (lsp-point-in-range? start range)

--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -143,7 +143,7 @@ caching purposes.")
 (defun lsp-headerline--fix-image-background (image)
   "Fix IMAGE background if it is a file otherwise return as an icon."
   (if image
-      (let* ((display-image (get-text-property 0 'display image)))
+      (let ((display-image (get-text-property 0 'display image)))
         (if (and (listp display-image)
                  (plist-member (cl-copy-list (cl-rest display-image)) :type))
             (propertize " " 'display


### PR DESCRIPTION
Fix #2421

It seems that happens for all-the-icons icons that use font instead of display images

Before:
```elisp
Debugger entered--Lisp error: (wrong-type-argument plistp (-0.18))
  plist-put((-0.18) :background "#282c34")
  lsp-headerline--fix-image-background(#(" " 0 1 (rear-nonsticky t display (raise -0.18) font-lock-face (:family "Material Icons" :height 1.14 :inherit all-the-icons-orange) face (:family "Material Icons" :height 1.14 :inherit all-the-icons-orange))))
  lsp-headerline--symbol-icon(#<hash-table equal 5/5 0x1ff5a4ab3a67>)
  #f(compiled-function (input0) #<bytecode -0xd7026fa7e369655>)((#<hash-table equal 5/5 0x1ff5a4ab3a67> . 1))
  mapconcat(#f(compiled-function (input0) #<bytecode -0xd7026fa7e369655>) ((#<hash-table equal 5/5 0x1ff5a4ab3a67> . 1) (#<hash-table equal 5/5 0x1ff5a48bc279> . 2)) #("  " 1 2 (rear-nonsticky t display (raise -0.24) font-lock-face (:family "Material Icons" :height 1.2 :inherit lsp-headerline-breadcrumb-separator-face) face (:family "Material Icons" :height 1.2 :inherit lsp-headerline-breadcrumb-separator-face))))
  lsp-headerline--build-symbol-string()
  #f(compiled-function (segment) #<bytecode -0xe468cfe3a5a0e4a>)(symbols)
  mapconcat(#f(compiled-function (segment) #<bytecode -0xe468cfe3a5a0e4a>) (path-up-to-project file symbols) "")
  lsp-headerline--build-string()
  lsp-headerline--check-breadcrumb()
  run-hooks(lsp-on-idle-hook)
  lsp--on-idle(#<buffer main.py>)
  apply(lsp--on-idle #<buffer main.py>)
  timer-event-handler([t 0 0 500000 nil lsp--on-idle (#<buffer main.py>) idle 0])
  ```
  
Now this works:
```elisp
(setq my-image1 (lsp-treemacs-get-icon "edn"))
(setq my-image2 (lsp-treemacs-get-icon "clj"))
(setq my-image3 #(" " 0 1 (rear-nonsticky t display (raise -0.18) font-lock-face (:family "Material Icons" :height 1.14 :inherit all-the-icons-orange) face (:family "Material Icons" :height 1.14 :inherit all-the-icons-orange))))
```
![image](https://user-images.githubusercontent.com/7820865/102693466-8e00a080-41f9-11eb-85c8-7d8f5f4823e7.png)
