### PR TITLE
Fix angular-ls starting exited error when using nvm

### DIFF
--- a/clients/lsp-angular.el
+++ b/clients/lsp-angular.el
@@ -36,13 +36,15 @@
   :link '(url-link "https://github.com/angular/vscode-ng-language-service"))
 
 (defcustom lsp-clients-angular-language-server-command
-  '("node"
-    "/usr/lib/node_modules/@angular/language-server"
-    "--ngProbeLocations"
-    "/usr/lib/node_modules"
-    "--tsProbeLocations"
-    "/usr/lib/node_modules"
-    "--stdio")
+  (let ((node-modules-path (concat (string-trim (shell-command-to-string "npm config get --global prefix")) "/lib/node_modules")))
+    (list
+     "node"
+     (concat node-modules-path "/@angular/language-server")
+     "--ngProbeLocations"
+     node-modules-path
+     "--tsProbeLocations"
+     node-modules-path
+     "--stdio"))
   "The command that starts the angular language server."
   :group 'lsp-angular
   :type '(choice

--- a/clients/lsp-angular.el
+++ b/clients/lsp-angular.el
@@ -36,15 +36,7 @@
   :link '(url-link "https://github.com/angular/vscode-ng-language-service"))
 
 (defcustom lsp-clients-angular-language-server-command
-  (let ((node-modules-path (concat (string-trim (shell-command-to-string "npm config get --global prefix")) "/lib/node_modules")))
-    (list
-     "node"
-     (concat node-modules-path "/@angular/language-server")
-     "--ngProbeLocations"
-     node-modules-path
-     "--tsProbeLocations"
-     node-modules-path
-     "--stdio"))
+  nil
   "The command that starts the angular language server."
   :group 'lsp-angular
   :type '(choice
@@ -60,7 +52,19 @@
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection
-                                   (lambda () lsp-clients-angular-language-server-command))
+                                   (lambda () (if lsp-clients-angular-language-server-command
+                                                  lsp-clients-angular-language-server-command
+                                                (let ((node-modules-path
+                                                       (concat (string-trim (shell-command-to-string "npm config get --global prefix"))
+                                                               "/lib/node_modules")))
+                                                  (list
+                                                   "node"
+                                                   (concat node-modules-path "/@angular/language-server")
+                                                   "--ngProbeLocations"
+                                                   node-modules-path
+                                                   "--tsProbeLocations"
+                                                   node-modules-path
+                                                   "--stdio")))))
                   :activation-fn (lambda (&rest _args)
                                    (and (string-match-p "\\(\\.html\\|\\.ts\\)\\'" (buffer-file-name))
                                         (lsp-workspace-root)


### PR DESCRIPTION
when using [nvm](https://github.com/nvm-sh/nvm) managed NodeJS installation, angular-ls cannot
start because the node_modules directory is located some where
under user home, instead of under the system location `/usr/lib'.