### PR TITLE
lsp-xml: Enable on all XML file types

### DIFF
--- a/clients/lsp-xml.el
+++ b/clients/lsp-xml.el
@@ -229,8 +229,7 @@ Newlines and excess whitespace are removed."
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-xml--create-connection)
-                  :activation-fn (lambda (file-name _mode)
-                                   (string= (f-ext file-name) "xml"))
+                  :activation-fn (lsp-activate-on "xml")
                   :priority 0
                   :server-id 'xmlls
                   :multi-root t


### PR DESCRIPTION
activation-fn limited it to files ending with xml, which doesn't cover
.xsd and other XML formats.