### PR TITLE
Add nix-direnv to lsp-file-watch-ignored-directories

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -340,8 +340,10 @@ the server has requested that."
     "[/\\\\]bin/Debug\\'"
     "[/\\\\]obj\\'"
     ;; OCaml and Dune
-     "[/\\\\]_opam\\'"
-     "[/\\\\]_build\\'")
+    "[/\\\\]_opam\\'"
+    "[/\\\\]_build\\'"
+    ;; nix-direnv
+    "[/\\\\]\\.direnv\\'")
   "List of regexps matching directory paths which won't be monitored when
 creating file watches. Customization of this variable is only honored at
 the global level or at a root of an lsp workspace."


### PR DESCRIPTION
In its default configuration, nix-direnv creates a .direnv directory next to direnv's .envrc. This directory contains no source code and links to all the projects dependencies, so it should be ignored.