### PR TITLE
Add mjs to ts-ls activation regexp

### DIFF
--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -45,7 +45,7 @@
 (defun lsp-typescript-javascript-tsx-jsx-activate-p (filename &optional _)
   "Check if the javascript-typescript language server should be enabled based on FILENAME."
   (or (string-match-p "\\`mjs\\|[jt]sx?\\'" (or (file-name-extension filename) ""))
-      (and (derived-mode-p 'js-mode 'js2-mode 'typescript-mode)
+      (and (derived-mode-p 'js-mode 'typescript-mode)
            (not (derived-mode-p 'json-mode)))))
 
 (lsp-register-client

--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -44,7 +44,7 @@
 
 (defun lsp-typescript-javascript-tsx-jsx-activate-p (filename &optional _)
   "Check if the javascript-typescript language server should be enabled based on FILENAME."
-  (or (string-match-p (rx (one-or-more anything) "." (or "ts" "js") (opt "x") string-end) filename)
+  (or (string-match-p "\\`mjs\\|[jt]sx?\\'" (or (file-name-extension filename) ""))
       (and (derived-mode-p 'js-mode 'js2-mode 'typescript-mode)
            (not (derived-mode-p 'json-mode)))))
 

--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -44,7 +44,7 @@
 
 (defun lsp-typescript-javascript-tsx-jsx-activate-p (filename &optional _)
   "Check if the javascript-typescript language server should be enabled based on FILENAME."
-  (or (string-match-p "\\`mjs\\|[jt]sx?\\'" (or (file-name-extension filename) ""))
+  (or (string-match-p "\\.mjs\\|[jt]sx?\\'" filename)
       (and (derived-mode-p 'js-mode 'typescript-mode)
            (not (derived-mode-p 'json-mode)))))
 


### PR DESCRIPTION
Node 14 now requires the ["mjs"](https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_enabling) file extension to opt into ES modules.