### PR TITLE
Avoid positional arguments to define-minor-mode

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -808,7 +808,7 @@ them with `crate` or the crate name they refer to."
 
 (define-minor-mode lsp-rust-analyzer-inlay-hints-mode
   "Mode for displaying inlay hints."
-  nil nil nil
+  :lighter nil
   (cond
    (lsp-rust-analyzer-inlay-hints-mode
     (lsp-rust-analyzer-update-inlay-hints (current-buffer))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2577,7 +2577,6 @@ and end-of-string meta-characters."
   "Keymap for `lsp-mode'.")
 
 (define-minor-mode lsp-mode ""
-  nil nil nil
   :keymap lsp-mode-map
   :lighter
   (" LSP["
@@ -3604,7 +3603,7 @@ yet."
 
 (define-minor-mode lsp-managed-mode
   "Mode for source buffers managed by lsp-mode."
-  nil nil nil
+  :lighter nil
   (cond
    (lsp-managed-mode
     (when (lsp-feature? "textDocument/hover")
@@ -4932,7 +4931,6 @@ RENDER-ALL - nil if only the signature should be rendered."
   "Keymap for `lsp-signature-mode-map'")
 
 (define-minor-mode lsp-signature-mode ""
-  nil nil nil
   :keymap lsp-signature-mode-map
   :lighter ""
   :group 'lsp-mode)


### PR DESCRIPTION
Back in Emacs-21.1, `define-minor-mode` grew keyword arguments to
replace its old positional arguments.  Starting with Emacs-28.1
warning will be omitted if positional arguments are still used.

Providing values for the optional arguments but using nil and then
subsequently using the corresponding keyword arguments was never
necessary.