### PR TITLE
Add reason-mode to ocaml-lsp-server client

### DIFF
--- a/clients/lsp-ocaml.el
+++ b/clients/lsp-ocaml.el
@@ -73,7 +73,7 @@
  (make-lsp-client
   :new-connection
   (lsp-stdio-connection (lambda () lsp-ocaml-lsp-server-command))
-  :major-modes '(caml-mode tuareg-mode)
+  :major-modes '(reason-mode caml-mode tuareg-mode)
   :priority 0
   :server-id 'ocaml-lsp-server))
 


### PR DESCRIPTION
I verified that this works.

I'm not sure why `ocaml-ls` has reason-mode added, but `ocaml-lsp-server` did not.