### PR TITLE
Enable dynamic registration for "codeAction/resolve" lsp-feature

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -786,7 +786,10 @@ directory")
      :check-command (lambda (workspace)
                       (with-lsp-workspace workspace
                         (lsp:code-action-options-resolve-provider?
-                         (lsp--capability :codeActionProvider)))))
+                         (or (lsp--capability :codeActionProvider)
+                             (when-let ((maybe-capability (lsp--registered-capability "textDocument/codeAction"))
+                                        (capability-options (lsp--registered-capability-options maybe-capability)))
+                               capability-options))))))
     ("textDocument/codeLens" :capability :codeLensProvider)
     ("textDocument/completion" :capability :completionProvider)
     ("completionItem/resolve"


### PR DESCRIPTION
Even though lsp-mode advertises dynamicRegistration for
"codeAction/resolve" it does not actually honor those registrations
coming dynamically from the server. This updates lsp-method-requirements
so that it now considers those registrations too.