### PR TITLE
`lsp-command-map`: change bindings to lowercase where possible

### DIFF
--- a/docs/page/keybindings.md
+++ b/docs/page/keybindings.md
@@ -25,7 +25,7 @@ configured `lsp-command-map` which is bound to `lsp-keymap-prefix`
 | `s-l t d`  | Toggle minor mode for showing hover information in child frame. (requires `lsp-ui`)                                                 |
 | `s-l t s`  | Toggle signature auto activate.                                                                                                     |
 | `s-l t f`  | Toggle on type formatting.                                                                                                          |
-| `s-l t T`  | Toggle global minor mode for synchronizing `lsp-mode` workspace folders and `treemacs` projects. (requires `lsp-treemacs`)          |
+| `s-l t t`  | Toggle global minor mode for synchronizing `lsp-mode` workspace folders and `treemacs` projects. (requires `lsp-treemacs`)          |
 | `s-l g g`  | Find definitions of the symbol under point.                                                                                         |
 | `s-l g r`  | Find references of the symbol under point.                                                                                          |
 | `s-l g i`  | Find implementations of the symbol under point.                                                                                     |

--- a/docs/page/keybindings.md
+++ b/docs/page/keybindings.md
@@ -15,17 +15,17 @@ configured `lsp-command-map` which is bound to `lsp-keymap-prefix`
 | `s-l s D`  | Disconnect the buffer from the language server keeping the server running.                                                          |
 | `s-l = =`  | Ask the server to format this document.                                                                                             |
 | `s-l = r`  | Ask the server to format the region, or if none is selected, the current line.                                                      |
-| `s-l F a`  | Add new project root to the list of workspace folders.                                                                              |
-| `s-l F r`  | Remove project root from the list of workspace folders.                                                                             |
-| `s-l F b`  | Remove project root from the workspace blacklist.                                                                                   |
-| `s-l T l`  | Toggle code-lens overlays.                                                                                                          |
-| `s-l T L`  | Toggle client-server protocol logging.                                                                                              |
-| `s-l T h`  | Toggle symbol highlighting.                                                                                                         |
-| `s-l T S`  | Toggle minor mode for showing information for current line in sideline. (requires `lsp-ui`)                                         |
-| `s-l T d`  | Toggle minor mode for showing hover information in child frame. (requires `lsp-ui`)                                                 |
-| `s-l T s`  | Toggle signature auto activate.                                                                                                     |
-| `s-l T f`  | Toggle on type formatting.                                                                                                          |
-| `s-l T T`  | Toggle global minor mode for synchronizing `lsp-mode` workspace folders and `treemacs` projects. (requires `lsp-treemacs`)          |
+| `s-l f a`  | Add new project root to the list of workspace folders.                                                                              |
+| `s-l f r`  | Remove project root from the list of workspace folders.                                                                             |
+| `s-l f b`  | Remove project root from the workspace blacklist.                                                                                   |
+| `s-l t l`  | Toggle code-lens overlays.                                                                                                          |
+| `s-l t L`  | Toggle client-server protocol logging.                                                                                              |
+| `s-l t h`  | Toggle symbol highlighting.                                                                                                         |
+| `s-l t S`  | Toggle minor mode for showing information for current line in sideline. (requires `lsp-ui`)                                         |
+| `s-l t d`  | Toggle minor mode for showing hover information in child frame. (requires `lsp-ui`)                                                 |
+| `s-l t s`  | Toggle signature auto activate.                                                                                                     |
+| `s-l t f`  | Toggle on type formatting.                                                                                                          |
+| `s-l t T`  | Toggle global minor mode for synchronizing `lsp-mode` workspace folders and `treemacs` projects. (requires `lsp-treemacs`)          |
 | `s-l g g`  | Find definitions of the symbol under point.                                                                                         |
 | `s-l g r`  | Find references of the symbol under point.                                                                                          |
 | `s-l g i`  | Find implementations of the symbol under point.                                                                                     |
@@ -41,10 +41,10 @@ configured `lsp-command-map` which is bound to `lsp-keymap-prefix`
 | `s-l a a`  | Execute code action.                                                                                                                |
 | `s-l a l`  | Click lsp lens using ‘avy’ package.                                                                                                 |
 | `s-l a h`  | Highlight symbol at point.                                                                                                          |
-| `s-l G g`  | Peek definitions to the identifier at point. (requires `lsp-ui`)                                                                    |
-| `s-l G r`  | Peek references to the identifier at point. (requires `lsp-ui`)                                                                     |
-| `s-l G i`  | Peek implementation locations of the symbol at point. (requires `lsp-ui`)                                                           |
-| `s-l G s`  | Peek symbols in the workspace. (requires `lsp-ui`)                                                                                  |
+| `s-l p g`  | Peek definitions to the identifier at point. (requires `lsp-ui`)                                                                    |
+| `s-l p r`  | Peek references to the identifier at point. (requires `lsp-ui`)                                                                     |
+| `s-l p i`  | Peek implementation locations of the symbol at point. (requires `lsp-ui`)                                                           |
+| `s-l p s`  | Peek symbols in the workspace. (requires `lsp-ui`)                                                                                  |
 | `C-u RET`  | When inserting `C-u` will change the behaviour from insert to replace or vice versa depending on `lsp-completion-default-behaviour` |
 
 ## which-key integration

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2283,26 +2283,26 @@ BINDINGS is a list of (key def desc cond)."
       "=r" lsp-format-region "format region" (lsp-feature? "textDocument/rangeFormatting")
 
       ;; folders
-      "Fa" lsp-workspace-folders-add "add folder" t
-      "Fb" lsp-workspace-blacklist-remove "un-blacklist folder" t
-      "Fr" lsp-workspace-folders-remove "remove folder" t
+      "fa" lsp-workspace-folders-add "add folder" t
+      "fb" lsp-workspace-blacklist-remove "un-blacklist folder" t
+      "fr" lsp-workspace-folders-remove "remove folder" t
 
       ;; toggles
-      "TD" lsp-modeline-diagnostics-mode "toggle modeline diagnostics" (lsp-feature?
+      "tD" lsp-modeline-diagnostics-mode "toggle modeline diagnostics" (lsp-feature?
                                                                         "textDocument/publishDiagnostics")
-      "TL" lsp-toggle-trace-io "toggle log io" t
-      "TS" lsp-ui-sideline-mode "toggle sideline" (featurep 'lsp-ui-sideline)
-      "TT" lsp-treemacs-sync-mode "toggle treemacs integration" (featurep 'lsp-treemacs)
-      "Ta" lsp-modeline-code-actions-mode "toggle modeline code actions" (lsp-feature?
+      "tL" lsp-toggle-trace-io "toggle log io" t
+      "tS" lsp-ui-sideline-mode "toggle sideline" (featurep 'lsp-ui-sideline)
+      "tT" lsp-treemacs-sync-mode "toggle treemacs integration" (featurep 'lsp-treemacs)
+      "ta" lsp-modeline-code-actions-mode "toggle modeline code actions" (lsp-feature?
                                                                           "textDocument/codeAction")
-      "Tb" lsp-headerline-breadcrumb-mode "toggle breadcrumb" (lsp-feature?
+      "tb" lsp-headerline-breadcrumb-mode "toggle breadcrumb" (lsp-feature?
                                                                "textDocument/documentSymbol")
-      "Td" lsp-ui-doc-mode "toggle documentation popup" (featurep 'lsp-ui-doc)
-      "Tf" lsp-toggle-on-type-formatting "toggle on type formatting" (lsp-feature?
+      "td" lsp-ui-doc-mode "toggle documentation popup" (featurep 'lsp-ui-doc)
+      "tf" lsp-toggle-on-type-formatting "toggle on type formatting" (lsp-feature?
                                                                       "textDocument/onTypeFormatting")
-      "Th" lsp-toggle-symbol-highlight "toggle highlighting" (lsp-feature? "textDocument/documentHighlight")
-      "Tl" lsp-lens-mode "toggle lenses" (lsp-feature? "textDocument/codeLens")
-      "Ts" lsp-toggle-signature-auto-activate "toggle signature" (lsp-feature? "textDocument/signatureHelp")
+      "th" lsp-toggle-symbol-highlight "toggle highlighting" (lsp-feature? "textDocument/documentHighlight")
+      "tl" lsp-lens-mode "toggle lenses" (lsp-feature? "textDocument/codeLens")
+      "ts" lsp-toggle-signature-auto-activate "toggle signature" (lsp-feature? "textDocument/signatureHelp")
 
       ;; goto
       "ga" xref-find-apropos "find symbol in workspace" (lsp-feature? "workspace/symbol")
@@ -2331,14 +2331,14 @@ BINDINGS is a list of (key def desc cond)."
       "al" lsp-avy-lens "lens" (and (bound-and-true-p lsp-lens-mode) (featurep 'avy))
 
       ;; peeks
-      "Gg" lsp-ui-peek-find-definitions "peek definitions" (and (lsp-feature? "textDocument/definition")
+      "pg" lsp-ui-peek-find-definitions "peek definitions" (and (lsp-feature? "textDocument/definition")
                                                                 (fboundp 'lsp-ui-peek-find-definitions))
-      "Gi" lsp-ui-peek-find-implementation "peek implementations" (and
+      "pi" lsp-ui-peek-find-implementation "peek implementations" (and
                                                                    (fboundp 'lsp-ui-peek-find-implementation)
                                                                    (lsp-feature? "textDocument/implementation"))
-      "Gr" lsp-ui-peek-find-references "peek references" (and (fboundp 'lsp-ui-peek-find-references)
+      "pr" lsp-ui-peek-find-references "peek references" (and (fboundp 'lsp-ui-peek-find-references)
                                                               (lsp-feature? "textDocument/references"))
-      "Gs" lsp-ui-peek-find-workspace-symbol "peek workspace symbol" (and (fboundp
+      "ps" lsp-ui-peek-find-workspace-symbol "peek workspace symbol" (and (fboundp
                                                                            'lsp-ui-peek-find-workspace-symbol)
                                                                           (lsp-feature? "workspace/symbol")))))
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2292,7 +2292,6 @@ BINDINGS is a list of (key def desc cond)."
                                                                         "textDocument/publishDiagnostics")
       "tL" lsp-toggle-trace-io "toggle log io" t
       "tS" lsp-ui-sideline-mode "toggle sideline" (featurep 'lsp-ui-sideline)
-      "tT" lsp-treemacs-sync-mode "toggle treemacs integration" (featurep 'lsp-treemacs)
       "ta" lsp-modeline-code-actions-mode "toggle modeline code actions" (lsp-feature?
                                                                           "textDocument/codeAction")
       "tb" lsp-headerline-breadcrumb-mode "toggle breadcrumb" (lsp-feature?
@@ -2303,6 +2302,7 @@ BINDINGS is a list of (key def desc cond)."
       "th" lsp-toggle-symbol-highlight "toggle highlighting" (lsp-feature? "textDocument/documentHighlight")
       "tl" lsp-lens-mode "toggle lenses" (lsp-feature? "textDocument/codeLens")
       "ts" lsp-toggle-signature-auto-activate "toggle signature" (lsp-feature? "textDocument/signatureHelp")
+      "tt" lsp-treemacs-sync-mode "toggle treemacs integration" (featurep 'lsp-treemacs)
 
       ;; goto
       "ga" xref-find-apropos "find symbol in workspace" (lsp-feature? "workspace/symbol")


### PR DESCRIPTION
Hi!

This PR changes some of the default bindings on `lsp-command-map`. In my humble opinion changing the `F` and `T` prefixes to be lowercase is a no-brainer because it doesn't even break existing bindings, and there is nothing bound under the lowercase versions. It also changes the `lsp-treemacs-sync-mode` binding from `TT` to `tt` under the same logic. Changing `G` prefix to `p` might be undesired on your end as it does break existing bindings, but I think it's more sensible as `p` is a) lowercase and b) is a memonic for "peek". 

Regradless, thank you for all your work on `lsp-mode`.