### PR TITLE
Do not require all-the-icons and lsp-treemacs for the user

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -128,7 +128,6 @@ This will help minimize popup flickering issue in `company-mode'."
 
 (declare-function company-mode "ext:company")
 (declare-function company-doc-buffer "ext:company")
-(declare-function yas-expand-snippet "ext:yasnippet")
 
 (cl-defun lsp-completion--make-item (item &key markers prefix)
   "Make completion item from lsp ITEM and with MARKERS and PREFIX."

--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -162,14 +162,14 @@ caching purposes.")
   (or
    lsp-headerline-arrow
    (setq lsp-headerline-arrow
-         (if (require 'all-the-icons nil t)
+         (if (functionp 'all-the-icons-material)
              (all-the-icons-material "chevron_right"
                                      :face 'lsp-headerline-breadcrumb-separator-face)
            (propertize "›" 'face 'lsp-headerline-breadcrumb-separator-face)))))
 
 (lsp-defun lsp-headerline--symbol-icon ((&DocumentSymbol :kind))
   "Build the SYMBOL icon for headerline breadcrumb."
-  (when (require 'lsp-treemacs nil t)
+  (when (functionp 'lsp-treemacs-symbol-icon)
     (concat (lsp-headerline--fix-image-background (lsp-treemacs-symbol-icon kind))
             " ")))
 

--- a/lsp-modeline.el
+++ b/lsp-modeline.el
@@ -82,7 +82,7 @@
 
 (defun lsp-modeline--code-actions-icon (face)
   "Build the icon for modeline code actions using FACE."
-  (if (require 'all-the-icons nil t)
+  (if (functionp 'all-the-icons-octicon)
       (all-the-icons-octicon "light-bulb"
                              :face face
                              :v-adjust -0.0575)
@@ -243,7 +243,7 @@ The `:global' workspace is global one.")
     (-> (s-join "/" strs)
         (propertize 'mouse-face 'mode-line-highlight
                     'help-echo "mouse-1: Show diagnostics"
-                    'local-map (when (require 'lsp-treemacs nil t)
+                    'local-map (when (functionp 'lsp-treemacs-errors-list)
                                  (make-mode-line-mouse-map
                                   'mouse-1 #'lsp-treemacs-errors-list))))))
 


### PR DESCRIPTION
If the user has installed but not required all-the-icons or lsp-treemacs, there must be a reason, so I don't think LSP mode should require them eagerly for the user. This PR fixes this issue.