### PR TITLE
`lsp-ext-unzip-script' overwrite files WITHOUT prompting

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7241,7 +7241,7 @@ STORE-PATH to make it executable."
 -nologo -ex bypass Expand-Archive -path '%s' -dest '%s'"
   "Powershell script to unzip file.")
 
-(defconst lsp-ext-unzip-script "bash -c 'mkdir -p %2$s && unzip -qq %1$s -d %2$s'"
+(defconst lsp-ext-unzip-script "bash -c 'mkdir -p %2$s && unzip -qq -o %1$s -d %2$s'"
   "Unzip script to unzip file.")
 
 (defcustom lsp-unzip-script (cond ((executable-find "powershell") lsp-ext-pwsh-script)


### PR DESCRIPTION
``` 
LSP :: Download clojure-lsp started.
LSP :: Starting to download https://github.com/clojure-lsp/clojure-lsp/releases/latest/download/clojure-lsp-native-linux-amd64.zip to /home/zsxh/.emacs.d/.cache/lsp/clojure/clojure-lsp.zip...
Contacting host: github.com:443
Mark set [2 times]
Wrote /home/zsxh/.emacs.d/.cache/lsp/clojure/clojure-lsp.zip
LSP :: Finished downloading /home/zsxh/.emacs.d/.cache/lsp/clojure/clojure-lsp.zip...
LSP :: Decompressing /home/zsxh/.emacs.d/.cache/lsp/clojure/clojure-lsp.zip...
replace /home/zsxh/.emacs.d/.cache/lsp/clojure/clojure-lsp? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
(EOF or read error, treating as "[N]one" ...)
LSP :: Decompressed /home/zsxh/.emacs.d/.cache/lsp/clojure/clojure-lsp...
LSP :: Server clojure-lsp downloaded, auto-starting in 0 buffers.
```
`lsp-install-server` failed to update clojure server when clojure-lsp file already exists.
