### PR TITLE
lsp-file-watch-ignored-directories: OCaml

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -338,7 +338,10 @@ the server has requested that."
     "[/\\\\]\\.cpcache\\'"
     ;; .Net Core build-output
     "[/\\\\]bin/Debug\\'"
-    "[/\\\\]obj\\'")
+    "[/\\\\]obj\\'"
+    ;; OCaml and Dune
+     "[/\\\\]_opam\\'"
+     "[/\\\\]_build\\'")
   "List of regexps matching directory paths which won't be monitored when
 creating file watches. Customization of this variable is only honored at
 the global level or at a root of an lsp workspace."


### PR DESCRIPTION
Ignore `_opam` (local Opam switch directory) and `_build` (build artefacts from the Dune tool).