### PR TITLE
Small clean-ups

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5442,7 +5442,7 @@ perform the request synchronously."
 (defun lsp--xref-elements-index (symbols path)
   (-mapcat
    (-lambda (sym)
-     (pcase sym
+     (pcase-exhaustive sym
        ((DocumentSymbol :name :children? :selection-range (Range :start))
         (cons (cons (concat path name)
                     (lsp--position-to-point start))

--- a/test/lsp-file-watch-test.el
+++ b/test/lsp-file-watch-test.el
@@ -158,20 +158,20 @@
   ;; (https://github.com/Microsoft/vscode/blob/466da1c9013c624140f6d1473b23a870abc82d44/src/vs/base/test/node/glob.test.ts)
   (should (string-match (lsp-glob-convert-to-wrapped-regexp "**/.*") ".git"))
   (should (string-match (lsp-glob-convert-to-wrapped-regexp "**/.*") ".hidden.txt"))
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "**/.*") "git")))
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "**/.*") "hidden.txt")))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "**/.*") "git"))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "**/.*") "hidden.txt"))
 
   (should (string-match (lsp-glob-convert-to-wrapped-regexp "**/.*") "path/.git"))
   (should (string-match (lsp-glob-convert-to-wrapped-regexp "**/.*") "path/.hidden.txt"))
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "**/.*") "path/git")))
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "**/.*") "pat.h/hidden.txt")))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "**/.*") "path/git"))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "**/.*") "pat.h/hidden.txt"))
 
   (should (string-match (lsp-glob-convert-to-wrapped-regexp "**/node_modules/**") "node_modules"))
   (should (string-match (lsp-glob-convert-to-wrapped-regexp "**/node_modules/**") "node_modules/"))
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "**/node_modules/**") "node/_modules/")))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "**/node_modules/**") "node/_modules/"))
 
   (should (string-match (lsp-glob-convert-to-wrapped-regexp "?") "h"))
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "?") "hi")))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "?") "hi"))
 
   (should (string-match (lsp-glob-convert-to-wrapped-regexp "foo.[[]") "foo.["))
 
@@ -187,19 +187,19 @@
   (should (string-match (lsp-glob-convert-to-wrapped-regexp "some/**/*") "some/foo.js"))
   (should (string-match (lsp-glob-convert-to-wrapped-regexp "some/**/*") "some/folder/foo.js"))
 
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "some/**/*") "something/foo.js")))
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "some/**/*") "something/folder/foo.js")))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "some/**/*") "something/foo.js"))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "some/**/*") "something/folder/foo.js"))
 
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "{**/*.d.ts,**/*.js,foo.[0-9]}") "foo.f")))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "{**/*.d.ts,**/*.js,foo.[0-9]}") "foo.f"))
   (should (string-match (lsp-glob-convert-to-wrapped-regexp "prefix/{**/*.d.ts,**/*.js,foo.[0-9]}") "prefix/foo.8"))
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "prefix/{**/*.d.ts,**/*.js,foo.[0-9]}") "prefix/foo.f")))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "prefix/{**/*.d.ts,**/*.js,foo.[0-9]}") "prefix/foo.f"))
 
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "foo.[!0-9]") "foo.5")))
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "foo.[!0-9]") "foo.8")))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "foo.[!0-9]") "foo.5"))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "foo.[!0-9]") "foo.8"))
   (should (string-match (lsp-glob-convert-to-wrapped-regexp "foo.[!0-9]") "foo.f"))
 
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "foo.[^0-9]") "foo.5")))
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "foo.[^0-9]") "foo.8")))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "foo.[^0-9]") "foo.5"))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "foo.[^0-9]") "foo.8"))
   (should (string-match (lsp-glob-convert-to-wrapped-regexp "foo.[^0-9]") "foo.f"))
 
   ;; ???: This should properly fail since path-separators should be
@@ -212,7 +212,7 @@
   ;; way of handling this to recognize that because we're unbalanced
   ;; at the end, that everything should be treated as a literal. But
   ;; after experimenting with zsh, this isn't what they use.
-  (should (not (string-match (lsp-glob-convert-to-wrapped-regexp "foo[/]bar") "foo/bar"))))
+  (should-not (string-match (lsp-glob-convert-to-wrapped-regexp "foo[/]bar") "foo/bar")))
 
 (ert-deftest lsp-file-watch--ignore-list ()
   :tags '(no-win)

--- a/test/lsp-javascript-test.el
+++ b/test/lsp-javascript-test.el
@@ -66,14 +66,14 @@
             (lsp-clients-flow-tag-string-present-p))))
 
 (ert-deftest lsp-flow-wrong-tag-detection ()
-  (should (not (with-temp-buffer
-                 (insert lsp-flow-wrong-tag)
-                 (lsp-clients-flow-tag-string-present-p)))))
+  (should-not (with-temp-buffer
+                (insert lsp-flow-wrong-tag)
+                (lsp-clients-flow-tag-string-present-p))))
 
 (ert-deftest lsp-flow-but-not-in-comment-tag-detection ()
-  (should (not (with-temp-buffer
-                 (insert lsp-flow-but-not-in-comment-tag)
-                 (lsp-clients-flow-tag-string-present-p)))))
+  (should-not (with-temp-buffer
+                (insert lsp-flow-but-not-in-comment-tag)
+                (lsp-clients-flow-tag-string-present-p))))
 
 (ert-deftest lsp-flow-should-activate-on-flow-project ()
   ;; Set `js-mode' ON and check that a Flow project activates the Flow
@@ -87,13 +87,13 @@
 
 (ert-deftest lsp-flow-should-not-activate-if-not-flow-project-or-no-tag ()
   (let ((major-mode 'js-mode))
-    (should (not (lsp-clients-flow-activate-p (concat test-location "fixtures/SampleJsProject/src/sample.js") nil)))))
+    (should-not (lsp-clients-flow-activate-p (concat test-location "fixtures/SampleJsProject/src/sample.js") nil))))
 
 (ert-deftest lsp-flow-should-not-activate-on-typescript-project ()
   ;; Set `js-mode' ON and check that a TypeScript project does not
   ;; activate the Flow LSP client.
   (let ((major-mode 'js-mode))
-    (should (not (lsp-clients-flow-activate-p (concat test-location "fixtures/SampleTypeScriptProject/src/sample.ts") nil)))))
+    (should-not (lsp-clients-flow-activate-p (concat test-location "fixtures/SampleTypeScriptProject/src/sample.ts") nil))))
 
 (ert-deftest lsp-typescript-javascript-activates-based-on-file-extension ()
   (should (lsp-typescript-javascript-tsx-jsx-activate-p "abc.js"))
@@ -102,7 +102,7 @@
   (should (lsp-typescript-javascript-tsx-jsx-activate-p "abc.tsx"))
   (should (lsp-typescript-javascript-tsx-jsx-activate-p "a1.ts"))
   (should (lsp-typescript-javascript-tsx-jsx-activate-p "a1.d.ts"))
-  (should (not (lsp-typescript-javascript-tsx-jsx-activate-p "abc.tsxx")))
-  (should (not (lsp-typescript-javascript-tsx-jsx-activate-p "abc.jss"))))
+  (should-not (lsp-typescript-javascript-tsx-jsx-activate-p "abc.tsxx"))
+  (should-not (lsp-typescript-javascript-tsx-jsx-activate-p "abc.jss")))
 
 ;;; lsp-clients-test.el ends here

--- a/test/lsp-protocol-test.el
+++ b/test/lsp-protocol-test.el
@@ -53,9 +53,9 @@
     (-let (((&MyPosition? :optional?) nil))
       (should (null optional?)))
 
-    (should (not (lsp-my-position? position)))
+    (should-not (lsp-my-position? position))
     (lsp:set-my-position-camel-case position "camel-case")
-    (should (not (lsp-my-position? "xx")))
+    (should-not (lsp-my-position? "xx"))
     (should (lsp-my-position? position))
 
     (-let (((&MyPosition? :line) nil))


### PR DESCRIPTION
* lsp--xref-elements-index: use `pcase-exhaustive'

The expression cannot be matched by anything not in the specified
forms.  Using `pcase-exhaustive' makes this clear.

* Prefer `should-not' macro over (should (not

The `should-not' macro is highlighted as a macro, so using it
consistently makes it easier to spot tests that should return nil.
