### PR TITLE
Add csharp-tree-sitter-mode to known C# modes

### DIFF
--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -257,7 +257,7 @@ using the `textDocument/references' request."
                                      (when-let ((binary (lsp-csharp--language-server-path)))
                                        (f-exists? binary))))
 
-                  :major-modes '(csharp-mode)
+                  :major-modes '(csharp-mode csharp-tree-sitter-mode)
                   :server-id 'csharp
                   :action-handlers (ht ("omnisharp/client/findReferences" 'lsp-csharp--action-client-find-references))
                   :notification-handlers (ht ("o#/projectadded" 'ignore)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -720,6 +720,7 @@ Changes take effect only when a new session is started."
                                         (erlang-mode . "erlang")
                                         (dockerfile-mode . "dockerfile")
                                         (csharp-mode . "csharp")
+                                        (csharp-tree-sitter-mode . "csharp")
                                         (plain-tex-mode . "plaintex")
                                         (latex-mode . "latex")
                                         (vhdl-mode . "vhdl")


### PR DESCRIPTION
I `csharp-mode` we now have a major mode with preliminary tree-sitter support. It would be nice to be able to use it on equal footing with the "legacy" `csharp-mode` to ease debugging going forward. This commit aims to add that. Are there any more places that need to be changed to get this right?