### PR TITLE
Drop lsp--send-execute-command

### DIFF
--- a/clients/lsp-clojure.el
+++ b/clients/lsp-clojure.el
@@ -79,7 +79,7 @@
 (defun lsp-clojure--execute-command (command &optional args)
   "Send an executeCommand request for COMMAND with ARGS."
   (lsp--cur-workspace-check)
-  (lsp--send-execute-command command (apply #'vector args)))
+  (lsp-send-execute-command command (apply #'vector args)))
 
 (defun lsp-clojure--refactoring-call (refactor-name &rest additional-args)
   "Send an executeCommand request for REFACTOR-NAME with ADDITIONAL-ARGS.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5219,7 +5219,7 @@ It will filter by KIND if non nil."
       (cl-no-applicable-method
        (if-let ((action-handler (lsp--find-action-handler command)))
            (funcall action-handler action)
-         (lsp--send-execute-command command arguments?))))))
+         (lsp-send-execute-command command arguments?))))))
 
 (lsp-defun lsp-execute-code-action ((action &as &CodeAction :command? :edit?))
   "Execute code action ACTION.
@@ -5747,17 +5747,13 @@ REFERENCES? t when METHOD returns references."
                   (list :command command))))
     (lsp-request "workspace/executeCommand" params)))
 
-(defun lsp--send-execute-command (command &optional args)
+(defun lsp-send-execute-command (command &optional args)
   "Create and send a 'workspace/executeCommand' message having command COMMAND and optional ARGS."
-  (condition-case-unless-debug err
-      (lsp-workspace-command-execute command args)
-    (error
-     (lsp--error "Please open an issue in lsp-mode for implementing `%s'.\n\n%S"
-                 command err))))
+  (lsp-workspace-command-execute command args))
 
 (defalias 'lsp-point-to-position #'lsp--point-to-position)
 (defalias 'lsp-text-document-identifier #'lsp--text-document-identifier)
-(defalias 'lsp-send-execute-command #'lsp--send-execute-command)
+(defalias 'lsp--send-execute-command #'lsp-send-execute-command)
 (defalias 'lsp-on-open #'lsp--text-document-did-open)
 (defalias 'lsp-on-save #'lsp--text-document-did-save)
 


### PR DESCRIPTION
- fixes 2530
- fixes 2250

There is no way to distinguish whether the function is failing due to valid
reason or whether it is failing due to lack of client handling, thus removing
lsp--send-execute-command wrapper because it seems like it is causing more
trouble than good.