### PR TITLE
[docs] Auto generate settings docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@ deps:
 	cask install
 
 generate: deps
-	@echo "Generating..."
+	@echo "Generating docs..."
 
 	@cask emacs -Q --batch \
 		-L ../ \

--- a/docs/lsp-doc.el
+++ b/docs/lsp-doc.el
@@ -102,13 +102,13 @@
   "Return all custom variables for a NAME."
   (let* ((group (intern (concat "lsp-" name)))
          (custom-group (get group 'custom-group)))
-    (seq-map
-     (apply-partially #'car)
-     (seq-filter (lambda (p)
-                   (and (consp p)
-                        (or (eq (cadr p) 'custom-variable)
-                            (eq (cadr p) 'custom-face))))
-                 custom-group))))
+    (->> custom-group
+      (seq-filter (lambda (p)
+                    (and (consp p)
+                         (or (eq (cadr p) 'custom-variable)
+                             (eq (cadr p) 'custom-face)))))
+      (seq-map (apply-partially #'car))
+      (seq-sort #'string<))))
 
 (defun lsp-doc--pretty-default-value (variable)
   "Return default value for a VARIABLE formatted."

--- a/docs/page/settings.md
+++ b/docs/page/settings.md
@@ -1,33 +1,7 @@
 Settings
 ========
 
-These are `lsp-mode` specific custom settings:
+For language specific settings check the [languages section](../languages).
 
-- `lsp-log-io` - If non-nil, print all messages to and from the language server to `*lsp-log*`.
-- `lsp-keep-workspace-alive` - If non nil keep workspace alive when the last workspace buffer is closed.
-- `lsp-enable-snippet` - Enable/disable snippet completion support.
-- `lsp-auto-guess-root` - Automatically guess the project root using projectile/project. Do **not** use this setting unless you are familiar with `lsp-mode` internals and you are sure that all of your projects are following `projectile=/=project.el` conventions.
-- `lsp-restart` - Defines how server exited event must be handled.
-- `lsp-session-file` - File where session information is stored.
-- `lsp-auto-configure` - Auto configure `lsp-mode`. When set to `t`, `lsp-mode` will auto-configure `lsp-ui`, `dap-mode` and other settings that makes sense to enable by default.
-- `lsp-document-sync-method` - How to sync the document with the language server.
-- `lsp-auto-execute-action` - Auto-execute single action.
-- `lsp-eldoc-render-all` - Display all of the info returned by `document/onHover`. If this is nil, `eldoc` will show only the symbol information.
-- `lsp-enable-completion-at-point` - Enable `completion-at-point` integration.
-- `lsp-enable-xref` - Enable xref integration.
-- `lsp-diagnostics-provider` - Specifies which package to use for diagnostics. Choose from `:auto`, `:flycheck`, `:flymake` and `:none`. Default is `:auto` which means use `:flycheck` if present and fallback to `:flymake`.
-- `lsp-enable-indentation` - Indent regions using the file formatting functionality provided by the language server.
-- `lsp-enable-on-type-formatting` - Enable `textDocument/onTypeFormatting` integration.
-- `lsp-before-save-edits` - If non-nil, `lsp-mode` will apply edits suggested by the language server before saving a document.
-- `lsp-imenu-show-container-name` - Display the symbol's container name in an imenu entry.
-- `lsp-imenu-container-name-separator` - Separator string to use to separate the container name from the symbol while displaying imenu entries.
-- `lsp-imenu-sort-methods` - How to sort the imenu items. The value is a list of `kind`, `name` or `position`. Priorities are determined by the index of the element.
-- `lsp-response-timeout` - Number of seconds to wait for a response from the language server before timing out.
-- `lsp-enable-file-watchers` - If non-nil lsp-mode will watch the files in the workspace if the server has requested that.
-- `lsp-server-trace` - Request trace mode on the language server.
-- `lsp-semantic-tokens-enable` - Enable semantic tokens highlighting support
-- `lsp-enable-imenu` - If non-nil, automatically enable imenu integration when server provides `textDocument/documentSymbol`.
-- `lsp-signature-auto-activate` - Auto activate signature when trigger conditions are meet.
-- `lsp-signature-render-documentation` - Include signature documentation in signature help.
-- `lsp-enable-text-document-color` - Enable `textDocument/documentColor` when server supports it.
-- `lsp-headerline-breadcrumb-enable` - Enable `lsp-headerline-breadcrumb-mode`.
+Below are all `lsp-mode` custom settings auto generated documentation:
+

--- a/docs/template/lsp-var.md
+++ b/docs/template/lsp-var.md
@@ -1,4 +1,4 @@
-### `{{name}}`
+#### `{{name}}`
 
 _Default: `{{default}}`_
 

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -23,6 +23,12 @@
 
 (require 'lsp-mode)
 
+(defgroup lsp-completion nil
+  "LSP support for completion"
+  :prefix "lsp-completion-"
+  :group 'lsp-mode
+  :tag "LSP Completion")
+
 ;;;###autoload
 (define-obsolete-variable-alias 'lsp-prefer-capf
   'lsp-completion-provider  "lsp-mode 7.0.1")
@@ -32,7 +38,7 @@
   :type '(choice
           (const :tag "Use company-capf" :capf)
           (const :tag "None" :none))
-  :group 'lsp-mode
+  :group 'lsp-completion
   :package-version '(lsp-mode . "7.0.1"))
 
 ;;;###autoload
@@ -42,7 +48,7 @@
 (defcustom lsp-completion-enable t
   "Enable `completion-at-point' integration."
   :type 'boolean
-  :group 'lsp-mode)
+  :group 'lsp-completion)
 
 (defcustom lsp-completion-enable-additional-text-edit t
   "Whether or not to apply additional text edit when performing completion.
@@ -51,43 +57,43 @@ If set to non-nil, `lsp-mode' will apply additional text edits
 from the server.  Otherwise, the additional text edits are
 ignored."
   :type 'boolean
-  :group 'lsp-mode
+  :group 'lsp-completion
   :package-version '(lsp-mode . "6.3.2"))
 
 (defcustom lsp-completion-show-kind t
   "Whether or not to show kind of completion candidates."
   :type 'boolean
-  :group 'lsp-mode
+  :group 'lsp-completion
   :package-version '(lsp-mode . "7.0.1"))
 
 (defcustom lsp-completion-show-detail t
   "Whether or not to show detail of completion candidates."
   :type 'boolean
-  :group 'lsp-mode)
+  :group 'lsp-completion)
 
 (defcustom lsp-completion-no-cache nil
   "Whether or not caching the returned completions from server."
   :type 'boolean
-  :group 'lsp-mode
+  :group 'lsp-completion
   :package-version '(lsp-mode . "7.0.1"))
 
 (defcustom lsp-completion-filter-on-incomplete t
   "Whether or not filter incomplete results."
   :type 'boolean
-  :group 'lsp-mode
+  :group 'lsp-completion
   :package-version '(lsp-mode . "7.0.1"))
 
 (defcustom lsp-completion-sort-initial-results t
   "Whether or not filter initial results from server."
   :type 'boolean
-  :group 'lsp-mode
+  :group 'lsp-completion
   :package-version '(lsp-mode . "7.1"))
 
 (defcustom lsp-completion-use-last-result t
   "Temporarily use last server result when interrupted by keyboard.
 This will help minimize popup flickering issue in `company-mode'."
   :type 'boolean
-  :group 'lsp-mode
+  :group 'lsp-completion
   :package-version '(lsp-mode . "7.1"))
 
 (defconst lsp-completion--item-kind
@@ -712,7 +718,7 @@ The CLEANUP-FN will be called to cleanup."
 ;;;###autoload
 (define-minor-mode lsp-completion-mode
   "Toggle LSP completion support."
-  :group 'lsp-mode
+  :group 'lsp-completion
   :global nil
   :lighter ""
   (let ((completion-started-fn (lambda (&rest _)

--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -23,6 +23,12 @@
 
 (require 'lsp-mode)
 
+(defgroup lsp-diagnostics nil
+  "LSP support for diagnostics"
+  :prefix "lsp-disagnostics-"
+  :group 'lsp-mode
+  :tag "LSP Diagnostics")
+
 ;;;###autoload
 (define-obsolete-variable-alias 'lsp-diagnostic-package
   'lsp-diagnostics-provider  "lsp-mode 7.0.1")
@@ -37,7 +43,7 @@
     (const :tag "Use neither flymake nor lsp" :none)
     (const :tag "Prefer flymake" t)
     (const :tag "Prefer flycheck" nil))
-  :group 'lsp-mode
+  :group 'lsp-diagnostics
   :package-version '(lsp-mode . "6.3"))
 
 ;;;###autoload
@@ -50,7 +56,7 @@
           (const error)
           (const warning)
           (const info))
-  :group 'lsp-mode)
+  :group 'lsp-diagnostics)
 
 (defcustom lsp-diagnostics-attributes
   `((unnecessary :foreground "gray")
@@ -60,12 +66,12 @@ List containing (tag attributes) where tag is the LSP diagnostic tag and
 attributes is a `plist' containing face attributes which will be applied
 on top the flycheck face for that error level."
   :type '(repeat list)
-  :group 'lsp-mode)
+  :group 'lsp-diagnostics)
 
 (defcustom lsp-diagnostics-disabled-modes nil
   "A list of major models for which `lsp-diagnostics-mode' should be disabled."
   :type '(repeat symbol)
-  :group 'lsp-mode
+  :group 'lsp-diagnostics
   :package-version '(lsp-mode . "7.1"))
 
 ;; Flycheck integration
@@ -323,7 +329,7 @@ See https://github.com/emacs-lsp/lsp-mode."
 ;;;###autoload
 (define-minor-mode lsp-diagnostics-mode
   "Toggle LSP diagnostics integration."
-  :group 'lsp-mode
+  :group 'lsp-diagnostics
   :global nil
   :lighter ""
   (cond

--- a/lsp-dired.el
+++ b/lsp-dired.el
@@ -27,6 +27,12 @@
 (require 'pcase)
 (require 'lsp-mode)
 
+(defgroup lsp-dired nil
+  "LSP support for dired"
+  :prefix "lsp-dired-"
+  :group 'lsp-mode
+  :tag "LSP Dired")
+
 (defvar lsp-dired--ranger-adjust nil)
 (with-eval-after-load 'ranger (setf lsp-dired--ranger-adjust t))
 
@@ -142,7 +148,7 @@ Will remove the killed subdir from `lsp-dired--covered-subdirs'."
   :require    'lsp-dired
   :init-value nil
   :global     t
-  :group      'lsp-mode
+  :group      'lsp-dired
   (cond
    (lsp-dired-mode
     (add-hook 'dired-after-readin-hook #'lsp-dired--display)

--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -24,6 +24,12 @@
 (require 'lsp-icons)
 (require 'lsp-mode)
 
+(defgroup lsp-headerline nil
+  "LSP support for headerline"
+  :prefix "lsp-headerline-"
+  :group 'lsp-mode
+  :tag "LSP Headerline")
+
 (defcustom lsp-headerline-breadcrumb-segments '(path-up-to-project file symbols)
   "Face used on breadcrumb text on modeline."
   :type '(repeat
@@ -31,17 +37,17 @@
                   (const :tag "Include the open file name." file)
                   (const :tag "Include the directories up to project." path-up-to-project)
                   (const :tag "Include document symbols if server supports it." symbols)))
-  :group 'lsp-mode)
+  :group 'lsp-headerline)
 
 (defcustom lsp-headerline-breadcrumb-enable-symbol-numbers nil
   "Whether to label symbols with numbers on the breadcrumb."
   :type 'boolean
-  :group 'lsp-mode)
+  :group 'lsp-headerline)
 
 (defcustom lsp-headerline-breadcrumb-enable-diagnostics t
   "If non-nil, apply different face on the breadcrumb based on the errors."
   :type 'boolean
-  :group 'lsp-mode
+  :group 'lsp-headerline
   :package-version '(lsp-mode . "7.1"))
 
 (defface lsp-headerline-breadcrumb-separator-face '((t :inherit shadow :height 0.8))
@@ -407,7 +413,7 @@ PATH is the current folder to be checked."
 ;;;###autoload
 (define-minor-mode lsp-headerline-breadcrumb-mode
   "Toggle breadcrumb on headerline."
-  :group 'lsp-mode
+  :group 'lsp-headerline
   :global nil
   (cond
    (lsp-headerline-breadcrumb-mode

--- a/lsp-icons.el
+++ b/lsp-icons.el
@@ -24,7 +24,7 @@
 (defgroup lsp-icons nil
   "LSP icons"
   :group 'lsp-mode
-  :tag "Icons")
+  :tag "LSP Icons")
 
 (defcustom lsp-headerline-breadcrumb-icons-enable t
   "If non-nil, icons support is enabled for headerline-breadcrumb."

--- a/lsp-ido.el
+++ b/lsp-ido.el
@@ -28,7 +28,8 @@
 
 (defgroup lsp-ido nil
   "LSP support for ido-based symbol completion"
-  :group 'lsp-mode)
+  :group 'lsp-mode
+  :tag "LSP ido")
 
 (defcustom lsp-ido-symbol-kind-to-string
   ["    "          ; Unknown - 0

--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -23,9 +23,15 @@
 
 (require 'lsp-mode)
 
+(defgroup lsp-lens nil
+  "LSP support for lens"
+  :prefix "lsp-lens-"
+  :group 'lsp-mode
+  :tag "LSP Lens")
+
 (defcustom lsp-lens-debounce-interval 0.001
   "Debounce interval for loading lenses."
-  :group 'lsp-mode
+  :group 'lsp-lens
   :type 'number)
 
 (defface lsp-lens-mouse-face
@@ -326,7 +332,7 @@ CALLBACK - callback for the lenses."
 ;;;###autoload
 (define-minor-mode lsp-lens-mode
   "Toggle code-lens overlays."
-  :group 'lsp-mode
+  :group 'lsp-lens
   :global nil
   :init-value nil
   :lighter " Lens"

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -57,6 +57,11 @@
 (require 'yasnippet nil t)
 (require 'lsp-protocol)
 
+(defgroup lsp-mode nil
+  "Language Server Protocol client."
+  :group 'tools
+  :tag "Language Server (lsp-mode)")
+
 (declare-function evil-set-command-property "ext:evil-common")
 (declare-function projectile-project-root "ext:projectile")
 (declare-function yas-expand-snippet "ext:yasnippet")
@@ -131,7 +136,7 @@ the buffer when it becomes large."
 
 (defcustom lsp-enable-snippet t
   "Enable/disable snippet completion support."
-  :group 'lsp-mode
+  :group 'lsp-completion
   :type 'boolean)
 
 (defcustom lsp-enable-folding t
@@ -145,7 +150,7 @@ the buffer when it becomes large."
 (defcustom lsp-semantic-tokens-enable nil
   "Enable/disable support for semantic tokens.
 As defined by the Language Server Protocol 3.16."
-  :group 'lsp-mode
+  :group 'lsp-semantic-tokens
   :type 'boolean)
 
 (defcustom lsp-folding-range-limit nil
@@ -403,15 +408,10 @@ This flag affects only servers which do not support incremental updates."
 (defvar lsp--delayed-requests nil)
 (defvar lsp--delay-timer nil)
 
-(defgroup lsp-mode nil
-  "Language Server Protocol client."
-  :group 'tools
-  :tag "Language Server")
-
 (defgroup lsp-faces nil
-  "Faces."
+  "LSP Faces."
   :group 'lsp-mode
-  :tag "Faces")
+  :tag "LSP Faces")
 
 (defcustom lsp-document-sync-method nil
   "How to sync the document with the language server."
@@ -463,7 +463,7 @@ If this is set to nil, `eldoc' will show only the symbol information."
 (defcustom lsp-completion-enable t
   "Enable `completion-at-point' integration."
   :type 'boolean
-  :group 'lsp-mode)
+  :group 'lsp-completion)
 
 (defcustom lsp-enable-symbol-highlighting t
   "Highlight references of the symbol at point."
@@ -507,23 +507,23 @@ It contains the operation source."
 (defcustom lsp-modeline-code-actions-enable t
   "Whether to show code actions on modeline."
   :type 'boolean
-  :group 'lsp-mode)
+  :group 'lsp-modeline)
 
 (defcustom lsp-modeline-diagnostics-enable t
   "Whether to show diagnostics on modeline."
   :type 'boolean
-  :group 'lsp-mode)
+  :group 'lsp-modeline)
 
 (defcustom lsp-modeline-workspace-status-enable t
   "Whether to show workspace status on modeline."
   :type 'boolean
-  :group 'lsp-mode
+  :group 'lsp-modeline
   :package-version '(lsp-mode . "7.1"))
 
 (defcustom lsp-headerline-breadcrumb-enable t
   "Whether to enable breadcrumb on headerline."
   :type 'boolean
-  :group 'lsp-mode)
+  :group 'lsp-headerline)
 
 (defcustom lsp-configure-hook nil
   "Hooks to run when `lsp-configure-buffer' is called."
@@ -571,9 +571,9 @@ The hook will receive two parameters list of added and removed folders."
   :group 'lsp-mode)
 
 (defgroup lsp-imenu nil
-  "Imenu."
+  "LSP Imenu."
   :group 'lsp-mode
-  :tag "Imenu")
+  :tag "LSP Imenu")
 
 (defcustom lsp-imenu-show-container-name t
   "Display the symbol's container name in an imenu entry."
@@ -659,7 +659,7 @@ than the second parameter.")
 Note that when that setting is nil, `lsp-mode' will show stale
 diagnostics until server publishes the new set of diagnostics"
   :type 'boolean
-  :group 'lsp-mode
+  :group 'lsp-diagnostics
   :package-version '(lsp-mode . "7.0.1"))
 
 (defcustom lsp-server-trace nil
@@ -869,7 +869,7 @@ must be used for handling a particular message.")
 
 (defcustom lsp-lens-enable nil
   "Auto enable lenses if server supports."
-  :group 'lsp-mode
+  :group 'lsp-lens
   :type 'boolean
   :package-version '(lsp-mode . "6.3"))
 
@@ -918,7 +918,7 @@ called with nil the signature info must be cleared."
   :package-version '(lsp-mode . "6.3"))
 
 (defcustom lsp-keymap-prefix "s-l"
-  "lsp-mode keymap prefix."
+  "LSP-mode keymap prefix."
   :group 'lsp-mode
   :type 'string
   :package-version '(lsp-mode . "6.3"))
@@ -7025,12 +7025,12 @@ detaches the installation buffer from commands like
 (defface lsp-installation-finished-buffer-face '((t :foreground "orange"))
   "Face used for finished installation buffers.
 Used in `lsp-select-installation-buffer'."
-  :group 'lsp-mode)
+  :group 'lsp-faces)
 
 (defface lsp-installation-buffer-face '((t :foreground "green"))
   "Face used for installation buffers still in progress.
 Used in `lsp-select-installation-buffer'."
-  :group 'lsp-mode)
+  :group 'lsp-faces)
 
 (defun lsp--installation-buffer? (buf)
   "Check whether BUF is an `lsp-async-start-process' buffer."

--- a/lsp-modeline.el
+++ b/lsp-modeline.el
@@ -23,10 +23,16 @@
 
 (require 'lsp-mode)
 
+(defgroup lsp-modeline nil
+  "LSP support for modeline"
+  :prefix "lsp-modeline-"
+  :group 'lsp-mode
+  :tag "LSP Modeline")
+
 (defcustom lsp-modeline-code-actions-kind-regex "$\\|quickfix.*\\|refactor.*"
   "Regex for the code actions kinds to show in the modeline."
   :type 'string
-  :group 'lsp-mode)
+  :group 'lsp-modeline)
 
 (defcustom lsp-modeline-code-actions-segments '(count icon)
   "Define what should display on the modeline when code actions are available."
@@ -34,13 +40,13 @@
                   (const :tag "Show the lightbulb icon" icon)
                   (const :tag "Show the name of the preferred code action" name)
                   (const :tag "Show the count of how many code actions available" count)))
-  :group 'lsp-mode
+  :group 'lsp-modeline
   :package-version '(lsp-mode . "7.1"))
 
 (defcustom lsp-modeline-code-action-fallback-icon "💡"
   "Define what should display on the modeline when code actions are available."
   :type 'string
-  :group 'lsp-mode
+  :group 'lsp-modeline
   :package-version '(lsp-mode . "7.1"))
 
 (defface lsp-modeline-code-actions-face
@@ -59,7 +65,7 @@
 
 (defcustom lsp-modeline-diagnostics-scope :workspace
   "The modeline diagnostics scope."
-  :group 'lsp-mode
+  :group 'lsp-modeline
   :type '(choice (const :tag "File" :file)
                  (const :tag "Project" :workspace)
                  (const :tag "All Projects" :global))
@@ -183,7 +189,7 @@
 ;;;###autoload
 (define-minor-mode lsp-modeline-code-actions-mode
   "Toggle code actions on modeline."
-  :group 'lsp-mode
+  :group 'lsp-modeline
   :global nil
   :lighter ""
   (cond
@@ -294,7 +300,7 @@ The `:global' workspace is global one.")
 ;;;###autoload
 (define-minor-mode lsp-modeline-diagnostics-mode
   "Toggle diagnostics modeline."
-  :group 'lsp-mode
+  :group 'lsp-modeline
   :global nil
   :lighter ""
   (cond
@@ -331,7 +337,7 @@ The `:global' workspace is global one.")
 ;;;###autoload
 (define-minor-mode lsp-modeline-workspace-status-mode
   "Toggle workspace status on modeline."
-  :group 'lsp-mode
+  :group 'lsp-modeline
   :global nil
   :lighter ""
   (cond

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -24,18 +24,24 @@
 
 (require 'lsp-mode)
 
+(defgroup lsp-semantic-tokens nil
+  "LSP support for semantic-tokens"
+  :prefix "lsp-semantic-tokens-"
+  :group 'lsp-mode
+  :tag "LSP Semantic tokens")
+
 (define-obsolete-variable-alias 'lsp-semantic-highlighting-warn-on-missing-face 'lsp-semantic-tokens-warn-on-missing-face "lsp-mode 7.1")
 
 (defcustom lsp-semantic-tokens-warn-on-missing-face nil
   "Warning on missing face for token type/modifier.
 When non-nil, this option will emit a warning any time a token
 or modifier type returned by a language server has no face associated with it."
-  :group 'lsp-mode
+  :group 'lsp-semantic-tokens
   :type 'boolean)
 
 (defcustom lsp-semantic-tokens-apply-modifiers nil
   "Whether semantic tokens should take token modifiers into account."
-  :group 'lsp-mode
+  :group 'lsp-semantic-tokens
   :type 'boolean)
 
 (defface lsp-face-semhl-constant
@@ -431,7 +437,7 @@ IS-RANGE-PROVIDER is non-nil when server supports range requests."
 ;;;###autoload
 (define-minor-mode lsp-semantic-tokens-mode
   "Toggle semantic-tokens support."
-  :group 'lsp-mode
+  :group 'lsp-semantic-tokens
   :global nil
   (cond
    (lsp-semantic-tokens-mode


### PR DESCRIPTION
- Fix wrong/missing groups on defcustom
- Create missing groups for each feature for easier browsing during customizing the variables and for make it easier to generate the documentation.
- Generate documentation for settings page with all `lsp-*.el` defcustoms.
- Generate documentation for settings page with all `lsp-*.el` deffaces.

Preview 
![image](https://user-images.githubusercontent.com/7820865/115131882-d70f0880-9fd1-11eb-8ad0-b70f66f44f03.png)
