### PR TITLE
lsp--persist: create parent directories if needed

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3407,9 +3407,14 @@ in that particular folder."
     (cl-first (read-from-string (f-read-text file 'utf-8)))))
 
 (defun lsp--persist (file-name to-persist)
-  "Persist TO-PERSIST in FILE-NAME."
+  "Persist TO-PERSIST in FILE-NAME.
+
+This function creates the parent directories if they don't exist
+yet."
   (let ((print-length nil)
         (print-level nil))
+    ;; Create all parent directories:
+    (apply #'f-mkdir (f-split (f-parent file-name)))
     (f-write-text (prin1-to-string to-persist) 'utf-8 file-name)))
 
 (defun lsp-workspace-folders-add (project-root)


### PR DESCRIPTION
This makes it easier for users to configure variables storing filenames, e.g., `lsp-eslint-library-choices-file`.