### PR TITLE
Leave default way to render str in lsp--render-str

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4787,12 +4787,13 @@ In addition, each can have property:
 (defun lsp--render-string (str language)
   "Render STR using `major-mode' corresponding to LANGUAGE.
 When language is nil render as markup if `markdown-mode' is loaded."
-  (setq str (s-replace "\r" "" (or str "")))
-  (when-let ((mode (-some (-lambda ((mode . lang))
-                            (when (and (equal lang language) (functionp mode))
-                              mode))
-                          lsp-language-id-configuration)))
-    (lsp--fontlock-with-mode str mode)))
+  (setq str (or str ""))
+  (if-let ((mode (-some (-lambda ((mode . lang))
+                           (when (and (equal lang language) (functionp mode))
+                             mode))
+                         lsp-language-id-configuration)))
+      (lsp--fontlock-with-mode str mode)
+    (s-replace "\r" "" str)))
 
 (defun lsp--render-element (content)
   "Render CONTENT element."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4787,13 +4787,13 @@ In addition, each can have property:
 (defun lsp--render-string (str language)
   "Render STR using `major-mode' corresponding to LANGUAGE.
 When language is nil render as markup if `markdown-mode' is loaded."
-  (setq str (or str ""))
+  (setq str (s-replace "\r" "" (or str "")))
   (if-let ((mode (-some (-lambda ((mode . lang))
                            (when (and (equal lang language) (functionp mode))
                              mode))
                          lsp-language-id-configuration)))
       (lsp--fontlock-with-mode str mode)
-    (s-replace "\r" "" str)))
+    str))
 
 (defun lsp--render-element (content)
   "Render CONTENT element."


### PR DESCRIPTION
By using `if-let` instead of `when-let`, we can return `str` itself if `mode` becomes `nil`. I made this change because in some cases, e.g. where I use web-mode to edit typescript files (this mode-language pair does not exist in `lap-language-id-configuration`), `mode` is `nil`, and then `when-let` will just devour the str and return nil so no sideline hovers will show up in the end.