### PR TITLE
`lsp-lens-mode`: add to `lsp-configure-hook`

### DIFF
--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -352,6 +352,7 @@ CALLBACK - callback for the lenses."
   (cond
    (lsp-lens-mode
     (add-hook 'lsp-unconfigure-hook #'lsp-lens--disable nil t)
+    (add-hook 'lsp-configure-hook #'lsp-lens--enable nil t)
     (add-hook 'lsp-on-idle-hook #'lsp-lens--idle-function nil t)
     (add-hook 'lsp-on-change-hook #'lsp-lens--schedule-refresh-modified nil t)
     (add-hook 'after-save-hook #'lsp-lens--schedule-refresh nil t)
@@ -368,6 +369,7 @@ CALLBACK - callback for the lenses."
     (lsp-lens-hide)
     (setq lsp-lens--last-count nil)
     (setq lsp-lens--backend-cache nil)
+    (remove-hook 'lsp-configure-hook #'lsp-lens--enable t)
     (remove-hook 'lsp-unconfigure-hook #'lsp-lens--disable t))))
 
 


### PR DESCRIPTION
`lsp-configure` modes should add their enable functions to `lsp-configure-hook`.
The corresponding code for `lsp-lens-mode` was removed in a previous commit due
to a misunderstanding.


----

#