### PR TITLE
Make sure that unchanged goes back to original buffer

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3142,9 +3142,10 @@ CANCEL-TOKEN is the token that can be used to cancel request."
                                (funcall error-callback error)))
              (cancel-callback (when cancel-callback
                                 (pcase mode
-                                  ((or 'alive 'tick) (lambda ()
-                                                       (with-current-buffer buf
-                                                         (funcall cancel-callback))))
+                                  ((or 'alive 'tick 'unchanged)
+                                   (lambda ()
+                                     (with-current-buffer buf
+                                       (funcall cancel-callback))))
                                   (_ cancel-callback))))
              (body (plist-put body :id id)))
 


### PR DESCRIPTION
Fixes #2701

there are cases in which post-command hook does not run in order to cancel the
request in 'unchanged mode, thus make sure that we are in the original buffer
when running the callback. Note that canceling the request is not critical and
we can afford those calls to run without canceling them.