### PR TITLE
Make sure that json server runs for json files even in js-mode

### DIFF
--- a/clients/lsp-json.el
+++ b/clients/lsp-json.el
@@ -62,9 +62,6 @@
   `(:provideFormatter t
     :handledSchemaProtocols ["file" "http" "https"]))
 
-(defvar lsp-json--major-modes '(json-mode jsonc-mode)
-  "List of supported JSON major modes.")
-
 (defvar lsp-json--schema-associations
   `(:/*.css-data.json ["https://raw.githubusercontent.com/Microsoft/vscode-css-languageservice/master/docs/customData.schema.json"]
     :/package.json ["http://json.schemastore.org/package"]
@@ -110,9 +107,9 @@
   :new-connection
   (lsp-stdio-connection
    (lambda () (list (lsp-package-path 'vscode-json-languageserver) "--stdio")))
-  :major-modes lsp-json--major-modes
+  :activation-fn (lsp-activate-on "json" "jsonc")
   :server-id 'json-ls
-  :priority -1
+  :priority 0
   :multi-root t
   :completion-in-comments? t
   :initialization-options lsp-json--extra-init-params

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -681,6 +681,8 @@ Changes take effect only when a new session is started."
                                         (".*\\.lua$" . "lua")
                                         (".*\\.sql$" . "sql")
                                         (".*\\.html$" . "html")
+                                        (".*\\.json$" . "json")
+                                        (".*\\.jsonc$" . "jsonc")
                                         (ada-mode . "ada")
                                         (sql-mode . "sql")
                                         (vimrc-mode . "vim")
@@ -4390,6 +4392,13 @@ Applies on type formatting."
                       ((eq mode-or-pattern major-mode) language))))
            cl-rest)
       (lsp-warn "Unable to calculate the languageId for current buffer. Take a look at lsp-language-id-configuration.")))
+
+(defun lsp-activate-on (&rest languages)
+  "Returns language activation function.
+The function will return t when the `lsp-buffer-language' returns
+one of the LANGUAGES."
+  (lambda (_file-name _mode)
+    (-contains? languages (lsp-buffer-language))))
 
 (defun lsp-workspace-root (&optional path)
   "Find the workspace root for the current file or PATH."


### PR DESCRIPTION
- introduced `lsp-activate-on` which mimic what vscode does - it selects the
language server based on the language in the file. This will make the language
servers a bit easier to configure and it will give more control to the users via
`lsp-language-id-configuration`.