### PR TITLE
Add support for `phpactor'

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,6 +15,7 @@
   * Enable headerline breadcrumb by default
   * Add [[https://github.com/soutaro/steep][Steep Language Server]] for typechecking Ruby code.
   * Rename semantic highlighting -> semantic tokens.
+  * Add [[https://github.com/phpactor/phpactor][Phpactor Language server]]
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -354,6 +354,12 @@ already present."
   :server-id 'serenata))
 
 ;;; phpactor
+
+(defgroup lsp-phpactor nil
+  "LSP support for Phpactor."
+  :link '(url-link "https://github.com/phpactor/phpactor")
+  :group 'lsp-mode)
+
 (defcustom lsp-phpactor-path "~/.composer/vendor/phpactor/phpactor/bin/phpactor"
   "Path to the `phpactor' command."
   :group 'lsp-phpactor
@@ -384,7 +390,8 @@ These extensions can be installed using
 
 (defun lsp-phpactor-install-extension (extension)
   "Install a `phpactor' EXTENSION.
-See `lsp-phpactor-extension-alist' and "
+See `lsp-phpactor-extension-alist' and
+https://phpactor.readthedocs.io/en/develop/extensions.html."
   (interactive (list (completing-read "Select extension: "
                                       lsp-phpactor-extension-alist)))
   (compilation-start

--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -367,7 +367,8 @@ already present."
 
 (lsp-register-client
  (make-lsp-client
-  :new-connection (lsp-stdio-connection (list lsp-phpactor-path "language-server"))
+  :new-connection (lsp-stdio-connection
+                   (lambda () (list lsp-phpactor-path "language-server")))
   :major-modes '(php-mode)
   ;; `phpactor' is not really that feature-complete: it doesn't support
   ;; `textDocument/showOccurence' and sometimes errors (e.g. find references on

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -340,6 +340,15 @@
     "debugger": "Yes"
   },
   {
+    "name": "phpactor",
+    "full-name": "Phpactor",
+    "server-name": "phpactor",
+    "server-url": "https://github.com/phpactor/phpactor",
+    "installation-url": "https://phpactor.readthedocs.io/en/develop/usage/standalone.html#installation-global",
+    "installation": "composer g require phpactor/phpactor",
+    "debugger": "yes"
+  },
+  {
     "name": "pwsh",
     "full-name": "Powershell",
     "server-name": "PowerShellEditorServices",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
     - PHP (intelephense): page/lsp-intelephense.md
     - PHP (Serenata): page/lsp-serenata.md
     - PHP (felixbecker): page/lsp-php.md
+    - PHP (phpactor): page/lsp-phpactor.md
     - Powershell: page/lsp-pwsh.md
     - Prolog: page/lsp-prolog.md
     - PureScript: page/lsp-purescript.md


### PR DESCRIPTION
Add it as an lsp client to lsp-php.

Expose its extension installation feature trough an `interactive`
command, `lsp-phpactor-install-extension`.

Add a CHANGELOG entry and add `phpactor` to lsp-clients.json.