### PR TITLE
Quote parentheses at bol inside of doc-strings

### DIFF
--- a/clients/lsp-elixir.el
+++ b/clients/lsp-elixir.el
@@ -75,8 +75,8 @@ If value is `\"\"` then defaults to the workspace rootUri."
   :package-version '(lsp-mode . "7.1"))
 
 (defcustom lsp-elixir-suggest-specs t
-  "Suggest @spec annotations inline using Dialyzer's inferred success typings
-(Requires Dialyzer)."
+  "Suggest @spec annotations inline using Dialyzer's inferred success typings.
+This requires Dialyzer."
   :type 'boolean
   :group 'lsp-elixir
   :package-version '(lsp-mode . "7.1"))

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -422,7 +422,7 @@ syntax highlighting."
 
 (defcustom lsp-rust-analyzer-diagnostics-enable-experimental t
   "Whether to show native rust-analyzer diagnostics that are still experimental
-(might have more false positives than usual)."
+\(might have more false positives than usual)."
   :type 'boolean
   :group 'lsp-rust
   :package-version '(lsp-mode . "7.1.0"))
@@ -712,7 +712,7 @@ them with `crate` or the crate name they refer to."
 
 (defcustom lsp-rust-analyzer-inlay-type-space-format "%s"
   "Format string for spacing around variable inlays
-(not part of the inlay face)."
+\(not part of the inlay face)."
   :type '(string :tag "String")
   :group 'lsp-rust
   :package-version '(lsp-mode . "7.1"))
@@ -731,7 +731,7 @@ them with `crate` or the crate name they refer to."
 
 (defcustom lsp-rust-analyzer-inlay-param-space-format "%s "
   "Format string for spacing around parameter inlays
-(not part of the inlay face)."
+\(not part of the inlay face)."
   :type '(string :tag "String")
   :group 'lsp-rust
   :package-version '(lsp-mode . "7.1"))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4761,8 +4761,7 @@ See #2588")
         (buffer-substring-no-properties (match-beginning 1) (match-end 1)))
        nil t))))
   "Replaced string regexp and function returning image.
-Each element should be:
-(MODE . (PROPERTY-LIST...))
+Each element should have the form (MODE . (PROPERTY-LIST...)).
 MODE (car) is function which is defined in `lsp-language-id-configuration'.
 Cdr should be list of PROPERTY-LIST.
 
@@ -7544,7 +7543,7 @@ optional flag that should be non-nil for boolean settings, when it is nil the
 property will be ignored if the VALUE is nil.
 
 Example: `(lsp-register-custom-settings '((\"foo.bar.buzz.enabled\" t t)))'
-(note the double parentheses)"
+\(note the double parentheses)"
   (let ((-compare-fn #'lsp--compare-setting-path))
     (setq lsp-client-settings (-uniq (append props lsp-client-settings)))))
 
@@ -8078,7 +8077,7 @@ The server(s) will be started in the buffer when it has finished."
                                                      (-not #'lsp--server-binary-present?)))))
         (lsp--warn "The following servers support current file but do not have automatic installation configuration: %s
 You may find the installation instructions at https://emacs-lsp.github.io/lsp-mode/page/languages.
-(If you have already installed the server check *lsp-log*)."
+\(If you have already installed the server check *lsp-log*)."
                    (mapconcat (lambda (client)
                                 (symbol-name (lsp--client-server-id client)))
                               clients


### PR DESCRIPTION
Without this `outline-minor-mode` gets confused and considers
this line to be the beginning of a top-level code-block.

In a few cases address this by either moving or removing the
offending parenthesis instead of quoting it.