### PR TITLE
Don't use `cursor-sensor-mode`

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7609,7 +7609,6 @@ When ALL is t, erase all log buffers of the running session."
         (buf (get-buffer-create "*lsp session*")))
     (with-current-buffer buf
       (lsp-browser-mode)
-      (cursor-sensor-mode 1)
       (let ((inhibit-read-only t))
         (erase-buffer)
         (--each (lsp-session-folders session)


### PR DESCRIPTION
`cursor-sensor-functions` isn't used anywhere, so don't enable it in
`lsp-describe-session`.


----

#