### PR TITLE
lsp-zig: allow zls executable path to be customized

### DIFF
--- a/clients/lsp-zig.el
+++ b/clients/lsp-zig.el
@@ -26,9 +26,21 @@
 
 (require 'lsp-mode)
 
+(defgroup lsp-zig nil
+  "LSP support for Zig via zls."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/zigtools/zls"))
+
+(defcustom lsp-clients-zls-executable "zls"
+  "The zls executable to use.
+Leave as just the executable name to use the default behavior of
+finding the executable with variable `exec-path'."
+  :group 'lsp-zig
+  :type 'string)
+
 (lsp-register-client
  (make-lsp-client
-  :new-connection (lsp-stdio-connection "zls")
+  :new-connection (lsp-stdio-connection lsp-clients-zls-executable)
   :activation-fn (lsp-activate-on "zig")
   :server-id 'zls))
 


### PR DESCRIPTION
zls is still in active development, and no up-to-date binary releases are maintained. Hence, building zls is a common occurrence and being able to customize the path to the zls executable would be beneficial.

I've tried to follow similar conventions as other clients in the codebase.