### PR TITLE
csharp: Remove custom installation code

### DIFF
--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -60,189 +60,67 @@ Usually this is to be set in your .dir-locals.el on the project root directory."
   :group 'lsp-csharp
   :type 'string)
 
-(defun lsp-csharp--version-list-latest (lst)
-  (->> lst
-       (-sort (lambda (a b) (not (version<= (substring a 1)
-                                            (substring b 1)))))
-       cl-first))
+(defcustom lsp-csharp-omnisharp-roslyn-download-url
+  (concat "https://github.com/omnisharp/omnisharp-roslyn/releases/latest/download/"
+          (cond ((eq system-type 'windows-nt)
+                 ; On Windows we're trying to avoid a crash starting 64bit .NET PE binaries in
+                 ; Emacs by using x86 version of omnisharp-roslyn on older (<= 26.4) versions
+                 ; of Emacs. See https://lists.nongnu.org/archive/html/bug-gnu-emacs/2017-06/msg00893.html"
+                 (if (and (string-match "^x86_64-.*" system-configuration)
+                          (version<= "26.4" emacs-version))
+                     "omnisharp-win-x64.zip"
+                   "omnisharp-win-x86.zip"))
 
-(defun lsp-csharp--latest-installed-version ()
-  "Returns latest version of the server installed on the machine (if any)."
-  (lsp-csharp--version-list-latest
-   (when (f-dir? lsp-csharp-server-install-dir)
-     (seq-filter
-      (lambda (f) (s-starts-with-p "v" f))
-      (seq-map 'f-filename (f-entries lsp-csharp-server-install-dir))))))
+                ((eq system-type 'darwin)
+                 "omnisharp-osx.zip")
 
-(defun lsp-csharp--fetch-json (url)
-  "Retrieves and parses JSON from URL."
-  (with-temp-buffer
-    (url-insert-file-contents url)
-    (let ((json-false :false)) (json-read))))
+                ((and (eq system-type 'gnu/linux)
+                      (or (eq (string-match "^x86_64" system-configuration) 0)
+                          (eq (string-match "^i[3-6]86" system-configuration) 0)))
+                 "omnisharp-linux-x64.zip")
 
-(defun lsp-csharp--latest-available-version ()
-  "Returns latest version of the server available from github."
-  (lsp-csharp--version-list-latest
-   (seq-map (lambda (elt) (s-trim (cdr (assq 'name elt))))
-            (lsp-csharp--fetch-json "https://api.github.com/repos/OmniSharp/omnisharp-roslyn/releases"))))
+                (t "omnisharp-mono.zip")))
+  "Automatic download url for omnisharp-roslyn."
+  :group 'lsp-csharp
+  :type 'string)
 
-(defun lsp-csharp--server-dir (version)
-  "The location of the installed OmniSharp server for VERSION."
-  (when version
-    (f-join (expand-file-name lsp-csharp-server-install-dir) version)))
+(defcustom lsp-csharp-omnisharp-roslyn-store-path
+  (f-join lsp-csharp-server-install-dir "latest" "omnisharp-roslyn.zip")
+  "The path where omnisharp-roslyn .zip archive will be stored."
+  :group 'lsp-csharp
+  :type 'file)
 
-(defun lsp-csharp--server-bin (version)
-  "The location of OmniSharp executable/script to use to start the server."
-  (let ((server-dir (lsp-csharp--server-dir version)))
-    (when server-dir
-      (f-join server-dir (cond ((eq system-type 'windows-nt) "OmniSharp.exe")
-                               (t "run"))))))
+(defcustom lsp-csharp-omnisharp-roslyn-server-dir
+  (f-join lsp-csharp-server-install-dir "latest" "omnisharp-roslyn")
+  "The path where omnisharp-roslyn .zip archive will be extracted."
+  :group 'lsp-csharp
+  :type 'file)
 
-(defun lsp-csharp--server-package-filename ()
-  "Returns name of tgz/zip file to be used for downloading the server
-for auto installation.
+(lsp-dependency
+ 'omnisharp-roslyn
+ `(:download :url lsp-csharp-omnisharp-roslyn-download-url
+             :store-path lsp-csharp-omnisharp-roslyn-store-path))
 
-On Windows we're trying to avoid a crash starting 64bit .NET PE binaries in
-Emacs by using x86 version of omnisharp-roslyn on older (<= 26.4) versions
-of Emacs. See https://lists.nongnu.org/archive/html/bug-gnu-emacs/2017-06/msg00893.html"
-  (cond ((eq system-type 'windows-nt)
-         (if (and (string-match "^x86_64-.*" system-configuration)
-                  (version<= "26.4" emacs-version))
-             "omnisharp-win-x64.zip"
-           "omnisharp-win-x86.zip"))
-        ((eq system-type 'darwin)
-         "omnisharp-osx.tar.gz")
-        ((and (eq system-type 'gnu/linux)
-              (or (eq (string-match "^x86_64" system-configuration) 0)
-                  (eq (string-match "^i[3-6]86" system-configuration) 0)))
-         "omnisharp-linux-x64.tar.gz")
-        (t "omnisharp-mono.tar.gz")))
-
-(defun lsp-csharp--server-package-url (version)
-  "Returns URL to tgz/zip file to be used for downloading the server VERSION
-for installation."
-  (concat "https://github.com/OmniSharp/omnisharp-roslyn/releases/download"
-          "/" version
-          "/" (lsp-csharp--server-package-filename)))
-
-(defun lsp-csharp--extract-server (url filename reinstall)
-  "Downloads and extracts a tgz/zip into the same directory."
-  ;; remove the file if reinstall is set
-  (when (and reinstall (f-exists-p filename))
-    (f-delete filename))
-
-  (lsp-csharp--download url filename)
-
-  (let ((target-dir (f-dirname filename)))
-    (message "lsp-csharp: extracting \"%s\" to \"%s\"" (f-filename filename) target-dir)
-    (lsp-csharp--extract filename target-dir)))
-
-(defun lsp-csharp-update-server ()
-  "Checks if the currently installed version (if any) is lower than then one
-available on github and if so, downloads and installs a newer version."
-  (interactive)
-  (let ((latest-version (lsp-csharp--latest-available-version))
-        (installed-version (lsp-csharp--latest-installed-version)))
-    (if latest-version
-        (progn
-          (when (and latest-version
-                     (or (not installed-version)
-                         (version< (substring installed-version 1)
-                                   (substring latest-version 1))))
-            (lsp-csharp--install-server latest-version nil))
-          (message "lsp-csharp-update-server: latest installed version is %s; latest available is %s"
-                   (lsp-csharp--latest-installed-version)
-                   latest-version))
-      (message "lsp-csharp-update-server: cannot retrieve latest version info"))))
-
-(defun lsp-csharp--install-server (update-version ask-confirmation)
-  "Installs (or updates to UPDATE-VERSION) server binary unless it is already installed."
-  (let ((installed-version (lsp-csharp--latest-installed-version))
-        (target-version (or update-version (lsp-csharp--latest-available-version))))
-    (when (and target-version
-               (not (string-equal installed-version target-version)))
-      (message "lsp-csharp-update-server: current version is %s; installing %s.."
-               (or installed-version "(none)")
-               target-version)
-      (when (or (not ask-confirmation)
-                (yes-or-no-p (format "OmniSharp Roslyn Server %s. Do you want to download and install %s now?"
-                                     (if installed-version
-                                         (format "can be updated, currently installed version is %s" installed-version)
-                                       "is not installed")
-                                     target-version)))
-        (let ((new-server-dir (lsp-csharp--server-dir target-version))
-              (new-server-bin (lsp-csharp--server-bin target-version))
-              (package-filename (lsp-csharp--server-package-filename))
-              (package-url (lsp-csharp--server-package-url target-version)))
-
-          (mkdir new-server-dir t)
-
-          (lsp-csharp--extract-server package-url
-                                      (f-join new-server-dir package-filename)
-                                      nil)
-
-          (unless (and new-server-bin (file-exists-p new-server-bin))
-            (error "Failed to auto-install the server %s; file \"%s\" was not found"
-                   target-version new-server-bin)))))))
-
-(defun lsp-csharp--get-or-install-server ()
-  "Resolves path to server binary installed, otherwise, if not found
-will ask the user if we can download and install it.
-Returns location of script or a binary to use to start the server."
-  (let ((installed-bin (lsp-csharp--server-bin (lsp-csharp--latest-installed-version))))
-    (if (and installed-bin (file-exists-p installed-bin))
-        installed-bin
-      (lsp-csharp--install-server nil t)
-      (let ((installed-bin (lsp-csharp--server-bin (lsp-csharp--latest-installed-version))))
-        (unless installed-bin (error "Server binary is required for LSP C# to work."))
-        installed-bin))))
-
-(defun lsp-csharp--download (url filename)
-  "Downloads file from URL as FILENAME. Will not do anything should
-the file exist already."
-  (unless (f-exists-p filename)
-    (message (format "lsp-csharp: downloading from \"%s\"..." url))
-    (let ((gnutls-algorithm-priority
-           (if (and (not gnutls-algorithm-priority)
-                    (boundp 'libgnutls-version)
-                    (>= libgnutls-version 30603)
-                    (version<= emacs-version "26.2"))
-               "NORMAL:-VERS-TLS1.3"
-             gnutls-algorithm-priority)))
-      (url-copy-file url filename nil))))
-
-(defun lsp-csharp--extract (filename target-dir)
-  "Extracts FILENAME which is a downloaded omnisharp-roslyn server
-tarball or a zip file (based on a current platform) to TARGET-DIR."
-  (cond
-   ((eq system-type 'windows-nt)
-    ;; on windows, we attempt to use powershell v5+, available on Windows 10+
-    (let ((powershell-version (substring
-                               (shell-command-to-string "powershell -command \"(Get-Host).Version.Major\"")
-                               0 -1)))
-      (if (>= (string-to-number powershell-version) 5)
-          (call-process "powershell"
-                        nil
-                        nil
-                        nil
-                        "-command"
-                        (concat "add-type -assembly system.io.compression.filesystem;"
-                                "[io.compression.zipfile]::ExtractToDirectory(\"" filename "\", \"" target-dir "\")"))
-
-        (message (concat "lsp-csharp: for automatic server installation procedure"
-                         " to work on Windows you need to have powershell v5+ installed")))))
-
-   ((or (eq system-type 'gnu/linux)
-        (eq system-type 'darwin))
-    (call-process "tar" nil nil t "xf" filename "-C" target-dir))
-
-   (t (error "lsp-csharp cannot extract \"%s\" on platform %s (yet)" filename system-type))))
+(defun lsp-csharp--download-server (_client callback error-callback _update?)
+  "Download zip package for omnisharp-roslyn and install it."
+  (lsp-package-ensure
+   'omnisharp-roslyn
+   (lambda ()
+     (lsp-unzip lsp-csharp-omnisharp-roslyn-store-path
+                lsp-csharp-omnisharp-roslyn-server-dir)
+     (unless (eq system-type 'windows-nt)
+       (set-file-modes (f-join lsp-csharp-omnisharp-roslyn-server-dir "run") #o700))
+     (funcall callback))
+   error-callback))
 
 (defun lsp-csharp--language-server-path ()
-  "Resolves path to use to start the server."
+  "Resolve path to use to start the server."
   (if lsp-csharp-server-path
       lsp-csharp-server-path
-    (lsp-csharp--server-bin (lsp-csharp--latest-installed-version))))
+    (let ((server-dir lsp-csharp-omnisharp-roslyn-server-dir))
+      (when (f-exists? server-dir)
+        (f-join server-dir (cond ((eq system-type 'windows-nt) "OmniSharp.exe")
+                                 (t "run")))))))
 
 (defun lsp-csharp--language-server-command ()
   "Resolves path and arguments to use to start the server."
@@ -470,13 +348,7 @@ using the `textDocument/references' request."
                                              ("o#/testcompleted" 'lsp-csharp--handle-os-testcompleted)
                                              ("o#/projectconfiguration" 'ignore)
                                              ("o#/projectdiagnosticstatus" 'ignore))
-                  :download-server-fn
-                  (lambda (_client callback error-callback _update?)
-                    (condition-case err
-                        (progn
-                          (lsp-csharp--install-server nil nil)
-                          (funcall callback))
-                      (error (funcall error-callback (error-message-string err)))))))
+                  :download-server-fn #'lsp-csharp--download-server))
 
 (provide 'lsp-csharp)
 ;;; lsp-csharp.el ends here


### PR DESCRIPTION
This removes custom in-sync server installation code in lsp-csharp.el in favor
of the standard lsp-dependency/package mechanism.

This removes lsp-csharp-update-server interactive fn, but hopefully
ability to update/upgrade will come as standard functionality in lsp-mode.