### PR TITLE
Remove go-bingo language server from documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,6 @@ nav:
     - Fortran: page/lsp-fortran.md
     - GDScript: page/lsp-gdscript.md
     - Go (gopls): page/lsp-gopls.md
-    - Go (bingo): page/lsp-bingo.md
     - Grammarly: page/lsp-grammarly.md
     - Groovy: page/lsp-groovy.md
     - Hack: page/lsp-hack.md


### PR DESCRIPTION
Go bingo docs are removed but it was still visible in the language server list https://emacs-lsp.github.io/lsp-mode/page/languages/. It is now removed.