### PR TITLE
Fix empty cache being treated as cache

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -419,8 +419,9 @@ The MARKERS and PREFIX value will be attached to each candidate."
                                      "textDocument/completion"
                                      (plist-put (lsp--text-document-position-params)
                                                 :context (lsp-completion--get-context trigger-chars))))
-                              (completed (or (and resp (not (lsp-completion-list? resp)))
-                                             (not (lsp:completion-list-is-incomplete resp))))
+                              (completed (and resp
+                                              (not (and (lsp-completion-list? resp)
+                                                        (lsp:completion-list-is-incomplete resp)))))
                               (items (lsp--while-no-input
                                        (--> (cond
                                              ((lsp-completion-list? resp)

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -403,6 +403,10 @@ The MARKERS and PREFIX value will be attached to each candidate."
               (lsp--catch 'input
                   (let ((lsp--throw-on-input lsp-completion-use-last-result)
                         (same-session? (and lsp-completion--cache
+                                            ;; Special case for empty prefix and empty result
+                                            (or (cl-second lsp-completion--cache)
+                                                (not (string-empty-p
+                                                      (plist-get (cddr lsp-completion--cache) :prefix))))
                                             (equal (cl-first lsp-completion--cache) bounds-start)
                                             (s-prefix?
                                              (plist-get (cddr lsp-completion--cache) :prefix)


### PR DESCRIPTION
Fixes the issue mentioned here: https://github.com/emacs-lsp/lsp-mode/issues/2612#issuecomment-817370085

I don't believe the `listp` check is necessary as well as it should either be set to a list or nil. I believe this essentially breaks the caching of "no results". We'd basically need some sentinel value to mean either no results or no cache.

It could also be that this is totally the wrong way to fix this, but it appears to work for me.