### PR TITLE
Run GitHub Actions with fail-fast false

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ jobs:
     unix-test:
         runs-on: ${{ matrix.os }}
         strategy:
+            fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest]
                 emacs-version:
@@ -61,6 +62,7 @@ jobs:
     windows-test:
         runs-on: windows-latest
         strategy:
+            fail-fast: false
             matrix:
                 emacs-version:
                     - 26.1


### PR DESCRIPTION
Hi, Thanks for maintaining such a great project!

And I'm sorry for your inconvenience on my Cask issue.
I got an issue from @jcs090218 and see your [CI log](https://github.com/emacs-lsp/lsp-mode/runs/2046150488).

I suggest put strategy#fail-fast as `false`. This option changes
the default behavior of canceling other jobs when a job fails, so
that each CI job completes to the end without canceling.

This option allows you to see the results of jobs that work
without being disturbed by jobs that randomly fail due to Cask
factors.