### PR TITLE
[diagnostics] Use a lighter gray on unnecessary face

### DIFF
--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -53,7 +53,7 @@
   :group 'lsp-mode)
 
 (defcustom lsp-diagnostics-attributes
-  `((unnecessary :foreground "dim gray")
+  `((unnecessary :foreground "gray")
     (deprecated  :strike-through t))
   "The Attributes used on the diagnostics.
 List containing (tag attributes) where tag is the LSP diagnostic tag and


### PR DESCRIPTION
The current default unnecessary face is too dark, this PR change to use a lighter gray instead of one for the darkest grays.

Before:
![image](https://user-images.githubusercontent.com/7820865/111723306-1404a580-8842-11eb-9c0a-2f547e51906b.png)
After:
![image](https://user-images.githubusercontent.com/7820865/111723506-65ad3000-8842-11eb-941b-18ed67e139e2.png)

