### PR TITLE
Remove `lsp--ht-get'

### DIFF
--- a/clients/lsp-svelte.el
+++ b/clients/lsp-svelte.el
@@ -274,12 +274,9 @@ Example: '((css-unused-selector . ignore) (unused-export-let . error))"
                             "svelte"))
   :initialization-options
   (lambda ()
-    ;; XXX: workaround for https://github.com/Wilfred/ht.el/issues/38
-    ;; Use `ht-get*' instead of `lsp--ht-get' when
-    ;; https://github.com/Wilfred/ht.el/pull/39 is merged
-    (list :config (lsp--ht-get (lsp-configuration-section "svelte.plugin")
-                               "svelte"
-                               "plugin")
+    (list :config (ht-get* (lsp-configuration-section "svelte.plugin")
+                           "svelte"
+                           "plugin")
           :prettierConfig (lsp-configuration-section "prettier")
           :emmetConfig (lsp-configuration-section "emmet")
           :typescriptConfig: (list :typescript (lsp-configuration-section "typescript")

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1987,14 +1987,6 @@ WORKSPACE is the workspace that contains the diagnostics."
 
 
 
-(defun lsp--ht-get (tbl &rest keys)
-  "Get nested KEYS in TBL."
-  (let ((val tbl))
-    (while (and keys val)
-      (setq val (ht-get val (cl-first keys)))
-      (setq keys (cl-rest keys)))
-    val))
-
 ;; textDocument/foldingRange support
 
 (cl-defstruct lsp--folding-range beg end kind children)


### PR DESCRIPTION
ht.el has now merged a fix for `ht-get*'.