### PR TITLE
Try to get rust-analyzer flyimport completions working

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -528,7 +528,7 @@ Others: CANDIDATES"
 
         (when lsp-completion-enable-additional-text-edit
           (if (or (get-text-property 0 'lsp-completion-resolved candidate)
-                  additional-text-edits?)
+                  (lsp-seq-first additional-text-edits?))
               (lsp--apply-text-edits additional-text-edits? 'completion)
             (-let [(callback cleanup-fn) (lsp--create-apply-text-edits-handlers)]
               (lsp-completion--resolve-async

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3258,6 +3258,7 @@ disappearing, unset all the variables related to it."
                                                                              :json-false)
                                                                             (lsp-enable-snippet t)
                                                                             (t :json-false)))
+                                                        (resolveSupport . ((properties . ["additionalTextEdits"])))
                                                         (documentationFormat . ["markdown"])
                                                         (resolveAdditionalTextEditsSupport . t)))
                                      (contextSupport . t)))


### PR DESCRIPTION
rust-analyzer can provide completions that automatically insert imports as needed, but this doesn't currently work with lsp-mode. These completions require `completionItem/resolve` support, which doesn't seem to be quite working.

I've fixed two things so far: the `resolveSupport` capability wasn't set; and `additional-text-edits?` was used in a condition, but it's a vector, which is truthy even when empty.

Sadly, it still doesn't work: The `completionItem/resolve` request gets sent, but rust-analyzer returns null. I think this is because lsp-mode sends a `didChange` notification before sending the request, which invalidates the completion item in rust-analyzer; but I haven't debugged it in detail yet.

You can reproduce the problem by applying this PR, then opening a new, empty cargo project and typing `repla` in the main function. You should get a completion for `std::mem::replace(...)` among others; if you select it, lsp-mode inserts `replace()` and nothing else. It should also insert a `use` statement.