### PR TITLE
clients/lsp-csharp.el: Implement go-to definition in metadata.

### DIFF
--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -60,6 +60,13 @@ Usually this is to be set in your .dir-locals.el on the project root directory."
   :group 'lsp-csharp
   :type 'string)
 
+(defcustom lsp-csharp-enable-decompilation-support
+  nil
+  "Decompile bytecode when browsing method metadata for types in assemblies.
+Otherwise only declarations for the methods are visible (the default)."
+  :group 'lsp-csharp
+  :type 'boolean)
+
 (defcustom lsp-csharp-omnisharp-roslyn-download-url
   (concat "https://github.com/omnisharp/omnisharp-roslyn/releases/latest/download/"
           (cond ((eq system-type 'windows-nt)
@@ -121,6 +128,12 @@ Will invoke CALLBACK on success, ERROR-CALLBACK on error."
          (set-file-modes run-script #o755)))
      (funcall callback))
    error-callback))
+
+(defun lsp-csharp--environment-fn ()
+  "Build environment structure for current values of lsp-csharp customizables.
+
+See https://github.com/OmniSharp/omnisharp-roslyn/wiki/Configuration-Options"
+  `(("OMNISHARP_RoslynExtensionsOptions:enableDecompilationSupport" . ,(if lsp-csharp-enable-decompilation-support "true" "false"))))
 
 (defun lsp-csharp--language-server-path ()
   "Resolve path to use to start the server."
@@ -380,6 +393,7 @@ stores this metadata and filename is returned so lsp-mode can display this file.
                                        (f-exists? binary))))
                   :major-modes '(csharp-mode csharp-tree-sitter-mode)
                   :server-id 'csharp
+                  :environment-fn #'lsp-csharp--environment-fn
                   :action-handlers (ht ("omnisharp/client/findReferences" 'lsp-csharp--action-client-find-references))
                   :notification-handlers (ht ("o#/projectadded" 'ignore)
                                              ("o#/projectchanged" 'ignore)

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -386,7 +386,9 @@ See `-let' for a description of the destructuring mechanism."
                (omnisharp:RunTestsInClassRequest (:MethodNames :RunSettings :TestFrameworkname :TargetFrameworkVersion :NoBuild :Line :Column :Buffer :FileName))
                (omnisharp:RunTestResponse (:Results :Pass :Failure :ContextHadNoTests))
                (omnisharp:TestMessageEvent (:MessageLevel :Message))
-               (omnisharp:DotNetTestResult (:MethodName :Outcome :ErrorMessage :ErrorStackTrace :StandardOutput :StandardError)))
+               (omnisharp:DotNetTestResult (:MethodName :Outcome :ErrorMessage :ErrorStackTrace :StandardOutput :StandardError))
+               (omnisharp:MetadataRequest (:AssemblyName :TypeName :ProjectName :VersionNumber :Language))
+               (omnisharp:MetadataResponse (:SourceName :Source)))
 
 (lsp-interface (rls:Cmd (:args :binary :env :cwd) nil))
 


### PR DESCRIPTION
This commit adds a handler for 'osmd://' uri when returned from
omnisharp-roslyn, parses the uri and issues corresponding 'o#/metadata'
request that is used to retrieve metadata source to display to the user.

The design is modelled after clients/lsp-clojure.el and lsp-java. I am not 100% about the directory: currently I save metadata .cs files under `<project-dir>/.cache/lsp-csharp/metadata` -- but maybe that needs to be a customizable variable or some other dir?

This PR is marked as draft as there is some changes pending to be merged into `omnisharp-roslyn` yet but open for review.