### PR TITLE
Add an option to override the computed project root

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -222,6 +222,13 @@ following `projectile'/`project.el' conventions."
   :group 'lsp-mode
   :type 'boolean)
 
+(defcustom lsp-project-root nil
+  "The root of the project.
+This will normally be automatically guessed via `projectile'/`project.el',
+but this can sometimes be inconsistent,especially when you have monorepos."
+  :group 'lsp-mode
+  :type 'directory)
+
 (defcustom lsp-restart 'interactive
   "Defines how server-exited events must be handled."
   :group 'lsp-mode
@@ -3429,6 +3436,7 @@ in that particular folder."
 (defun lsp--suggest-project-root ()
   "Get project root."
   (or
+   lsp-project-root
    (when (featurep 'projectile) (condition-case nil
                                     (projectile-project-root)
                                   (error nil)))


### PR DESCRIPTION
# Context
Currently, `lsp-mode` will attempt to use `projectile` or `project.el` to determine the project root. This works great for most projects, but runs into some difficulties in some situations, namely, monorepos. It is common to place a project file at the _top level_ of the project, which leads to `lsp-mode` inferring the incorrect project root. You can disable this behavior via `lsp-auto-guess-root`, but this means that the user needs to fill in the prompt every time they start the language server. Furthermore, these errors are often subtle, and show up only when relative paths are involved.

# Patch Description
This PR adds an option `lsp-project-root` that allows users to override the auto-computed project root. Ideally, this should be set in a `.dir-locals` file. In the future, it may be a good idea to provide each language server configuration with the ability to configure the project root, but this is out of scope of this ticket.

# Impact
This issue is currently impacting many users of the [haskell-language-server](https://github.com/haskell/haskell-language-server), particularly those with template haskell that uses relative paths.
