### PR TITLE
Fix byte compile error in Emacs 28

### DIFF
--- a/clients/lsp-ocaml.el
+++ b/clients/lsp-ocaml.el
@@ -57,8 +57,8 @@
   :group 'lsp-mode
   :link '(url-link "https://github.com/ocaml/ocaml-lsp"))
 
-(define-obsolete-variable-alias 'lsp-merlin 'lsp-ocaml-lsp-server)
-(define-obsolete-variable-alias 'lsp-merlin-command 'lsp-ocaml-lsp-server-command)
+(define-obsolete-variable-alias 'lsp-merlin 'lsp-ocaml-lsp-server "lsp-mode 6.1")
+(define-obsolete-variable-alias 'lsp-merlin-command 'lsp-ocaml-lsp-server-command "lsp-mode 6.1")
 
 (defcustom lsp-ocaml-lsp-server-command
   '("ocamllsp")


### PR DESCRIPTION
The third argument `WHEN` is mandatory since https://github.com/emacs-mirror/emacs/commit/32c6732d16385f242b1109517f25e9aefd6caa5c

The file `lsp-ocaml.el` is added in https://github.com/emacs-lsp/lsp-mode/commit/7904b838732591a8b2be550e139debb16bd46230, where 

``` elisp
(define-obsolete-variable-alias
  'lsp-ocaml-ocaml-lang-server-command
  'lsp-ocaml-lang-server-command
  "lsp-mode 6.1")
```

So `lsp-merlin` and `lsp-merlin-command` are obsolete after `"lsp-mode 6.1"`.