### PR TITLE
Add support for dlang (serve-d)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -25,6 +25,7 @@
   * Add ~lsp-dired-mode~ - integration between [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Dired.html][dired]] and ~lsp-mode~
   `dired` and `lsp-mode` diagnostics.
   * Add Grammarly support.
+  * Add D support.
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/clients/lsp-d.el
+++ b/clients/lsp-d.el
@@ -1,0 +1,35 @@
+;;; lsp-d.el --- lsp-mode dlang integration -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2021 lsp-mode maintainers
+
+;; Author: lsp-mode maintainers
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;  client for serve-d
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection "serve-d")
+                  :major-modes '(d-mode)
+                  :server-id 'serve-d))
+
+(provide 'lsp-d)
+;;; lsp-d.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -96,6 +96,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "d",
+    "full-name": "D",
+    "server-name": "serve-d",
+    "server-url": "https://github.com/pure-d/serve-d",
+    "installation-url": "https://github.com/pure-d/serve-d#installation",
+    "debugger": "Yes"
+  },
+  {
     "name": "dhall",
     "full-name": "Dhall",
     "server-name": "dhall-lsp-server",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -768,7 +768,8 @@ Changes take effect only when a new session is started."
                                         (nix-mode . "nix")
                                         (prolog-mode . "prolog")
                                         (vala-mode . "vala")
-                                        (actionscript-mode . "actionscript"))
+                                        (actionscript-mode . "actionscript")
+                                        (d-mode . "d"))
   "Language id configuration.")
 
 (defvar lsp--last-active-workspaces nil

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -169,7 +169,7 @@ As defined by the Language Server Protocol 3.16."
 
 (defcustom lsp-client-packages
   '(ccls lsp-actionscript lsp-ada lsp-angular lsp-bash lsp-clangd lsp-clojure lsp-cmake
-         lsp-crystal lsp-csharp lsp-css lsp-dart lsp-dhall lsp-dockerfile lsp-elm
+         lsp-crystal lsp-csharp lsp-css lsp-d lsp-dart lsp-dhall lsp-dockerfile lsp-elm
          lsp-elixir lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript lsp-go
          lsp-hack lsp-grammarly lsp-groovy lsp-haskell lsp-haxe lsp-java lsp-javascript lsp-json
          lsp-kotlin lsp-lua lsp-nim lsp-nix lsp-metals lsp-ocaml lsp-perl lsp-php lsp-pwsh

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
     - CMake: page/lsp-cmake.md
     - Crystal: page/lsp-crystal.md
     - CSS/LessCSS/SASS/SCSS: page/lsp-css.md
+    - D: page/d.md
     - Dart: https://emacs-lsp.github.io/lsp-dart
     - Dhall: page/lsp-dhall.md
     - Dockerfile: page/lsp-dockerfile.md


### PR DESCRIPTION
This PR adds bare-bones support for [the D programming language](https://dlang.org/) using [the serve-d language server](https://github.com/Pure-D/serve-d).

![image](https://user-images.githubusercontent.com/9300702/111452524-fcfe7000-86e8-11eb-8814-d2cae63b91a1.png)