### PR TITLE
README: link the opencollective page from the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ we need to implement new features and help the community on a lot of issues.
 
 You can help us keep going and improving it by **[supporting the project](https://opencollective.com/emacs-lsp)**
 
-<img src="https://opencollective.com/emacs-lsp/tiers/backer.svg">
+<a href="https://opencollective.com/emacs-lsp"><img src="https://opencollective.com/emacs-lsp/tiers/backer.svg" /></a>
 
 ### Members
 


### PR DESCRIPTION
We prefer to take users to the opencollective page, and not to a page
with the image alone.