### PR TITLE
Make paths for typescript-language-server configurable

### DIFF
--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -68,6 +68,18 @@
   :group 'lsp-mode
   :link '(url-link "https://github.com/theia-ide/typescript-language-server"))
 
+(defcustom lsp-clients-typescript-tls-path nil
+  "Path to the typescript-language-server binary."
+  :group 'lsp-typescript
+  :risky t
+  :type 'string)
+
+(defcustom lsp-clients-typescript-tsserver-path nil
+  "Path to the tsserver binary."
+  :group 'lsp-typescript
+  :risky t
+  :type 'string)
+
 (defcustom lsp-clients-typescript-server-args '("--stdio")
   "Extra arguments for the typescript-language-server language server."
   :group 'lsp-typescript
@@ -109,9 +121,11 @@ directory containing the package. Example:
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
-                                                          `(,(lsp-package-path 'typescript-language-server)
+                                                          `(,(or lsp-clients-typescript-tls-path
+                                                                 (lsp-package-path 'typescript-language-server))
                                                             "--tsserver-path"
-                                                            ,(lsp-package-path 'typescript)
+                                                            ,(or lsp-clients-typescript-tsserver-path
+                                                                 (lsp-package-path 'typescript))
                                                             ,@lsp-clients-typescript-server-args)))
                   :activation-fn 'lsp-typescript-javascript-tsx-jsx-activate-p
                   :priority -2

--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -68,14 +68,8 @@
   :group 'lsp-mode
   :link '(url-link "https://github.com/theia-ide/typescript-language-server"))
 
-(defcustom lsp-clients-typescript-tls-path nil
+(defcustom lsp-clients-typescript-tls-path "typescript-language-server"
   "Path to the typescript-language-server binary."
-  :group 'lsp-typescript
-  :risky t
-  :type 'string)
-
-(defcustom lsp-clients-typescript-tsserver-path nil
-  "Path to the tsserver binary."
   :group 'lsp-typescript
   :risky t
   :type 'string)
@@ -110,7 +104,7 @@ directory containing the package. Example:
                                                 xs)))))
 
 (lsp-dependency 'typescript-language-server
-                '(:system "typescript-language-server")
+                '(:system lsp-clients-typescript-tls-path)
                 '(:npm :package "typescript-language-server"
                        :path "typescript-language-server"))
 
@@ -121,11 +115,9 @@ directory containing the package. Example:
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
-                                                          `(,(or lsp-clients-typescript-tls-path
-                                                                 (lsp-package-path 'typescript-language-server))
+                                                          `(,(lsp-package-path 'typescript-language-server)
                                                             "--tsserver-path"
-                                                            ,(or lsp-clients-typescript-tsserver-path
-                                                                 (lsp-package-path 'typescript))
+                                                            ,(lsp-package-path 'typescript)
                                                             ,@lsp-clients-typescript-server-args)))
                   :activation-fn 'lsp-typescript-javascript-tsx-jsx-activate-p
                   :priority -2


### PR DESCRIPTION
This PR adds two new configuration options, `lsp-clients-typescript-tls-path` for setting an path to `typescript-language-server`, and `lsp-clients-typescript-tsserver-path` for setting a path to `tsserver`. The reasoning for adding these options is to better support [Yarn 2](https://yarnpkg.com/getting-started/editor-sdks) and [PnPify](https://yarnpkg.com/advanced/pnpify). Because of the way Yarn 2 and PnP work, Yarn needs to create wrapper scripts around `tsserver` and `typescript-language-server` for them to work correctly. With this PR, users can set the aformentioned configuration options to the path to Yarn's generated wrappers so they can use lsp-mode in Yarn 2 projects.