### PR TITLE
Fix CI by removing dash-functional

### DIFF
--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -40,7 +40,6 @@
 (eval-when-compile (require 'subr-x))
 
 (require 'dash)
-(require 'dash-functional)
 (require 's)
 
 (defvar flycheck-explain-error-buffer)

--- a/docs/lsp-doc.el
+++ b/docs/lsp-doc.el
@@ -1,7 +1,7 @@
 ;;; lsp-doc.el --- LSP doc converter -*- lexical-binding: t; -*-
 
 ;; Keywords: languages, tool
-;; Package-Requires: ((emacs "25.1") (dash "2.14.1") (dash-functional "2.14.1") (f "0.20.0") (ht "2.0") (spinner "1.7.3") (markdown-mode "2.3") (lv "0"))
+;; Package-Requires: ((emacs "25.1") (dash "2.18.0") (f "0.20.0") (ht "2.0") (spinner "1.7.3") (markdown-mode "2.3") (lv "0"))
 ;; Version: 6.4
 
 ;; URL: https://github.com/emacs-lsp/lsp-mode

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: Vibhav Pant, Fangrui Song, Ivan Yonchovski
 ;; Keywords: languages
-;; Package-Requires: ((emacs "26.1") (dash "2.14.1") (dash-functional "2.14.1") (f "0.20.0") (ht "2.3") (spinner "1.7.3") (markdown-mode "2.3") (lv "0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.18.0") (f "0.20.0") (ht "2.3") (spinner "1.7.3") (markdown-mode "2.3") (lv "0"))
 ;; Version: 7.1.0
 
 ;; URL: https://github.com/emacs-lsp/lsp-mode

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -32,7 +32,6 @@
 (require 'cl-lib)
 (require 'compile)
 (require 'dash)
-(require 'dash-functional)
 (require 'ewoc)
 (require 'f)
 (require 'filenotify)

--- a/test/windows-bootstrap.el
+++ b/test/windows-bootstrap.el
@@ -31,7 +31,7 @@
 
 (let* ((package-archives '(("melpa" . "https://melpa.org/packages/")
                            ("gnu" . "https://elpa.gnu.org/packages/")))
-       (pkgs '(dash dash-functional f lv ht spinner markdown-mode deferred)))
+       (pkgs '(dash f lv ht spinner markdown-mode deferred)))
   (package-initialize)
   (package-refresh-contents)
 


### PR DESCRIPTION
I think `dash-functional` is obsolete? You will get the following error.

```
Package dash-functional is obsolete; use dash 2.18.0 instead
```