### PR TITLE
lsp--get-current-innermost-folding-range: fix bug

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2000,7 +2000,7 @@ WORKSPACE is the workspace that contains the diagnostics."
     (seq-doseq (range (lsp--get-folding-ranges))
       (when (lsp--point-inside-range-p point range)
         (if inner
-            (when (lsp--range-inside-p inner range)
+            (when (lsp--range-inside-p range inner)
               (setq inner range))
           (setq inner range))))
     inner))


### PR DESCRIPTION
Also use `seq-reduce` over `seq-doseq` for readability.