### PR TITLE
Set correct indentation width for `ess-mode`

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5125,6 +5125,7 @@ If ACTION is not set it will be selected from `lsp-code-actions-at-point'."
     (rustic-mode        . rustic-indent-offset)      ; Rust
     (scala-mode         . scala-indent:step)         ; Scala
     (powershell-mode    . powershell-indent)         ; PowerShell
+    (ess-mode           . ess-indent-offset)         ; ESS (R)
 
     (default            . standard-indent))          ; default fallback
   "A mapping from `major-mode' to its indent variable.")


### PR DESCRIPTION
Currently, any mode derived from `ess-mode` (`ess-r-mode`, for example), falls back to using `standard-indent`, which is surprising since `ess-mode` has a variable for indentation offset -- `ess-ident-offset`.