### PR TITLE
Fix handling of lsp-file-watch-ignored-[directories|files]

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -28,6 +28,7 @@
   * Add Zig support.
   * Add an interactive ~lsp-rust-analyzer-reload-workspace~ function that reloads the Rust-Analyzer workspace from Cargo.toml
   * Rename ~lsp-rust-analyzer-cargo-load-out-dirs-from-check~ to ~lsp-rust-analyzer-cargo-run-build-scripts~ to align with upstream.
+  * Allow customization of ~lsp-file-watch-ignored-directories~ and ~lsp-file-watch-ignored-files~ at the root of an lsp workspace.
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/test/lsp-file-watch-test.el
+++ b/test/lsp-file-watch-test.el
@@ -40,7 +40,9 @@
                  temp-directory
                  (lambda (event)
                    (message "received: %s" event)
-                   (add-to-list 'events (cdr event)))))
+                   (add-to-list 'events (cdr event)))
+                 lsp-file-watch-ignored-files
+                 lsp-file-watch-ignored-directories))
 
     (write-region "bla" nil matching-file)
 
@@ -111,7 +113,9 @@
   :tags '(no-win)
   (lsp-kill-watch (lsp-watch-root-folder
                    "non-existing-directory"
-                   #'ignore)))
+                   #'ignore
+                   lsp-file-watch-ignored-files
+                   lsp-file-watch-ignored-directories)))
 
 (ert-deftest lsp-file-watch--relative-path-glob-patterns ()
   :tags '(no-win)
@@ -131,7 +135,9 @@
                  temp-directory
                  (lambda (event)
                    (message "received: %s" event)
-                   (add-to-list 'events (cdr event)))))
+                   (add-to-list 'events (cdr event)))
+                 lsp-file-watch-ignored-files
+                 lsp-file-watch-ignored-directories))
 
     (write-region "bla" nil matching-file)
     (sit-for 0.3)
@@ -220,14 +226,17 @@
          (nested-dir (f-join temp-directory "nested"))
          (nested-matching-file (f-join nested-dir "file.ext"))
          (create-lockfiles nil)
-         (lsp-file-watch-ignored-directories '("nested"))
+         (ignored-files lsp-file-watch-ignored-files)
+         (ignored-directories '("nested"))
          events watch)
 
     (mkdir nested-dir)
 
     (setq watch (lsp-watch-root-folder
                  temp-directory
-                 (lambda (event) (add-to-list 'events (cdr event)))))
+                 (lambda (event) (add-to-list 'events (cdr event)))
+                 ignored-files
+                 ignored-directories))
 
     (write-region "bla" nil nested-matching-file)
     (sit-for 0.3)
@@ -241,6 +250,8 @@
          (nested-dir (f-join temp-directory "nested"))
          (nested-matching-file (f-join nested-dir "file.ext"))
          (create-lockfiles nil)
+         (ignored-files lsp-file-watch-ignored-files)
+         (ignored-directories lsp-file-watch-ignored-directories)
          events watch expected-events)
 
     (mkdir nested-dir)
@@ -248,7 +259,9 @@
     (setq watch (lsp-watch-root-folder
                  temp-directory
                  (lambda (event)
-                   (add-to-list 'events (cdr event)))))
+                   (add-to-list 'events (cdr event)))
+                 ignored-files
+                 ignored-directories))
 
     (write-region "bla" nil nested-matching-file)
     (sit-for 0.3)


### PR DESCRIPTION
When either lsp-file-watch-ignored-directories or
lsp-file-watch-ignored-files are buffer local, the correct value may
not be used when a new directory is added to an already watched
directory. This is due to the watch callback invoking at any time. A
different buffer could be the active buffer when the callback is
invoked causing a different value of either of those two variables to
be used.

This was solved by capturing the value of those two variables at the
time the original watch was created and passing those values into the
watch function.