### PR TITLE
lsp-angular: can process typescript as well

### DIFF
--- a/clients/lsp-angular.el
+++ b/clients/lsp-angular.el
@@ -60,7 +60,7 @@
  (make-lsp-client :new-connection (lsp-stdio-connection
                                    (lambda () lsp-clients-angular-language-server-command))
                   :activation-fn (lambda (&rest _args)
-                                   (and (string-match-p "\\.html\\'" (buffer-file-name))
+                                   (and (string-match-p "\\.html$\\|\\.ts$\\'" (buffer-file-name))
                                         (lsp-workspace-root)
                                         (file-exists-p (f-join (lsp-workspace-root) "angular.json"))))
                   :priority -1


### PR DESCRIPTION
Angular lsp server can support inline HTML templates, but `activation-fn` prevents from `angular-ls` to be executed for Typescript files. Also extensions should match end of line, other wise "some-file.html.json" will match.