### PR TITLE
Follow upstream change of iedit and add evil multiedit support

### DIFF
--- a/lsp-iedit.el
+++ b/lsp-iedit.el
@@ -28,12 +28,14 @@
 (declare-function iedit-make-occurrence-overlay "iedit-lib" (begin end))
 (declare-function iedit-start-buffering "iedit-lib" ())
 (declare-function iedit-lib-start "iedit-lib" ())
+(declare-function evil-multiedit-state "evil-multiedit" ())
 
 (defvar iedit-mode)
 (defvar iedit-auto-buffering)
 (defvar iedit-occurrences-overlays)
 (defvar iedit-occurrence-keymap)
 (defvar iedit-mode-occurrence-keymap)
+(defvar evil-multiedit--dont-recall)
 
 (defun lsp-iedit--on-ranges (ranges)
   "Start an `iedit' operation using RANGES.
@@ -72,6 +74,20 @@ See also `lsp-enable-symbol-highlighting'."
   (let ((highlights (lsp-request "textDocument/documentHighlight"
                                  (lsp--text-document-position-params))))
     (lsp-iedit--on-ranges (mapcar #'lsp:document-highlight-range highlights))))
+
+;;;###autoload
+(defun lsp-evil-multiedit-highlights ()
+  "Start an `evil-multiedit' operation on the documentHighlights at point.
+This can be used as a primitive `lsp-rename' replacement if the
+language server doesn't support renaming.
+
+See also `lsp-enable-symbol-highlighting'."
+  (interactive)
+  (require 'evil-multiedit)
+  (if (fboundp 'ahs-clear) (ahs-clear))
+  (setq evil-multiedit--dont-recall t)
+  (lsp-iedit-highlights)
+  (evil-multiedit-state))
 
 (provide 'lsp-iedit)
 ;;; lsp-iedit.el ends here

--- a/lsp-iedit.el
+++ b/lsp-iedit.el
@@ -27,7 +27,8 @@
 
 (declare-function iedit-make-occurrence-overlay "iedit-lib" (begin end))
 (declare-function iedit-start-buffering "iedit-lib" ())
-(declare-function iedit-lib-start "iedit-lib" ())
+(declare-function iedit-lib-start "iedit-lib" (mode-exit-func))
+(declare-function iedit-done "iedit" ())
 (declare-function evil-multiedit-state "evil-multiedit" ())
 
 (defvar iedit-mode)
@@ -53,7 +54,7 @@ from various lsp protocol requests, e.g.
     (setq iedit-mode t)
     (when iedit-auto-buffering
       (iedit-start-buffering))
-    (iedit-lib-start)
+    (iedit-lib-start 'iedit-done)
     (run-hooks 'iedit-mode-hook)
     (add-hook 'before-revert-hook 'iedit-done nil t)
     (add-hook 'kbd-macro-termination-hook 'iedit-done nil t)

--- a/lsp-iedit.el
+++ b/lsp-iedit.el
@@ -27,10 +27,13 @@
 
 (declare-function iedit-make-occurrence-overlay "iedit-lib" (begin end))
 (declare-function iedit-start-buffering "iedit-lib" ())
+(declare-function iedit-lib-start "iedit-lib" ())
 
 (defvar iedit-mode)
 (defvar iedit-auto-buffering)
 (defvar iedit-occurrences-overlays)
+(defvar iedit-occurrence-keymap)
+(defvar iedit-mode-occurrence-keymap)
 
 (defun lsp-iedit--on-ranges (ranges)
   "Start an `iedit' operation using RANGES.
@@ -44,9 +47,11 @@ from various lsp protocol requests, e.g.
                   iedit-occurrences-overlays))
           ranges)
     ;; See `iedit-start'; TODO: upstream this
+    (setq iedit-occurrence-keymap iedit-mode-occurrence-keymap)
     (setq iedit-mode t)
     (when iedit-auto-buffering
       (iedit-start-buffering))
+    (iedit-lib-start)
     (run-hooks 'iedit-mode-hook)
     (add-hook 'before-revert-hook 'iedit-done nil t)
     (add-hook 'kbd-macro-termination-hook 'iedit-done nil t)

--- a/lsp-iedit.el
+++ b/lsp-iedit.el
@@ -84,7 +84,7 @@ language server doesn't support renaming.
 See also `lsp-enable-symbol-highlighting'."
   (interactive)
   (require 'evil-multiedit)
-  (if (fboundp 'ahs-clear) (ahs-clear))
+  (when (fboundp 'ahs-clear) (ahs-clear))
   (setq evil-multiedit--dont-recall t)
   (lsp-iedit-highlights)
   (evil-multiedit-state))


### PR DESCRIPTION
Currently `lsp-iedit-highlights` is broken because of an upstream change, this PR fixes it. The problem was that occurrences were correctly highlighted, but edits were applied only to the current occurrence, not all of them.

And I created a new `lsp-evil-multiedit-highlights` function, which has a similar functionality as `lsp-iedit-highlights`, but it works with `evil-multiedit` mode.