### PR TITLE
`lsp-unzip-script': prefer unzip over powershell

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6950,8 +6950,8 @@ STORE-PATH to make it executable."
 (defconst lsp-ext-unzip-script "bash -c 'mkdir -p %2$s && unzip -qq %1$s -d %2$s'"
   "Unzip script to unzip file.")
 
-(defcustom lsp-unzip-script (cond ((executable-find "powershell") lsp-ext-pwsh-script)
-                                  ((executable-find "unzip") lsp-ext-unzip-script)
+(defcustom lsp-unzip-script (cond ((executable-find "unzip") lsp-ext-unzip-script)
+                                  ((executable-find "powershell") lsp-ext-pwsh-script)
                                   (t nil))
   "The script to unzip."
   :group 'lsp-mode


### PR DESCRIPTION
The powershell unzip script does not work on linux, but the former is available
on e.g. Ubuntu as a snap. Prefer unzip if available, so that `lsp-unzip-script`
works out of the box even if the user has powershell installed.

If I try to install `eslint` using `M-x lsp-install-server`, I get the following error:
```
The argument 'Expand-Archive' is not recognized as the name of a script file. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```
which leads me to believe that the powershell unzip script doesn't work on Linux.
I have `powershell` installed as a snap and `Expand-Archive` works if I run `powershell` in a regular terminal. `unzip` works just fine, and I believe it should be the default, also because it is less heavy.