### PR TITLE
Add Rust-Analyzer reload workspace command

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -26,6 +26,7 @@
   * Add Grammarly support.
   * Add D support.
   * Add Zig support.
+  * Add an interactive ~lsp-rust-analyzer-reload-workspace~ function that reloads the Rust-Analyzer workspace from Cargo.toml
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -607,6 +607,7 @@ them with `crate` or the crate name they refer to."
 (defun lsp-rust-analyzer-reload-workspace ()
   "Reload workspace, picking up changes from Cargo.toml"
   (interactive)
+  (lsp--cur-workspace-check)
   (lsp-send-request (lsp-make-request "rust-analyzer/reloadWorkspace")))
 
 (defcustom lsp-rust-analyzer-download-url

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -604,6 +604,11 @@ them with `crate` or the crate name they refer to."
          (result (lsp-send-request (lsp-make-request "experimental/joinLines" params))))
     (lsp--apply-text-edits result 'code-action)))
 
+(defun lsp-rust-analyzer-reload-workspace ()
+  "Reload workspace, picking up changes from Cargo.toml"
+  (interactive)
+  (lsp-send-request (lsp-make-request "rust-analyzer/reloadWorkspace")))
+
 (defcustom lsp-rust-analyzer-download-url
   (format "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/%s"
           (pcase system-type


### PR DESCRIPTION
This lets Rust-Analyzer pick up project changes without a full server restart.