### PR TITLE
Update clojure lsp server install

### DIFF
--- a/clients/lsp-clojure.el
+++ b/clients/lsp-clojure.el
@@ -42,15 +42,23 @@
   :risky t
   :type '(repeat string))
 
-(defcustom lsp-clojure-server-download-url "https://github.com/snoe/clojure-lsp/releases/latest/download/clojure-lsp"
+(defcustom lsp-clojure-server-download-url
+  (format "https://github.com/clojure-lsp/clojure-lsp/releases/latest/download/clojure-lsp-native-%s-amd64.zip"
+          (pcase system-type
+            ('gnu/linux "linux")
+            ('darwin "macos")
+            ('windows-nt "windows")))
   "Automatic download url for lsp-clojure."
   :type 'string
   :group 'lsp-clojure
   :package-version '(lsp-mode . "7.1"))
 
-(defcustom lsp-clojure-server-store-path (f-join lsp-server-install-dir
-                                                "clojure"
-                                                "clojure-lsp")
+(defcustom lsp-clojure-server-store-path
+  (f-join lsp-server-install-dir
+          "clojure"
+          (if (eq system-type 'windows-nt)
+              "clojure-lsp.exe"
+            "clojure-lsp"))
   "The path to the file in which `clojure-lsp' will be stored."
   :type 'file
   :group 'lsp-clojure
@@ -60,10 +68,11 @@
 
 (lsp-dependency
  'clojure-lsp
- '(:system "clojure-lsp")
  `(:download :url lsp-clojure-server-download-url
+             :decompress :zip
              :store-path lsp-clojure-server-store-path
-             :set-executable? t))
+             :set-executable? t)
+ '(:system "clojure-lsp"))
 
 ;; Refactorings
 

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -633,10 +633,10 @@ them with `crate` or the crate name they refer to."
 
 (lsp-dependency
  'rust-analyzer
- '(:system "rust-analyzer")
  `(:download :url lsp-rust-analyzer-download-url
              :store-path lsp-rust-analyzer-store-path
-             :set-executable? t))
+             :set-executable? t)
+ '(:system "rust-analyzer"))
 
 (lsp-defun lsp-rust--analyzer-run-single ((&Command :arguments?))
   (lsp-rust-analyzer-run (lsp-seq-first arguments?)))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7061,7 +7061,7 @@ nil."
                (pcase decompress
                  (:gzip
                   (lsp-gunzip download-path))
-                 (:zip (lsp-unzip download-path store-path)))
+                 (:zip (lsp-unzip download-path (f-parent store-path))))
                (lsp--info "Decompressed %s..." store-path))
              (funcall callback))
          (error (funcall error-callback err)))))))
@@ -7097,7 +7097,7 @@ STORE-PATH to make it executable."
   :package-version '(lsp-mode . "7.1"))
 
 (defun lsp-unzip (zip-file dest)
-  "Get extension from URL and extract to DEST."
+  "Unzip ZIP-FILE to DEST."
   (unless lsp-unzip-script
     (error "Unable to find `unzip' or `powershell' on the path, please customize `lsp-unzip-script'"))
   (shell-command (format lsp-unzip-script zip-file dest)))
@@ -7117,7 +7117,7 @@ in place."
   :package-version '(lsp-mode . "7.1"))
 
 (defun lsp-gunzip (gz-file)
-  "Decompress file in place."
+  "Decompress GZ-FILE in place."
   (unless lsp-gunzip-script
     (error "Unable to find `gzip' on the path, please either customize `lsp-gunzip-script' or manually decompress %s" gz-file))
   (shell-command (format lsp-gunzip-script gz-file)))


### PR DESCRIPTION
* Update `lsp-clojure.el` to download native binaries compiled with GraalVM instead of legacy embedded jar executable.
* Update `lsp-rust.el` and `lsp-clojure.el` to prioritize lsp installed executables instead of system executables.
* Update `lsp-download-install` to keep the same path of store-path when unzipping.