### PR TITLE
Add yaml-mode to lsp--formatting-indent-alist

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5330,6 +5330,7 @@ Request codeAction/resolve for more info if server supports."
     (scala-mode         . scala-indent:step)         ; Scala
     (powershell-mode    . powershell-indent)         ; PowerShell
     (ess-mode           . ess-indent-offset)         ; ESS (R)
+    (yaml-mode          . yaml-indent-offset)        ; YAML
 
     (default            . standard-indent))          ; default fallback
   "A mapping from `major-mode' to its indent variable.")


### PR DESCRIPTION
Changes:
- Adds yaml-mode's indent variable to lsp--formatting-indent-alist

Closes #2828 