### PR TITLE
Define missing lsp-face-semhl-deprecated face

### DIFF
--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -164,6 +164,11 @@ unless overridden by a more specific face association."
   "Face used for labels."
   :group 'lsp-faces)
 
+(defface lsp-face-semhl-deprecated
+  '((t :strike-through t))
+  "Face used for semantic highlighting scopes matching constant scopes."
+  :group 'lsp-faces)
+
 (defvar lsp-semantic-token-faces
   '(("comment" . lsp-face-semhl-comment)
     ("keyword" . lsp-face-semhl-keyword)
@@ -193,6 +198,7 @@ unless overridden by a more specific face association."
 (defvar lsp-semantic-token-modifier-faces
   ;; TODO: add default definitions
   '(("declaration" . lsp-face-semhl-interface)
+    ("deprecated" . lsp-face-semhl-deprecated)
     ("readonly" . lsp-face-semhl-constant))
   "Semantic tokens modifier faces.
 Faces to use for semantic token modifiers if


### PR DESCRIPTION
I noticed that `lsp-face-semhl-deprecated` face is already used in https://github.com/emacs-lsp/lsp-mode/blob/ee4d07f178174e935099971affe12e2e13af908f/lsp-mode.el#L6051 and https://github.com/emacs-lsp/lsp-mode/blob/ee4d07f178174e935099971affe12e2e13af908f/lsp-mode.el#L6062 but it's not defined anywhere.