### PR TITLE
clients/lsp-csharp.el: add lsp-csharp-open-project-file

### DIFF
--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -235,6 +235,15 @@ tarball or a zip file (based on a current platform) to TARGET-DIR."
   "Resolves path and arguments to use to start the server."
   (list (lsp-csharp--language-server-path) "-lsp"))
 
+(lsp-defun lsp-csharp-open-project-file ()
+  "Open corresponding project file  (.csproj) for the current file."
+  (interactive)
+  (-let* ((project-info-req (lsp-make-omnisharp-project-information-request :file-name (buffer-file-name)))
+          (project-info (lsp-request "o#/project" project-info-req))
+          ((&omnisharp:ProjectInformation :ms-build-project) project-info)
+          ((&omnisharp:MsBuildProject :path) ms-build-project))
+    (find-file path)))
+
 (lsp-defun lsp-csharp--action-client-find-references ((&Command :arguments?))
   "Read first argument from ACTION as Location and display xrefs for that location
 using the `textDocument/references' request."

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -364,7 +364,10 @@ See `-let' for a description of the destructuring mechanism."
 
 (lsp-interface (pwsh:ScriptRegion (:StartLineNumber :EndLineNumber :StartColumnNumber :EndColumnNumber :Text) nil))
 
-(lsp-interface (omnisharp:ErrorMessage (:Text :FileName :Line :Column)))
+(lsp-interface (omnisharp:ErrorMessage (:Text :FileName :Line :Column))
+               (omnisharp:ProjectInformationRequest (:FileName))
+               (omnisharp:MsBuildProject (:IsUnitProject :IsExe :Platform :Configuration :IntermediateOutputPath :OutputPath :TargetFrameworks :SourceFiles :TargetFramework :TargetPath :AssemblyName :Path :ProjectGuid))
+               (omnisharp:ProjectInformation (:ScriptProject :MsBuildProject)))
 
 (lsp-interface (rls:Cmd (:args :binary :env :cwd) nil))
 


### PR DESCRIPTION
This adds a custom interactive command `lsp-csharp-open-project-file` that opens .csproj file for .cs file being edited.

Note that this PR is pending for merge as a draft for review until we have corresponding `omnisharp-roslyn` server version released.