### PR TITLE
`lsp-method-requirements': fix :check-command for 'prepareRename'

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -788,8 +788,8 @@ directory")
                       (with-lsp-workspace workspace
                         (lsp:rename-options-prepare-provider?
                          (or (lsp--capability :renameProvider)
-                             (lsp--registered-capability-options (lsp--registered-capability "textDocument/rename")))))))
-
+                             (when-let ((maybe-capability (lsp--registered-capability "textDocument/rename")))
+                               (lsp--registered-capability-options maybe-capability)))))))
     ("textDocument/rangeFormatting" :capability :documentRangeFormattingProvider)
     ("textDocument/references" :capability :referencesProvider)
     ("textDocument/rename" :capability :renameProvider)


### PR DESCRIPTION
Ensure that `lsp--registered-capability-options' is not called with a
nil value.

Closes #2548.