### PR TITLE
Revert "Force older working version for rust-analyzer"

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -611,13 +611,12 @@ them with `crate` or the crate name they refer to."
     (lsp--apply-text-edits result 'code-action)))
 
 (defcustom lsp-rust-analyzer-download-url
-  (format "https://github.com/rust-analyzer/rust-analyzer/releases/download/2020-12-14/%s"
+  (format "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/%s"
           (pcase system-type
             ('gnu/linux "rust-analyzer-linux")
             ('darwin "rust-analyzer-mac")
             ('windows-nt "rust-analyzer-windows.exe")))
-  "Automatic download url for Rust Analyzer.
-Force 12/14 release until we fix https://github.com/emacs-lsp/lsp-mode/issues/2436"
+  "Automatic download url for Rust Analyzer"
   :type 'string
   :group 'lsp-rust
   :package-version '(lsp-mode . "7.1"))


### PR DESCRIPTION
This reverts commit dc7708639fa5d2650bd18b0f161bbd53e77b25a6 since #2436 has been closed