### PR TITLE
bug: always remove cr in lsp--render-string and langId for pwsh

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -710,6 +710,7 @@ Changes take effect only when a new session is started."
                                         (hack-mode . "hack")
                                         (php-mode . "php")
                                         (powershell-mode . "powershell")
+                                        (powershell-mode . "PowerShell")
                                         (json-mode . "json")
                                         (jsonc-mode . "jsonc")
                                         (rjsx-mode . "javascript")
@@ -4743,13 +4744,12 @@ In addition, each can have property:
 (defun lsp--render-string (str language)
   "Render STR using `major-mode' corresponding to LANGUAGE.
 When language is nil render as markup if `markdown-mode' is loaded."
-  (setq str (or str ""))
-  (if-let ((mode (-some (-lambda ((mode . lang))
-                          (when (and (equal lang language) (functionp mode))
-                            mode))
-                        lsp-language-id-configuration)))
-      (lsp--fontlock-with-mode str mode)
-    (s-replace "\r" "" str)))
+  (setq str (s-replace "\r" "" (or str "")))
+  (when-let ((mode (-some (-lambda ((mode . lang))
+                            (when (and (equal lang language) (functionp mode))
+                              mode))
+                          lsp-language-id-configuration)))
+    (lsp--fontlock-with-mode str mode)))
 
 (defun lsp--render-element (content)
   "Render CONTENT element."


### PR DESCRIPTION
Always remove CR in `lsp--render-string` so the Eldoc will not contain useless `^M` in Windows.
Also, add new case sensitive language id for PowerShell.