### PR TITLE
lsp-nix.el: fix server-id

### DIFF
--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -40,7 +40,7 @@
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-nix-server-path))
                   :major-modes '(nix-mode)
-                  :server-id 'nix-ls))
+                  :server-id 'rnix-lsp))
 
 (provide 'lsp-nix)
 ;;; lsp-nix.el ends here


### PR DESCRIPTION
From `nix-ls` to `rnix-lsp`.