### PR TITLE
Use inclusive comparison to construct a document-symbol hierarchy

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5480,11 +5480,8 @@ perform the request synchronously."
 (defun lsp--document-symbols->document-symbols-hierarchy (document-symbols current-position)
   "Convert DOCUMENT-SYMBOLS to symbols hierarchy on CURRENT-POSITION."
   (-let (((symbol &as &DocumentSymbol? :children?)
-          (seq-some (-lambda ((symbol &as &DocumentSymbol :range (&Range :start start-position
-                                                                         :end end-position)))
-                      (when (and (lsp--position-compare current-position start-position)
-                                 (lsp--position-compare end-position current-position))
-                        symbol))
+          (seq-find (-lambda ((&DocumentSymbol :range))
+                      (lsp-point-in-range? current-position range))
                     document-symbols)))
     (if children?
         (cons symbol (lsp--document-symbols->document-symbols-hierarchy children? current-position))


### PR DESCRIPTION
The previous way of doing it disregarded any current-position that did
not satisfy a_start < b_start, b_end < a_end. The current comparison
is more like a_start <= b_start, b_end <= b_end.

This fixes the following headerline bug:

![output-2021-03-07-15:41:33](https://user-images.githubusercontent.com/29217594/110261721-263f3380-7f66-11eb-866b-b1f24b36f3bb.gif)

When on the first character of a heading, the headerline does not include that heading entry, and only when we move to the second character do we see the headerline include that heading.