### PR TITLE
Fix type of lsp-yaml-custom-tags

### DIFF
--- a/clients/lsp-yaml.el
+++ b/clients/lsp-yaml.el
@@ -102,7 +102,7 @@
 
 (defcustom lsp-yaml-custom-tags nil
   "Custom tags for the parser to use."
-  :type '(repeat string)
+  :type '(lsp-repeatable-vector string)
   :group 'lsp-yaml
   :package-version '(lsp-mode . "6.2"))
 


### PR DESCRIPTION
The language server expects a JSON array. This adds the correct type. (discovered in this issue https://github.com/emacs-lsp/lsp-mode/issues/2804)

