### PR TITLE
Use compilation for `lsp-install` buffers (`lsp-async-start-process`)

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6999,11 +6999,13 @@ JavaScript file, tsserver.js (the *.js is required for Windows)."
 
 (defvar-local lsp--installation-buffer nil)
 
-(defun lsp-select-installation-buffer ()
-  "Interactively choose an installation buffer."
-  (interactive)
+(defun lsp-select-installation-buffer (&optional show-finished)
+  "Interactively choose an installation buffer.
+If SHOW-FINISHED is set, leftover (finished) installation buffers
+are still shown."
+  (interactive "P")
   (let ((bufs (--filter (and (buffer-local-value 'lsp--installation-buffer it)
-                             (get-buffer-process it))
+                             (or show-finished (get-buffer-process it)))
                         (buffer-list))))
     (pcase bufs
       (`nil (user-error "No installation buffers"))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6999,6 +6999,16 @@ JavaScript file, tsserver.js (the *.js is required for Windows)."
 
 (defvar-local lsp--installation-buffer nil)
 
+(defface lsp-installation-finished-buffer-face '((t :foreground "orange"))
+  "Face used for finished installation buffers.
+Used in `lsp-select-installation-buffer'."
+  :group 'lsp-mode)
+
+(defface lsp-installation-buffer-face '((t :foreground "green"))
+  "Face used for installation buffers still in progress.
+Used in `lsp-select-installation-buffer'."
+  :group 'lsp-mode)
+
 (defun lsp-select-installation-buffer (&optional show-finished)
   "Interactively choose an installation buffer.
 If SHOW-FINISHED is set, leftover (finished) installation buffers
@@ -7011,7 +7021,11 @@ are still shown."
       (`nil (user-error "No installation buffers"))
       (`(,buf) (pop-to-buffer buf))
       (bufs (pop-to-buffer (completing-read "Select installation buffer: "
-                                            (mapcar #'buffer-name bufs)))))))
+                                            (--map (propertize (buffer-name it) 'face
+                                                               (if (get-buffer-process it)
+                                                                   'lsp-installation-buffer-face
+                                                                 'lsp-installation-finished-buffer-face))
+                                                   bufs)))))))
 
 (defun lsp--download-status ()
   (-some--> #'lsp--client-download-in-progress?


### PR DESCRIPTION
- There is now a separate buffer for each `M-x lsp-install-server` invocation,
  instead of a single `*lsp-install*` buffer.
- `ansi` escapes now install buffers, so `npm install`/everything else now looks
  pretty and colourful instead of gray with escapes intermingled
- The modeline button to select the `*lsp-install*` buffer still works, but it
  now uses `completing-read`, with the code refactored to a new function
  + this function colourises buffer names based on whether the installation is
    still running
  + if there is only a single installation buffer, it is switched to immediately
    (the various commits go into more detail)

----

#