### PR TITLE
Add consult-lsp to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ most popular Emacs packages like `company`, `flycheck` and `projectile`.
   - Helm integration -
     [helm-lsp](https://github.com/emacs-lsp/helm-lsp/)
   - Ivy integration - [lsp-ivy](https://github.com/emacs-lsp/lsp-ivy/)
+  - Consult integration - [consult-lsp](https://github.com/gagbo/consult-lsp)
   - Treemacs integration -
     [lsp-treemacs](https://github.com/emacs-lsp/lsp-treemacs)
   - Semantic tokens as defined by LSP 3.16 (compatible language servers include recent development builds of clangd and rust-analyzer)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
       - Treemacs: https://github.com/emacs-lsp/lsp-treemacs
       - Helm: https://github.com/emacs-lsp/helm-lsp
       - Ivy: https://github.com/emacs-lsp/lsp-ivy
+      - Consult: https://github.com/gagbo/consult-lsp
       - Dired: page/settings/dired.md
       - Iedit: page/settings/iedit.md
       - Ido: page/settings/ido.md


### PR DESCRIPTION
Now that consult-lsp is on MELPA I feel safer adding it to the readme