### PR TITLE
Fix to reflect diagnostics to flymake on enabling lsp-diagnostics-mode

### DIFF
--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -261,9 +261,9 @@ See https://github.com/emacs-lsp/lsp-mode."
 (defun lsp-diagnostics--flymake-setup ()
   "Setup flymake."
   (setq lsp-diagnostics--flymake-report-fn nil)
-  (flymake-mode 1)
   (add-hook 'flymake-diagnostic-functions 'lsp-diagnostics--flymake-backend nil t)
-  (add-hook 'lsp-diagnostics-updated-hook 'lsp-diagnostics--flymake-after-diagnostics nil t))
+  (add-hook 'lsp-diagnostics-updated-hook 'lsp-diagnostics--flymake-after-diagnostics nil t)
+  (flymake-mode 1))
 
 (defun lsp-diagnostics--flymake-after-diagnostics ()
   "Handler for `lsp-diagnostics-updated-hook'."


### PR DESCRIPTION
Thank you for your great work.
Let me give you a small patch for flymake integration.

The first time lsp-diagnostics-mode is enabled, flymake syntax check
with lsp-diagnostics--flymake-backend is not started even though
flymake-start-on-flymake-mode is t.

I can't figure out that it is expected behavior of lsp-mode flymake backend.

### Before This Change

The first time lsp-diagnostics-mode is enabled:  
<img width="860" alt="00_before_lsp-diagnostics-flymake-first-time" src="https://user-images.githubusercontent.com/12934757/116548611-71a30c00-a92f-11eb-8b68-7990bf1979f8.png">

### After This Change

The first time lsp-diagnostics-mode is enabled:  
<img width="858" alt="01_after_lsp-diagnostics-flymake-first-time" src="https://user-images.githubusercontent.com/12934757/116548616-749dfc80-a92f-11eb-93e9-1cec2f27a1b4.png">
