### PR TITLE
git-commit-major-mode is not safe buffer-local variable

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,6 +1,4 @@
 ((nil
   (require-final-newline . t))
- (git-commit-mode
-  (git-commit-major-mode . git-commit-elisp-text-mode))
  (emacs-lisp-mode
   (indent-tabs-mode . nil)))


### PR DESCRIPTION
CC: @leungbk
This is remained work on #2689.
`git-commit-major-mode` is also not safe buffer-local variable.

Sorry, this variable for `git-commit-mode`, I couldnot catch it.