### PR TITLE
lsp-workspace-command-execute: log command which sent to server and fail

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5789,10 +5789,14 @@ REFERENCES? t when METHOD returns references."
 
 (defun lsp-workspace-command-execute (command &optional args)
   "Execute workspace COMMAND with ARGS."
-  (let ((params (if args
-                    (list :command command :arguments args)
-                  (list :command command))))
-    (lsp-request "workspace/executeCommand" params)))
+  (condition-case-unless-debug err
+      (let ((params (if args
+                        (list :command command :arguments args)
+                      (list :command command))))
+        (lsp-request "workspace/executeCommand" params))
+    (error
+     (lsp--error "`workspace/executeCommand' with `%s' failed.\n\n%S"
+                 command err))))
 
 (defun lsp-send-execute-command (command &optional args)
   "Create and send a 'workspace/executeCommand' message having command COMMAND and optional ARGS."


### PR DESCRIPTION
There's a lot of cases that we supposed to handle the execute command in local but missing handler and sent to server instead.
In this case, the current error message is just `workspace/executeCommand` is not supported.
This PR provides a better message by also log the command sent to server and fail so we can decide if we need to handle that command on client-side or not.