### PR TITLE
digestif: support context-mode and texinfo-mode

### DIFF
--- a/clients/lsp-tex.el
+++ b/clients/lsp-tex.el
@@ -46,7 +46,7 @@
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection lsp-clients-digestif-executable)
-                  :major-modes '(plain-tex-mode latex-mode)
+                  :major-modes '(plain-tex-mode latex-mode context-mode texinfo-mode)
                   :priority (if (eq lsp-tex-server 'digestif) 1 -1)
                   :server-id 'digestif))
 


### PR DESCRIPTION
digestif officially supports `context-mode` and `texinfo-mode` in
addition to `plain-tex-mode` and `latex-mode`. Add them to
`:major-modes'.


----

#