### PR TITLE
Change headerline separator until we find a way to detect missing glyph

### DIFF
--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -165,7 +165,7 @@ caching purposes.")
          (if (require 'all-the-icons nil t)
              (all-the-icons-material "chevron_right"
                                      :face 'lsp-headerline-breadcrumb-separator-face)
-           (propertize "›" 'face 'lsp-headerline-breadcrumb-separator-face)))))
+           (propertize ">" 'face 'lsp-headerline-breadcrumb-separator-face)))))
 
 (lsp-defun lsp-headerline--symbol-icon ((&DocumentSymbol :kind))
   "Build the SYMBOL icon for headerline breadcrumb."


### PR DESCRIPTION
This char is not present in a lot of the popular fonts and it is causing trouble.


----

#