### PR TITLE
Adds deno entry to languages list in docs

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -247,7 +247,7 @@
   },
   {
     "name": "deno",
-    "full-name": "Deno",
+    "full-name": "Javascript/Typescript (deno)",
     "server-name": "deno lsp",
     "server-url": "https://deno.land/#installation",
     "debugger": "Yes (Chrome)"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
     - Lua (Lua Language Server): page/lsp-lua-language-server.md
     - Lua (Lua-Lsp): page/lsp-lua-lsp.md
     - Java: https://emacs-lsp.github.io/lsp-java
+    - Javascript/Typescript (deno): page/lsp-deno.md
     - JavaScript/TypeScript (sourcegraph): page/lsp-typescript-javascript.md
     - JavaScript/TypeScript (theia-ide): page/lsp-typescript.md
     - JavaScript Flow: page/lsp-flow.md


### PR DESCRIPTION
Related to #2607 it was missing the entry to the languages list in the docs.