### PR TITLE
Bump ht.el version

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: Vibhav Pant, Fangrui Song, Ivan Yonchovski
 ;; Keywords: languages
-;; Package-Requires: ((emacs "26.1") (dash "2.14.1") (dash-functional "2.14.1") (f "0.20.0") (ht "2.0") (spinner "1.7.3") (markdown-mode "2.3") (lv "0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.14.1") (dash-functional "2.14.1") (f "0.20.0") (ht "2.3") (spinner "1.7.3") (markdown-mode "2.3") (lv "0"))
 ;; Version: 7.1.0
 
 ;; URL: https://github.com/emacs-lsp/lsp-mode


### PR DESCRIPTION
This release forces an update on those users who may still be running
a rev of ht.el containing a buggy ht-get*.

There are tiny improvements to performance in this release as well.