### PR TITLE
Update gopls installation path

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -175,7 +175,7 @@
     "full-name": "Go",
     "server-name": "gopls",
     "server-url": "https://github.com/golang/tools/tree/master/gopls",
-    "installation-url": "https://github.com/golang/tools/blob/master/gopls/doc/user.md#installation",
+    "installation-url": "https://github.com/golang/tools/tree/master/gopls#installation",
     "debugger": "Yes"
   },
   {


### PR DESCRIPTION
URL was deprecated and lead to 404.