### PR TITLE
lsp-zig: rename variable to `lsp-zig-zls-executable`

### DIFF
--- a/clients/lsp-zig.el
+++ b/clients/lsp-zig.el
@@ -31,7 +31,7 @@
   :group 'lsp-mode
   :link '(url-link "https://github.com/zigtools/zls"))
 
-(defcustom lsp-clients-zls-executable "zls"
+(defcustom lsp-zig-zls-executable "zls"
   "The zls executable to use.
 Leave as just the executable name to use the default behavior of
 finding the executable with variable `exec-path'."
@@ -40,7 +40,7 @@ finding the executable with variable `exec-path'."
 
 (lsp-register-client
  (make-lsp-client
-  :new-connection (lsp-stdio-connection lsp-clients-zls-executable)
+  :new-connection (lsp-stdio-connection (lambda () lsp-zig-zls-executable))
   :activation-fn (lsp-activate-on "zig")
   :server-id 'zls))
 


### PR DESCRIPTION
This commit also uses a lambda to get the latest value of `lsp-zig-zls-executable` to allow customization after `lsp-zig` has been loaded.

Ref. https://github.com/emacs-lsp/lsp-mode/pull/2724#discussion_r596966814.
Ref. https://github.com/emacs-lsp/lsp-mode/pull/2724#discussion_r596967468.