### PR TITLE
Document lsp-mode entry point

### DIFF
--- a/docs/page/installation.md
+++ b/docs/page/installation.md
@@ -2,7 +2,7 @@
 
 You need first `lsp-mode`, that is a Emacs client for an LSP server.
 Then you need to install the specific LSP server for your language.
-Finally, use `M-x lsp` to start a new language server.
+Finally, call `M-x lsp` to use `lsp-mode` or use the corresponding major mode hook to autostart the server.
 
 ## Client
 

--- a/docs/page/installation.md
+++ b/docs/page/installation.md
@@ -2,7 +2,7 @@
 
 You need first `lsp-mode`, that is a Emacs client for an LSP server.
 Then you need to install the specific LSP server for your language.
-Finally, call `M-x lsp` to use `lsp-mode` or use the corresponding major mode hook to autostart the server.
+Finally, call `M-x lsp` or use the corresponding major mode hook to autostart the server.
 
 ## Client
 

--- a/docs/page/installation.md
+++ b/docs/page/installation.md
@@ -2,6 +2,7 @@
 
 You need first `lsp-mode`, that is a Emacs client for an LSP server.
 Then you need to install the specific LSP server for your language.
+Finally, use `M-x lsp` to start a new language server.
 
 ## Client
 


### PR DESCRIPTION
As far as I understand it, `lsp-mode` uses a non-conventional entry point, `M-x lsp` instead of `M-x lsp-mode`.

The [GNU Conventions for Writing Minor Modes](https://www.gnu.org/software/emacs/manual/html_node/elisp/Minor-Mode-Conventions.html) states to:

1. Define a variable whose name ends in ‘-mode’. We call this the mode variable. 
2. Define a command, called the mode command, whose name is the same as the mode variable. Its job is to set the value of the mode variable, plus anything else that needs to be done to actually enable or disable the mode’s features. 

`lsp-mode` does implement an `lsp-mode` variable and command.  The variable appears to fit the first convention, however, the command is undocumented and the `lsp` command is documented in the docstring as being the entry point.  Further, to quote @yyoncho,

> The proper way to start lsp-mode is using `M-x lsp`

https://github.com/emacs-lsp/lsp-mode/issues/2295#issuecomment-720051764

I could find nowhere in the online docs that says what the appropriate entry point is.  Since `lsp-mode` uses a non-conventional entry point, I feel it should be mentioned.  I put it in the introductory Setup > Installation paragraph.  This paragraph is an overview of the installation process.  Enabling the mode is a sensible last step.

I am new to `lsp-mode`, so I chose wording that derived from the `lsp` docstring.  It may be more appropriate to say something like,

```
Finally, call `M-x lsp` to use `lsp-mode`.
```

as users may not know that "start a language server" really means "start using `lsp-mode`".  Actually, as a new user, that's not clear to me at all, although it appears to be the case (through the docstrings and @yyoncho's comment).  

