### PR TITLE
lsp-clojure: remove bash -c from launch cmd

### DIFF
--- a/clients/lsp-clojure.el
+++ b/clients/lsp-clojure.el
@@ -217,7 +217,7 @@ If there are more arguments expected after the line and column numbers."
   :new-connection (lsp-stdio-connection
                    (lambda ()
                      (or lsp-clojure-custom-server-command
-                         `("bash" "-c" ,(lsp-clojure--server-executable-path))))
+                         `(,(lsp-clojure--server-executable-path))))
                    (lambda ()
                      (or lsp-clojure-custom-server-command
                          (lsp-clojure--server-executable-path))))


### PR DESCRIPTION
Since we switched to use native binary, `bash -c` is no longer needed. Removing it will allow `lsp-clojure` to work OTB in Windows.
Tested on WSL2 and Windows.