### PR TITLE
[svelte] Workaround: Use ht-get over ht-get* because of upstream bug

### DIFF
--- a/clients/lsp-svelte.el
+++ b/clients/lsp-svelte.el
@@ -270,9 +270,12 @@ Example: '((css-unused-selector . ignore) (unused-export-let . error))"
                             "svelte"))
   :initialization-options
   (lambda ()
-    (list :config (ht-get* (lsp-configuration-section "svelte.plugin")
-                           "svelte"
-                           "plugin")
+    ;; XXX: workaround for https://github.com/Wilfred/ht.el/issues/38
+    ;; Use `ht-get*' instead of `lsp--ht-get' when
+    ;; https://github.com/Wilfred/ht.el/pull/39 is merged
+    (list :config (lsp--ht-get (lsp-configuration-section "svelte.plugin")
+                               "svelte"
+                               "plugin")
           :prettierConfig (lsp-configuration-section "prettier")
           :emmetConfig (lsp-configuration-section "emmet")
           :typescriptConfig: (list :typescript (lsp-configuration-section "typescript")


### PR DESCRIPTION
See https://github.com/Wilfred/ht.el/issues/38


----

#