### PR TITLE
Update CPP-guide.md

### DIFF
--- a/docs/tutorials/CPP-guide.md
+++ b/docs/tutorials/CPP-guide.md
@@ -102,7 +102,7 @@ in your config or you could run in separate session.
 
 (which-key-mode)
 (add-hook 'c-mode-hook 'lsp)
-(add-hook 'cpp-mode-hook 'lsp)
+(add-hook 'c++-mode-hook 'lsp)
 
 (setq gc-cons-threshold (* 100 1024 1024)
       read-process-output-max (* 1024 1024)


### PR DESCRIPTION
`(add-hook 'cpp-mode-hook 'lsp)` doesn't work (took me a while to figure out why things weren't auto starting), needs to be `++`.