### PR TITLE
Get PHP Composer directory if possible

### DIFF
--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -34,7 +34,7 @@
   :group 'lsp-mode)
 
 (defcustom lsp-php-composer-dir
-  (if (eq (shell-command "composer -V") 0)
+  (if (executable-find "composer")
       (replace-regexp-in-string "\n$" "" (shell-command-to-string "composer config --global home"))
     "~/.composer")
   "Home directory of composer."

--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -33,8 +33,17 @@
   :link '(url-link "https://github.com/felixfbecker/php-language-server")
   :group 'lsp-mode)
 
+(defcustom lsp-php-composer-dir
+  (if (eq (shell-command "composer -V") 0)
+      (replace-regexp-in-string "\n$" "" (shell-command-to-string "composer config --global home"))
+    "~/.composer")
+  "Home directory of composer."
+  :group 'lsp-php
+  :type 'string)
+
 (defcustom lsp-clients-php-server-command
-  `("php" ,(expand-file-name "~/.composer/vendor/felixfbecker/language-server/bin/php-language-server.php"))
+  `("php", (expand-file-name
+            (concat lsp-php-composer-dir "/vendor/felixfbecker/language-server/bin/php-language-server.php")))
   "Install directory for php-language-server."
   :group 'lsp-php
   :type '(repeat string))
@@ -360,7 +369,7 @@ already present."
   :link '(url-link "https://github.com/phpactor/phpactor")
   :group 'lsp-mode)
 
-(defcustom lsp-phpactor-path "~/.composer/vendor/phpactor/phpactor/bin/phpactor"
+(defcustom lsp-phpactor-path (concat lsp-php-composer-dir "/vendor/phpactor/phpactor/bin/phpactor")
   "Path to the `phpactor' command."
   :group 'lsp-phpactor
   :type "string")

--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -37,8 +37,7 @@
   "Get composer home directory if possible."
   (if (executable-find "composer")
       (replace-regexp-in-string "\n$" "" (shell-command-to-string "composer config --global home"))
-    "~/.composer")
-  )
+    "~/.composer"))
 
 (defcustom lsp-php-composer-dir nil
   "Home directory of composer."
@@ -54,15 +53,14 @@
   "Create lsp connection."
   (lsp-stdio-connection
    (lambda ()
-     (if (not lsp-php-composer-dir)
-         (setq lsp-php-composer-dir (lsp-php-get-composer-dir)))
-     (if (not lsp-clients-php-server-command)
-         (setq lsp-clients-php-server-command
-               `("php",
-                 (expand-file-name
-                  (concat lsp-php-composer-dir "/vendor/felixfbecker/language-server/bin/php-language-server.php")))))
-     lsp-clients-php-server-command
-     )
+     (unless lsp-php-composer-dir
+       (setq lsp-php-composer-dir (lsp-php-get-composer-dir)))
+     (unless lsp-clients-php-server-command
+       (setq lsp-clients-php-server-command
+             `("php",
+               (expand-file-name
+                (f-join lsp-php-composer-dir "vendor/felixfbecker/language-server/bin/php-language-server.php")))))
+     lsp-clients-php-server-command)
    (lambda ()
      (if (and (cdr lsp-clients-php-server-command)
               (eq (string-match-p "php[0-9.]*\\'" (car lsp-clients-php-server-command)) 0))
@@ -389,10 +387,10 @@ already present."
  (make-lsp-client
   :new-connection (lsp-stdio-connection
                    (lambda ()
-                     (if (not lsp-php-composer-dir)
-                         (setq lsp-php-composer-dir (lsp-php-get-composer-dir)))
-                     (if (not lsp-phpactor-path)
-                         (setq lsp-phpactor-path (concat lsp-php-composer-dir "/vendor/phpactor/phpactor/bin/phpactor")))
+                     (unless lsp-php-composer-dir
+                       (setq lsp-php-composer-dir (lsp-php-get-composer-dir)))
+                     (unless lsp-phpactor-path
+                       (setq lsp-phpactor-path (f-join lsp-php-composer-dir "vendor/phpactor/phpactor/bin/phpactor")))
                      (list lsp-phpactor-path "language-server")))
   :activation-fn (lsp-activate-on "php")
   ;; `phpactor' is not really that feature-complete: it doesn't support

--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -41,9 +41,7 @@
   :group 'lsp-php
   :type 'string)
 
-(defcustom lsp-clients-php-server-command
-  `("php", (expand-file-name
-            (concat lsp-php-composer-dir "/vendor/felixfbecker/language-server/bin/php-language-server.php")))
+(defcustom lsp-clients-php-server-command nil
   "Install directory for php-language-server."
   :group 'lsp-php
   :type '(repeat string))
@@ -51,7 +49,12 @@
 (defun lsp-php--create-connection ()
   "Create lsp connection."
   (lsp-stdio-connection
-   (lambda () lsp-clients-php-server-command)
+   (lambda ()
+     (if (not lsp-clients-php-server-command)
+         (setq lsp-clients-php-server-command
+               `("php",
+                 (expand-file-name
+                  (concat lsp-php-composer-dir "/vendor/felixfbecker/language-server/bin/php-language-server.php"))))))
    (lambda ()
      (if (and (cdr lsp-clients-php-server-command)
               (eq (string-match-p "php[0-9.]*\\'" (car lsp-clients-php-server-command)) 0))


### PR DESCRIPTION
- Currently, composer directory is ~/.composer/.
- It can be get from command: composer config --global home
- Introduce new variable in lsp-php group: lsp-php-composer-dir