### PR TITLE
lsp-csharp.el: add "lsp-csharp-solution-file" customizable

### DIFF
--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -53,6 +53,13 @@ Set this if you have the binary installed or have it built yourself."
   :group 'lsp-csharp
   :type 'string)
 
+(defcustom lsp-csharp-solution-file
+  nil
+  "Solution to load when starting the server.
+Usually this is to be set in your .dir-locals.el on the project root directory."
+  :group 'lsp-csharp
+  :type 'string)
+
 (defun lsp-csharp--version-list-latest (lst)
   (->> lst
        (-sort (lambda (a b) (not (version<= (substring a 1)
@@ -239,7 +246,9 @@ tarball or a zip file (based on a current platform) to TARGET-DIR."
 
 (defun lsp-csharp--language-server-command ()
   "Resolves path and arguments to use to start the server."
-  (list (lsp-csharp--language-server-path) "-lsp"))
+  (append
+   (list (lsp-csharp--language-server-path) "-lsp")
+   (when lsp-csharp-solution-file (list "-s" (expand-file-name lsp-csharp-solution-file)))))
 
 (lsp-defun lsp-csharp-open-project-file ()
   "Open corresponding project file  (.csproj) for the current file."


### PR DESCRIPTION
This can be used to select a particular solution file to load out of
many in a large project to reduce loading time by loading just the
projects that are included in the solution only.