### PR TITLE
Properly build path for clj-kondo config

### DIFF
--- a/clients/lsp-clojure.el
+++ b/clients/lsp-clojure.el
@@ -214,8 +214,8 @@ If there are more arguments expected after the line and column numbers."
   "Ask to user the clj-kondo config dir path."
   (lsp--completing-read
    "Select where LSP should save this setting:"
-   (list (concat (expand-file-name "~/") ".clj-kondo/config.edn")
-         (concat (or (lsp-workspace-root) "project") ".clj-kondo/config.edn"))
+   (list (f-join (expand-file-name "~/") ".clj-kondo/config.edn")
+         (f-join (or (lsp-workspace-root) "project") ".clj-kondo/config.edn"))
    #'identity
    nil
    t))


### PR DESCRIPTION
`concat` doesn't handle inserting path separators where necessary,
whereas `f-join` does.

Brief discussion of this here: https://clojurians.slack.com/archives/CPABC1H61/p1617831599255600