### PR TITLE
[lsp-mode] *lsp-mode.el: ignore the workspace/semanticTokens/refresh notification

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5730,6 +5730,7 @@ textDocument/didOpen for the new file."
 (defconst lsp--default-notification-handlers
   (ht ("window/showMessage" #'lsp--window-show-message)
       ("window/logMessage" #'lsp--window-log-message)
+      ("workspace/semanticTokens/refresh" #'ignore)
       ("textDocument/publishDiagnostics" #'lsp--on-diagnostics)
       ("textDocument/diagnosticsEnd" #'ignore)
       ("textDocument/diagnosticsBegin" #'ignore)


### PR DESCRIPTION
Hi,

I got an error messsage `Unknown notification: workspace/semanticTokens/refresh`  from lsp-mode with the backend [lua-language-server](https://github.com/sumneko/lua-language-server/).

This change try to ignore this notification to avoid the error message in Emacs.
