### PR TITLE
Improve signature help content

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5019,11 +5019,13 @@ It will show up only if current point has signature help."
             (active-signature? (or lsp--signature-last-index active-signature? 0))
             (_ (setq lsp--signature-last-index active-signature?))
             ((signature &as &SignatureInformation? :label :parameters?) (seq-elt signatures active-signature?))
-            (prefix (concat (propertize (format " %s/%s"
-                                                (1+ active-signature?)
-                                                (length signatures))
-                                        'face 'success)
-                            " │ "))
+            (prefix (if (eq 1 (length signatures))
+                        ""
+                      (concat (propertize (format " %s/%s"
+                                                  (1+ active-signature?)
+                                                  (length signatures))
+                                          'face 'success)
+                              " ")))
             (method-docs (when
                              (and lsp-signature-render-documentation
                                   (or (not (numberp lsp-signature-doc-lines)) (< 0 lsp-signature-doc-lines)))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5019,7 +5019,7 @@ It will show up only if current point has signature help."
             (active-signature? (or lsp--signature-last-index active-signature? 0))
             (_ (setq lsp--signature-last-index active-signature?))
             ((signature &as &SignatureInformation? :label :parameters?) (seq-elt signatures active-signature?))
-            (prefix (if (eq 1 (length signatures))
+            (prefix (if (not (cl-rest signatures))
                         ""
                       (concat (propertize (format " %s/%s"
                                                   (1+ active-signature?)


### PR DESCRIPTION
Just make the content of signature help cleaner/less noisy

- Remove the `|` on the content, the green face already makes that a different section
- Remove the args count when length = 1, [just like vscode](https://github.com/BetterThanTomorrow/calva/blob/published/assets/howto/signature-help.gif)

![signature-help-cleaner](https://user-images.githubusercontent.com/7820865/108615653-072c9780-73e5-11eb-9509-d824f92d75dc.gif)
