### PR TITLE
Fix lsp-vhdl executable PATH search

### DIFF
--- a/clients/lsp-vhdl.el
+++ b/clients/lsp-vhdl.el
@@ -84,7 +84,7 @@ VHDL LS: A complete VHDL language server protocol implementation with diagnostic
   (lsp-vhdl--set-server-args)
   (lsp-stdio-connection
     (lambda () (cons (plist-get lsp-vhdl--params 'server-path) (plist-get lsp-vhdl--params 'server-args)))
-    (lambda () (f-executable? (plist-get lsp-vhdl--params 'server-path)))))
+    (lambda () (executable-find (plist-get lsp-vhdl--params 'server-path)))))
 
 (defun lsp-vhdl--set-server-path()
   "Set path to server binary based on selection in lsp-vhdl-server."


### PR DESCRIPTION
Using f-executable? is not appropriate for finding the lsp-vhdl server executable, as it does not do a PATH search -- rather it just checks whether a literal file path is executable. We want to use executable-find instead, which allows lsp-mode to correctly find the server executable from the PATH.

The concrete impact of this is that the language server can be started, rather than failing with the "server is not installed, and automatic installation is not enabled" message.

From my browsing of the changelog, it seems like bugfixes this small are not recorded there. But let me know if I should update it!