### PR TITLE
Implement lsp-eslint--confirm-local and update ESLint language server

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7080,7 +7080,7 @@ the next question until the queue is empty."
          (answer (completing-read question options nil t)))
     (pop lsp--question-queue)
     (funcall callback answer)
-    (unless (eq lsp--question-queue nil)
+    (when lsp--question-queue
       (lsp--process-question-queue))))
 
 (defun lsp--matching-clients? (client)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7054,6 +7054,35 @@ VERSION is the version of the extension, defaults to `latest'"
 
 
 
+;; Queueing prompts
+
+(defvar lsp--question-queue nil
+  "List of questions yet to be asked by `lsp-ask-question'.")
+
+(defun lsp-ask-question (question options callback)
+  "Prompt the user to answer the QUESTION with one of the OPTIONS from the
+minibuffer. Once the user selects an option, the CALLBACK function will be
+called, passing the selected option to it.
+
+If the user is currently being shown a question, the question will be stored in
+`lsp--question-queue', and will be asked once the user has answered the current
+question."
+  (add-to-list 'lsp--question-queue `(("question" . ,question)
+                                      ("options" . ,options)
+                                      ("callback" . ,callback)) t)
+  (when (eq (length lsp--question-queue) 1)
+    (lsp--process-question-queue)))
+
+(defun lsp--process-question-queue ()
+  "Take the first question from `lsp--question-queue', process it, then process
+the next question until the queue is empty."
+  (-let* (((&alist "question" "options" "callback") (car lsp--question-queue))
+         (answer (completing-read question options nil t)))
+    (pop lsp--question-queue)
+    (funcall callback answer)
+    (unless (eq lsp--question-queue nil)
+      (lsp--process-question-queue))))
+
 (defun lsp--matching-clients? (client)
   (and
    ;; both file and client remote or both local

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -358,7 +358,7 @@ See `-let' for a description of the destructuring mechanism."
 
 (lsp-interface (eslint:StatusParams  (:state) nil)
                (eslint:OpenESLintDocParams (:url) nil)
-               (eslint:ConfirmESLintLibraryParams (:scope :file :libraryPath) nil))
+               (eslint:ConfirmExecutionParams (:scope :file :libraryPath) nil))
 
 (lsp-interface (haxe:ProcessStartNotification (:title) nil))
 


### PR DESCRIPTION
- Implement `lsp-eslint--confirm-local` to handle `eslint/confirmESLintExecution` reqests
- Update the ESLint language server from 2.1.8 -> 2.1.14
- Create `lsp-ask-question` as a way to queue up minibuffer prompts

We should probably find a way to give users the ability to persist the value of `lsp-eslint--stored-libraries`. Using desktop.el and `desktop-globals-to-save` is one option, but some users may not want to use all the other features desktop.el provides. We should probably figure this one out before merging.