### PR TITLE
Implement eslint/probeFailed in lsp-eslint

### DIFF
--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -295,6 +295,10 @@ to allow or deny it.")
              (lsp--persist lsp-eslint-library-choices-file lsp-eslint--stored-libraries)))
          (funcall callback (car option)))))))
 
+(defun lsp-eslint--probe-failed (_workspace _message)
+  "Called when the server detects a misconfiguration in ESLint."
+  (user-error "ESLint is not configured correctly. Please ensure your eslintrc is set up for the languages you are using"))
+
 (lsp-register-client
  (make-lsp-client
   :new-connection
@@ -313,7 +317,8 @@ to allow or deny it.")
   :multi-root t
   :notification-handlers (ht ("eslint/status" #'lsp-eslint-status-handler))
   :request-handlers (ht ("workspace/configuration" #'lsp-eslint--configuration)
-                        ("eslint/openDoc" #'lsp-eslint--open-doc))
+                        ("eslint/openDoc" #'lsp-eslint--open-doc)
+                        ("eslint/probeFailed" #'lsp-eslint--probe-failed))
   :async-request-handlers (ht ("eslint/confirmESLintExecution" #'lsp-eslint--confirm-local))
   :server-id 'eslint
   :initialized-fn (lambda (workspace)

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -297,7 +297,7 @@ to allow or deny it.")
 
 (defun lsp-eslint--probe-failed (_workspace _message)
   "Called when the server detects a misconfiguration in ESLint."
-  (user-error "ESLint is not configured correctly. Please ensure your eslintrc is set up for the languages you are using"))
+  (lsp--error "ESLint is not configured correctly. Please ensure your eslintrc is set up for the languages you are using."))
 
 (lsp-register-client
  (make-lsp-client


### PR DESCRIPTION
This PR implements the `eslint/probeFailed` request in the ESLint language server. From my investigations, this request seems to be fired on the following conditions:

- The ESLint configuration does not exist
- ESLint is not configured for the language in use (eg. `@typescript-eslint/parser` isn't set as the parser when using ESLint on TypeScript files)

The best way for us to handle this is probably just to display an error to the user, telling them to check their ESLint configurations.