### PR TITLE
Update lsp-tramp-connection

### DIFF
--- a/docs/page/remote.md
+++ b/docs/page/remote.md
@@ -30,6 +30,59 @@ _Note:_ when you do not have root privileges on the remote machine to put the la
 With TRAMP, Emacs does not have an easy way to distinguish stdout and stderr, so when the underlying LSP process writes to stderr, it breaks the `lsp-mode` parser. As a workaround, `lsp-mode` is redirecting stderr to `/tmp/<process-name>-<id>~stderr`.
 
 
+### Troubleshooting
+
+#### Remote LSP fails to starts/initializes - spinner going for a long time
+
+If you have been waiting for LSP to connect to the remote server for longer than 1-2 minutes (and your connection isn't the problem), it might be an encoding error during the first `initialize` request sent by the client. This can often be observed by an active spinner that never settles to a green tick or whatever symbol you have for successful connection. 
+
+This seems to be caused by incorrect JSON encoding leaving out the last curly brace and thus causing the LSP server to fail to parse it as valid JSON. 
+
+Examples of the same error caused by the client to different servers. 
+
+##### pyls 
+
+```bash
+020-06-26 18:09:27,104 UTC - ERROR - pyls_jsonrpc.streams - Failed to parse JSON message b'\n\n{"jsonrpc":"2.0","method":"initialize","params":{"processId":null,"rootPath":"/home/wts/test","clientInfo":{"name":"emacs","version":"GNU Emacs 27.0.91 (build 1, x86_64-apple-darwin19.5.0, NS appkit-1894.50 Version 10.15.5 (Build 19F101))\\n of 2020-06-20"},"rootUri":"file:///home/wts/test","capabilities":{"workspace":{"workspaceEdit":{"documentChanges":true,"resourceOperations":["create","rename","delete"]},"applyEdit":true,"symbol":{"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]}},"executeCommand":{"dynamicRegistration":false},"didChangeWatchedFiles":{"dynamicRegistration":true},"workspaceFolders":true,"configuration":true},"textDocument":{"declaration":{"linkSupport":true},"definition":{"linkSupport":true},"implementation":{"linkSupport":true},"typeDefinition":{"linkSupport":true},"synchronization":{"willSave":true,"didSave":true,"willSaveWaitUntil":true},"documentSymbol":{"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]},"hierarchicalDocumentSymbolSupport":true},"formatting":{"dynamicRegistration":true},"rangeFormatting":{"dynamicRegistration":true},"rename":{"dynamicRegistration":true,"prepareSupport":true},"codeAction":{"dynamicRegistration":true,"isPreferredSupport":true,"codeActionLiteralSupport":{"codeActionKind":{"valueSet":["","quickfix","refactor","refactor.extract","refactor.inline","refactor.rewrite","source","source.organizeImports"]}}},"completion":{"completionItem":{"snippetSupport":true,"documentationFormat":["markdown"]},"contextSupport":true},"signatureHelp":{"signatureInformation":{"parameterInformation":{"labelOffsetSupport":true}}},"documentLink":{"dynamicRegistration":true,"tooltipSupport":true},"hover":{"contentFormat":["markdown","plaintext"]},"foldingRange":{"dynamicRegistration":true},"callHierarchy":{"dynamicRegistration":false},"publishDiagnostics":{"relatedInformation":true,"tagSupport":{"valueSet":[1,2]},"versionSupport":true}},"window":{"workDoneProgress":true}},"initializationOptions":null,"workDoneToken":"1"},"id":1'
+Traceback (most recent call last):
+  File "/home/wts/.anaconda3/lib/python3.7/site-packages/pyls_jsonrpc/streams.py", line 40, in listen
+    message_consumer(json.loads(request_str.decode('utf-8')))
+ValueError: Unexpected character in found when decoding object value
+```
+
+##### clangd
+
+```bash
+I[08:40:24.923] clangd version 11.0.0 (https://github.com/llvm/llvm-project.git 414f32a9e862b11f51063b75729278f8d81b12e9)
+I[08:40:24.923] PID: 2531726
+I[08:40:24.923] Working directory: /scratch/work
+I[08:40:24.923] argv[0]: /usr/local/bin/clangd
+I[08:40:24.923] Starting LSP over stdin/stdout
+E[08:40:24.924] JSON parse error: [3:2081, byte=2083]: Expected , or } after object property
+```
+
+##### Solution
+
+Upgrade to TRAMP >2.5.0-pre. Check your version by running `M-x tramp-version RET`. Michael Albinus has fixed this in upstream tramp (version 2.5.0 onwards) and lsp-mode now uses a modern start-process method (requires emacs-27.1) with no encoding.
+
+#### Diagnosing other problems
+
+If the LSP server is running on remote, you can either look for a buffer called *\$LSP_SERVER_NAME-stderr* or ssh to the remote machine where the LSP server is running to examine its state. 
+
+```bash
+# First find the process ID of your LSP server
+$ pgrep pyls # the process name of your LSP server
+21229
+# now use the process ID to read the stderr of the process 
+# works on a unix system where /proc/ 
+# this will start streaming and following the contents of your LSP server's 
+# stderr. Keep this terminal running. 
+# go back to your editor and repeat the actions that you suspect cause the crash or misbehaviour
+$ tail -f /proc/21229/fd/2 
+2021-01-16 22:35:10,155 UTC - WARNING - pyls_jsonrpc.endpoint - Received cancel notification for unknown message id 4016
+2021-01-16 22:35:10,157 UTC - WARNING - pyls_jsonrpc.endpoint - Received cancel notification for unknown message id 4018
+```
+
 ## Docker
 
 Refer to [lsp-docker](https://github.com/emacs-lsp/lsp-docker/) README which provides a guide on how you can run `lsp-mode` in `docker` container.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6734,28 +6734,33 @@ should return the command to start the LS server."
   "Create LSP stdio connection named name.
 LOCAL-COMMAND is either list of strings, string or function which
 returns the command to execute."
+  ;; Force a direct asynchronous process.
+  (add-to-list 'tramp-connection-properties
+               (list (regexp-quote (file-remote-p default-directory))
+                     "direct-async-process" t))
   (list :connect (lambda (filter sentinel name environment-fn)
-                   (let* ((final-command (lsp-resolve-final-function local-command))
-                          ;; wrap with stty to disable converting \r to \n
+                   (let* ((final-command (lsp-resolve-final-function
+                                          local-command))
+                          (_stderr (or (when generate-error-file-fn
+                                         (funcall generate-error-file-fn name))
+                                       (format "/tmp/%s-%s-stderr" name
+                                               (cl-incf lsp--stderr-index))))
                           (process-name (generate-new-buffer-name name))
-                          (wrapped-command (append '("stty" "raw" ";")
-                                                   final-command
-                                                   (list
-                                                    (concat "2>"
-                                                            (or (when generate-error-file-fn
-                                                                  (funcall generate-error-file-fn name))
-                                                                (format "/tmp/%s-%s-stderr" name
-                                                                        (cl-incf lsp--stderr-index)))))))
                           (process-environment
-                           (lsp--compute-process-environment environment-fn)))
-                     (let ((proc (apply 'start-file-process-shell-command process-name
-                                        (format "*%s*" process-name) wrapped-command)))
-                       (set-process-sentinel proc sentinel)
-                       (set-process-filter proc filter)
-                       (set-process-query-on-exit-flag proc nil)
-                       (set-process-coding-system proc 'binary 'binary)
-                       (cons proc proc))))
-        :test? (lambda () (-> local-command lsp-resolve-final-function lsp-server-present?))))
+                           (lsp--compute-process-environment environment-fn))
+                          (proc (make-process
+                                 :name process-name
+                                 :buffer (format "*%s*" process-name)
+                                 :command final-command
+                                 :connection-type 'pipe
+                                 :coding 'no-conversion
+                                 :noquery t
+                                 :filter filter
+                                 :sentinel sentinel
+                                 :file-handler t)))
+                     (cons proc proc)))
+        :test? (lambda () (-> local-command lsp-resolve-final-function
+                              lsp-server-present?))))
 
 (defun lsp--auto-configure ()
   "Autoconfigure `company', `flycheck', `lsp-ui', etc if they are installed."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6749,10 +6749,10 @@ returns the command to execute."
   (list :connect (lambda (filter sentinel name environment-fn)
                    (let* ((final-command (lsp-resolve-final-function
                                           local-command))
-                          (_stderr (or (when generate-error-file-fn
-                                         (funcall generate-error-file-fn name))
-                                       (format "/tmp/%s-%s-stderr" name
-                                               (cl-incf lsp--stderr-index))))
+                          (stderr-buf (or (when generate-error-file-fn
+                                            (funcall generate-error-file-fn name))
+                                          (format "/tmp/%s-%s-stderr" name
+                                                  (cl-incf lsp--stderr-index))))
                           (process-name (generate-new-buffer-name name))
                           (process-environment
                            (lsp--compute-process-environment environment-fn))
@@ -6765,6 +6765,7 @@ returns the command to execute."
                                  :noquery t
                                  :filter filter
                                  :sentinel sentinel
+                                 :stderr stderr-buf
                                  :file-handler t)))
                      (cons proc proc)))
         :test? (lambda () (-> local-command lsp-resolve-final-function

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6734,6 +6734,14 @@ should return the command to start the LS server."
   "Create LSP stdio connection named name.
 LOCAL-COMMAND is either list of strings, string or function which
 returns the command to execute."
+  ;; 2.5.0-pre (as built from native-comp branch before M Albinus released tramp-2.5)
+  ;; worked fine
+  (defvar tramp-version)
+  (defvar tramp-connection-properties)
+  (when (version< "2.5.0-pre" tramp-version)
+    (lsp-warn
+     "Your tramp version - %s - might fail to work with remote LSP. Update to tramp-2.5 for tested reliability improvements"
+     tramp-version))
   ;; Force a direct asynchronous process.
   (add-to-list 'tramp-connection-properties
                (list (regexp-quote (file-remote-p default-directory))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6738,9 +6738,9 @@ returns the command to execute."
   ;; worked fine
   (defvar tramp-version)
   (defvar tramp-connection-properties)
-  (when (version< "2.5.0-pre" tramp-version)
+  (when (version< tramp-version "2.5.0-pre")
     (lsp-warn
-     "Your tramp version - %s - might fail to work with remote LSP. Update to tramp-2.5 for tested reliability improvements"
+     "Your tramp version - %s - might fail to work with remote LSP. Update to version 2.5 or greater (available on elpa)"
      tramp-version))
   ;; Force a direct asynchronous process.
   (add-to-list 'tramp-connection-properties


### PR DESCRIPTION
Copy the implementation that Michael Albinus suggested when
graciously helping people understand why lsp wasn't working over tramp.

https://lists.gnu.org/archive/html/emacs-devel/2020-12/msg00896.html

This replaces start-file-process-shell-command with make-process 
and moving from binary encoding to none.

> One disadvantage is, that direct asynch processes work only with the
upcoming Tramp 2.5 (that's already in Emacs master), and it works only
if the asynchronous process does not require password handling. The
latter is true, if your ssh authentication is based on keys, or if you
use Tramp's control master arguments (enabled by default).

Added a Troubleshooting section to the remote doc with examples
of the errors. Suggested solution and tips to debug other
remote LSP errors.