### PR TITLE
`lsp-iedit': add to docs, changelog, contributors

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -19,6 +19,7 @@
   * Add [[https://github.com/phpactor/phpactor][Phpactor Language server]]
   * Add ~lsp-headerline-breadcrumb-icons-enable~ to disable breadcrumb icons.
   * Add ActionScript support.
+  * Add ~iedit~ integration (=documentHighlights=)
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ most popular Emacs packages like `company`, `flycheck` and `projectile`.
   - Semantic tokens as defined by LSP 3.16 (compatible language servers include recent development builds of clangd and rust-analyzer)
   - [which-key](https://github.com/justbur/emacs-which-key/) integration
     for better discovery
+  - [iedit](https://emacs-lsp.github.io/lsp-mode/page/main-features/#iedit)
 
 ## Presentations/demos
   - [System Crafters](https://twitter.com/SystemCrafters) channel
@@ -255,7 +256,7 @@ primary working on/responsible for.
           <sub><b>nbfalcon</b></sub>
         </a>
         <br/>
-        lsp-mode core
+        lsp-mode core | iedit
       </div>
     </td>
   </tr>

--- a/docs/page/integration/iedit.md
+++ b/docs/page/integration/iedit.md
@@ -1,0 +1,13 @@
+# iedit
+
+`lsp-mode` can leverage [`iedit`](https://github.com/victorhge/iedit) to edit
+semantic matches in parallel:
+
+- `lsp-iedit-highlights`: invoke `iedit` on the symbol highlights at point, all
+  of which will be edited in parallel.
+
+  To finish and exit, press `C-g`, with the cursor on `iedit` highlight.
+
+  If an `iedit` session is already active, `lsp-iedit-highlights` will simply
+  add the document highlights to it, without restarting it. This way, another
+  group of symbol highlights can be added to the current `iedit` session.

--- a/docs/page/main-features.md
+++ b/docs/page/main-features.md
@@ -94,20 +94,6 @@ In general the formatter settings are language server specific(e. g. `JDT LS` us
 
 ![](../examples/lsp-dart-flutter-debug.gif)
 
-## iedit
-
-`lsp-mode` can leverage [`iedit`](https://github.com/victorhge/iedit) to edit
-semantic matches in parallel:
-
-- `lsp-iedit-highlights`: invoke `iedit` on the symbol highlights at point, all
-  of which will be edited in parallel.
-
-  To finish and exit, press `C-g`, with the cursor on `iedit` highlight.
-
-  If an `iedit` session is already active, `lsp-iedit-highlights` will simply
-  add the document highlights to it, without restarting it. This way, another
-  group of symbol highlights can be added to the current `iedit` session.
-
 ## Integrations
 
 `lsp-mode` supports many integrations for improve the user experience like [treemacs](https://github.com/emacs-lsp/lsp-treemacs), [Helm](https://github.com/emacs-lsp/helm-lsp), [Ivy](https://github.com/emacs-lsp/lsp-ivy) and others. 

--- a/docs/page/main-features.md
+++ b/docs/page/main-features.md
@@ -94,6 +94,20 @@ In general the formatter settings are language server specific(e. g. `JDT LS` us
 
 ![](../examples/lsp-dart-flutter-debug.gif)
 
+## iedit
+
+`lsp-mode` can leverage [`iedit`](https://github.com/victorhge/iedit) to edit
+semantic matches in parallel:
+
+- `lsp-iedit-highlights`: invoke `iedit` on the symbol highlights at point, all
+  of which will be edited in parallel.
+
+  To finish and exit, press `C-g`, with the cursor on `iedit` highlight.
+
+  If an `iedit` session is already active, `lsp-iedit-highlights` will simply
+  add the document highlights to it, without restarting it. This way, another
+  group of symbol highlights can be added to the current `iedit` session.
+
 ## Integrations
 
 `lsp-mode` supports many integrations for improve the user experience like [treemacs](https://github.com/emacs-lsp/lsp-treemacs), [Helm](https://github.com/emacs-lsp/helm-lsp), [Ivy](https://github.com/emacs-lsp/lsp-ivy) and others. 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
         - Treemacs: https://github.com/emacs-lsp/lsp-treemacs
         - Helm: https://github.com/emacs-lsp/helm-lsp
         - Ivy: https://github.com/emacs-lsp/lsp-ivy
+        - Iedit: page/integration/iedit.md
     - Limitations: page/limitations.md
     - Remote: page/remote.md
     - FAQ: page/faq.md


### PR DESCRIPTION
Add `lsp-iedit` to the docs, describing `lsp-iedit-highlights'. Add it
to the integrations section.

Add `lsp-iedit` to the changelog.

Add `lsp-iedit` to nbfalcon under CONTRIBUTORS.