### PR TITLE
fix - add escaping "`" to lsp--to-yasnippet-snippet

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4067,8 +4067,8 @@ The method uses `replace-buffer-contents'."
 
 (defun lsp--to-yasnippet-snippet (snippet)
   "Convert LSP SNIPPET to yasnippet snippet."
-  ;; LSP snippet doesn't escape "{", but yasnippet requires escaping it.
-  (replace-regexp-in-string (rx (or bos (not (any "$" "\\"))) (group "{"))
+  ;; LSP snippet doesn't escape "{" and "`", but yasnippet requires escaping it.
+  (replace-regexp-in-string (rx (or bos (not (any "$" "\\"))) (group (or "{" "`")))
                             (rx "\\" (backref 1))
                             snippet
                             nil nil 1))


### PR DESCRIPTION
This PR attemts to fix completion involving backticks. e.g. in scala:

```scala
object Foo {
   val `bar-bar` = 1
}

Foo.
//  👆 completing here
```
Right now trying to complete `bar-bar` will  result in in:

```scala
object Foo {
   val `bar-bar` = 1
}

Foo.Symbol’s value as variable is void: bar-bar
```

Escaping "`" in conversion to yasnippet enables successful completion:
```scala
object Foo {
   val `bar-bar` = 1
}

Foo.`bar-bar`
```
As far as I know  [lsp snippets](https://github.com/microsoft/language-server-protocol/blob/b7c1afdb0f2b27f483fc11005f9abff9f0f45844/snippetSyntax.md) don't use backticks, so we should be safe here 😃 
I am happy to fix  this PR  if I've overlooked something 😄 