### PR TITLE
Add a command to kill the server behind a workspace

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7979,6 +7979,16 @@ Errors if there are none."
   (lsp--warn "Stopping %s" (lsp--workspace-print workspace))
   (with-lsp-workspace workspace (lsp--shutdown-workspace)))
 
+(defun lsp-workspace-kill (workspace)
+  "Kill the language server behind WORKSPACE.
+Prefer `lsp-workspace-shutdown' if possible, since this command
+may leave the server and Emacs in an inconsistent state, so use
+only in an emergency."
+  (interactive (list (lsp--read-workspace)))
+  (lsp--warn "Killing %s" (lsp--workspace-print workspace))
+  (setf (lsp--workspace-shutdown-action workspace) 'shutdown)
+  (kill-process (lsp--workspace-proc workspace)))
+
 (defun lsp-disconnect ()
   "Disconnect the buffer from the language server."
   (interactive)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7979,14 +7979,18 @@ Errors if there are none."
   (lsp--warn "Stopping %s" (lsp--workspace-print workspace))
   (with-lsp-workspace workspace (lsp--shutdown-workspace)))
 
-(defun lsp-workspace-kill (workspace)
+(defun lsp-workspace-kill (workspace &optional restart)
   "Kill the language server behind WORKSPACE.
 Prefer `lsp-workspace-shutdown' if possible, since this command
 may leave the server and Emacs in an inconsistent state, so use
-only in an emergency."
-  (interactive (list (lsp--read-workspace)))
+only in an emergency.
+
+If RESTART (prefix-arg) is non-nil, cause the server to be
+restarted afterwards."
+  (interactive (list (lsp--read-workspace) current-prefix-arg))
   (lsp--warn "Killing %s" (lsp--workspace-print workspace))
-  (setf (lsp--workspace-shutdown-action workspace) 'shutdown)
+  (setf (lsp--workspace-shutdown-action workspace)
+        (if restart 'restart 'shutdown))
   (kill-process (lsp--workspace-proc workspace)))
 
 (defun lsp-disconnect ()


### PR DESCRIPTION
`lsp-workspace-kill` will kill the server behind a given workspace using
`kill-process`, and optionally restart it. The naming was chosen to be
consistent with `lsp-workspace-restart/shutdown`.