### PR TITLE
Add flag to hide debug message

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1030,6 +1030,9 @@ Deprecated. Use `lsp-repeatable-vector' instead. "
 
 (make-obsolete 'lsp-string-vector nil "lsp-mode 7.1")
 
+(defvar lsp--show-message t
+  "If non-nil, show debug message from `lsp-mode'.")
+
 (defun lsp--message  (format &rest args)
   "Wrapper for `message'
 
@@ -1041,9 +1044,10 @@ minibuffer prompt. The issue with async messages is already fixed
 in emacs 27.
 
 See #2049"
-  (let ((inhibit-message (and (minibufferp)
-                              (version< emacs-version "27.0"))))
-    (apply #'message format args)))
+  (when lsp--show-message
+    (let ((inhibit-message (and (minibufferp)
+                                (version< emacs-version "27.0"))))
+      (apply #'message format args))))
 
 (defun lsp--info (format &rest args)
   "Display lsp info message with FORMAT with ARGS."


### PR DESCRIPTION
This patch added the flag `lsp--show-message` for use to disable `lsp` message. I personally think this is quite useful when the user wants to temporary disabled lsp message.