### PR TITLE
[icons] Add lsp-icons to centralize icons management

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -17,6 +17,7 @@
   * Add [[https://github.com/soutaro/steep][Steep Language Server]] for typechecking Ruby code.
   * Rename semantic highlighting -> semantic tokens.
   * Add [[https://github.com/phpactor/phpactor][Phpactor Language server]]
+  * Add ~lsp-headerline-breadcrumb-icons-enable~ to disable breadcrumb icons.
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -144,11 +144,13 @@ caching purposes.")
    (setq lsp-headerline-arrow (lsp-icons-all-the-icons-material-icon
                                "chevron_right"
                                'lsp-headerline-breadcrumb-separator-face
-                               ">"))))
+                               ">"
+                               'headerline-breadcrumb))))
 
 (lsp-defun lsp-headerline--symbol-icon ((&DocumentSymbol :kind))
   "Build the SYMBOL icon for headerline breadcrumb."
-  (concat (lsp-icons-get-by-symbol-kind kind) " "))
+  (concat (lsp-icons-get-by-symbol-kind kind 'headerline-breadcrumb)
+          " "))
 
 (lsp-defun lsp-headerline--go-to-symbol ((&DocumentSymbol
                                           :selection-range (&RangeToPoint :start selection-start)
@@ -254,7 +256,7 @@ PATH is the current folder to be checked."
   (let* ((file-path (buffer-file-name))
          (filename (f-filename file-path)))
     (if-let ((file-ext (f-ext file-path)))
-        (concat (lsp-icons-get-by-file-ext file-ext)
+        (concat (lsp-icons-get-by-file-ext file-ext 'headerline-breadcrumb)
                 " "
                 (propertize filename
                             'font-lock-face

--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -21,6 +21,7 @@
 ;;
 ;;; Code:
 
+(require 'lsp-icons)
 (require 'lsp-mode)
 
 (defcustom lsp-headerline-breadcrumb-segments '(path-up-to-project file symbols)
@@ -136,42 +137,18 @@ is an hints in symbols range."
   "Holds the current breadcrumb path-up-to-project segments for
 caching purposes.")
 
-(declare-function all-the-icons-material "ext:all-the-icons" t t)
-(declare-function lsp-treemacs-symbol-icon "ext:lsp-treemacs" (kind))
-(declare-function lsp-treemacs-get-icon "ext:lsp-treemacs" (icon-name))
-
-(defun lsp-headerline--fix-image-background (image)
-  "Fix IMAGE background if it is a file otherwise return as an icon."
-  (if image
-      (let ((display-image (get-text-property 0 'display image)))
-        (if (and (listp display-image)
-                 (plist-member (cl-copy-list (cl-rest display-image)) :type))
-            (propertize " " 'display
-                        (cl-list* 'image
-                                  (plist-put
-                                   (cl-copy-list
-                                    (cl-rest display-image))
-                                   :background (face-attribute 'header-line :background nil t))))
-          (if (stringp display-image)
-              (replace-regexp-in-string "\s\\|\t" "" display-image)
-            (replace-regexp-in-string "\s\\|\t" "" image))))
-    ""))
-
 (defun lsp-headerline--arrow-icon ()
   "Build the arrow icon for headerline breadcrumb."
   (or
    lsp-headerline-arrow
-   (setq lsp-headerline-arrow
-         (if (require 'all-the-icons nil t)
-             (all-the-icons-material "chevron_right"
-                                     :face 'lsp-headerline-breadcrumb-separator-face)
-           (propertize ">" 'face 'lsp-headerline-breadcrumb-separator-face)))))
+   (setq lsp-headerline-arrow (lsp-icons-all-the-icons-material-icon
+                               "chevron_right"
+                               'lsp-headerline-breadcrumb-separator-face
+                               ">"))))
 
 (lsp-defun lsp-headerline--symbol-icon ((&DocumentSymbol :kind))
   "Build the SYMBOL icon for headerline breadcrumb."
-  (when (require 'lsp-treemacs nil t)
-    (concat (lsp-headerline--fix-image-background (lsp-treemacs-symbol-icon kind))
-            " ")))
+  (concat (lsp-icons-get-by-symbol-kind kind) " "))
 
 (lsp-defun lsp-headerline--go-to-symbol ((&DocumentSymbol
                                           :selection-range (&RangeToPoint :start selection-start)
@@ -276,11 +253,8 @@ PATH is the current folder to be checked."
   "Build the file-segment string for the breadcrumb."
   (let* ((file-path (buffer-file-name))
          (filename (f-filename file-path)))
-    (-if-let* ((file-ext (f-ext file-path))
-               (icon (and file-ext
-                          (require 'lsp-treemacs nil t)
-                          (lsp-treemacs-get-icon file-ext))))
-        (concat (lsp-headerline--fix-image-background icon)
+    (if-let ((file-ext (f-ext file-path)))
+        (concat (lsp-icons-get-by-file-ext file-ext)
                 " "
                 (propertize filename
                             'font-lock-face

--- a/lsp-icons.el
+++ b/lsp-icons.el
@@ -1,0 +1,68 @@
+;;; lsp-icons.el --- LSP icons management -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2020 emacs-lsp maintainers
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;;
+;;  LSP icons management
+;;
+;;; Code:
+
+(declare-function all-the-icons-material "ext:all-the-icons" t t)
+(declare-function lsp-treemacs-symbol-icon "ext:lsp-treemacs" (kind))
+(declare-function lsp-treemacs-get-icon "ext:lsp-treemacs" (icon-name))
+
+(defun lsp-icons--fix-image-background (image)
+  "Fix IMAGE background if it is a file otherwise return as an icon."
+  (if image
+      (let ((display-image (get-text-property 0 'display image)))
+        (if (and (listp display-image)
+                 (plist-member (cl-copy-list (cl-rest display-image)) :type))
+            (propertize " " 'display
+                        (cl-list* 'image
+                                  (plist-put
+                                   (cl-copy-list
+                                    (cl-rest display-image))
+                                   :background (face-attribute 'header-line :background nil t))))
+          (if (stringp display-image)
+              (replace-regexp-in-string "\s\\|\t" "" display-image)
+            (replace-regexp-in-string "\s\\|\t" "" image))))
+    ""))
+
+(defun lsp-icons-get-by-file-ext (file-ext)
+  "Get an icon by file FILE-EXT."
+  (when (and file-ext
+             (require 'lsp-treemacs nil t))
+    (lsp-icons--fix-image-background
+     (lsp-treemacs-get-icon file-ext))))
+
+(defun lsp-icons-get-by-symbol-kind (kind)
+  "Get an icon by symbol KIND."
+  (when (and kind
+             (require 'lsp-treemacs nil t))
+    (lsp-icons--fix-image-background
+     (lsp-treemacs-symbol-icon kind))))
+
+(defun lsp-icons-all-the-icons-material-icon (icon-name face fallback)
+  "Get a material icon from all-the-icons by ICON-NAME using FACE.
+Fallback to FALLBACK string if not found or not available."
+  (if (require 'all-the-icons nil t)
+      (all-the-icons-material icon-name
+                              :face face)
+    (propertize fallback 'face face)))
+
+(provide 'lsp-icons)
+;;; lsp-icons.el ends here

--- a/lsp-icons.el
+++ b/lsp-icons.el
@@ -21,9 +21,25 @@
 ;;
 ;;; Code:
 
+(defgroup lsp-icons nil
+  "LSP icons"
+  :group 'lsp-mode
+  :tag "Icons")
+
+(defcustom lsp-headerline-breadcrumb-icons-enable t
+  "If non-nil, icons support is enabled for headerline-breadcrumb."
+  :type 'boolean
+  :group 'lsp-icons)
+
 (declare-function all-the-icons-material "ext:all-the-icons" t t)
 (declare-function lsp-treemacs-symbol-icon "ext:lsp-treemacs" (kind))
 (declare-function lsp-treemacs-get-icon "ext:lsp-treemacs" (icon-name))
+
+(defun lsp-icons--enabled-for-feature (feature)
+  "Check if icons support is enabled for FEATURE."
+  (cond
+   ((= feature 'headerline-breadcrumb) lsp-headerline-breadcrumb-icons-enable)
+   (t t)))
 
 (defun lsp-icons--fix-image-background (image)
   "Fix IMAGE background if it is a file otherwise return as an icon."
@@ -42,24 +58,33 @@
             (replace-regexp-in-string "\s\\|\t" "" image))))
     ""))
 
-(defun lsp-icons-get-by-file-ext (file-ext)
-  "Get an icon by file FILE-EXT."
+(defun lsp-icons-get-by-file-ext (file-ext &optional feature)
+  "Get an icon by file FILE-EXT.
+FEATURE is the feature that will use the icon which we should check
+if its enabled."
   (when (and file-ext
+             (lsp-icons--enabled-for-feature feature)
              (require 'lsp-treemacs nil t))
     (lsp-icons--fix-image-background
      (lsp-treemacs-get-icon file-ext))))
 
-(defun lsp-icons-get-by-symbol-kind (kind)
-  "Get an icon by symbol KIND."
+(defun lsp-icons-get-by-symbol-kind (kind &optional feature)
+  "Get an icon by symbol KIND.
+FEATURE is the feature that will use the icon which we should check
+if its enabled."
   (when (and kind
+             (lsp-icons--enabled-for-feature feature)
              (require 'lsp-treemacs nil t))
     (lsp-icons--fix-image-background
      (lsp-treemacs-symbol-icon kind))))
 
-(defun lsp-icons-all-the-icons-material-icon (icon-name face fallback)
+(defun lsp-icons-all-the-icons-material-icon (icon-name face fallback &optional feature)
   "Get a material icon from all-the-icons by ICON-NAME using FACE.
-Fallback to FALLBACK string if not found or not available."
-  (if (require 'all-the-icons nil t)
+Fallback to FALLBACK string if not found or not available.
+FEATURE is the feature that will use the icon which we should check
+if its enabled."
+  (if (and (require 'all-the-icons nil t)
+           (lsp-icons--enabled-for-feature feature))
       (all-the-icons-material icon-name
                               :face face)
     (propertize fallback 'face face)))

--- a/lsp-icons.el
+++ b/lsp-icons.el
@@ -21,6 +21,9 @@
 ;;
 ;;; Code:
 
+(require 'lsp-treemacs nil t)
+(require 'all-the-icons nil t)
+
 (defgroup lsp-icons nil
   "LSP icons"
   :group 'lsp-mode
@@ -64,7 +67,7 @@ FEATURE is the feature that will use the icon which we should check
 if its enabled."
   (when (and file-ext
              (lsp-icons--enabled-for-feature feature)
-             (require 'lsp-treemacs nil t))
+             (featurep 'lsp-treemacs-get-icon))
     (lsp-icons--fix-image-background
      (lsp-treemacs-get-icon file-ext))))
 
@@ -74,7 +77,7 @@ FEATURE is the feature that will use the icon which we should check
 if its enabled."
   (when (and kind
              (lsp-icons--enabled-for-feature feature)
-             (require 'lsp-treemacs nil t))
+             (featurep 'lsp-treemacs-symbol-icon))
     (lsp-icons--fix-image-background
      (lsp-treemacs-symbol-icon kind))))
 
@@ -83,7 +86,7 @@ if its enabled."
 Fallback to FALLBACK string if not found or not available.
 FEATURE is the feature that will use the icon which we should check
 if its enabled."
-  (if (and (require 'all-the-icons nil t)
+  (if (and (featurep 'all-the-icons-material)
            (lsp-icons--enabled-for-feature feature))
       (all-the-icons-material icon-name
                               :face face)

--- a/lsp-icons.el
+++ b/lsp-icons.el
@@ -21,9 +21,6 @@
 ;;
 ;;; Code:
 
-(require 'lsp-treemacs nil t)
-(require 'all-the-icons nil t)
-
 (defgroup lsp-icons nil
   "LSP icons"
   :group 'lsp-mode
@@ -67,7 +64,7 @@ FEATURE is the feature that will use the icon which we should check
 if its enabled."
   (when (and file-ext
              (lsp-icons--enabled-for-feature feature)
-             (featurep 'lsp-treemacs-get-icon))
+             (functionp 'lsp-treemacs-get-icon))
     (lsp-icons--fix-image-background
      (lsp-treemacs-get-icon file-ext))))
 
@@ -77,7 +74,7 @@ FEATURE is the feature that will use the icon which we should check
 if its enabled."
   (when (and kind
              (lsp-icons--enabled-for-feature feature)
-             (featurep 'lsp-treemacs-symbol-icon))
+             (functionp 'lsp-treemacs-symbol-icon))
     (lsp-icons--fix-image-background
      (lsp-treemacs-symbol-icon kind))))
 
@@ -86,7 +83,7 @@ if its enabled."
 Fallback to FALLBACK string if not found or not available.
 FEATURE is the feature that will use the icon which we should check
 if its enabled."
-  (if (and (featurep 'all-the-icons-material)
+  (if (and (functionp 'all-the-icons-material)
            (lsp-icons--enabled-for-feature feature))
       (all-the-icons-material icon-name
                               :face face)


### PR DESCRIPTION
Fix #2430

* Add `lsp-icons.el`, the idea is to every feature that needs icons on lsp-mode, should use it since will check if user supports third party packages and if the icon to feature  is enabled.
* Change `lsp-headerline.el` to use `lsp-icons.el`