### PR TITLE
Add lsp-sql-execute-paragraph

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Release 7.1
+  * Add ~lsp-sql-execute-paragraph~ to execute the current paragraph (like ~sql-send-paragraph~).
   * Breaking change: bindings for commands under ~s~ (like ~lsp-workspace-shutdown~) were moved under ~w~ for better compatibility with =Spacemacs=
   * removed ~lsp-print-performance~
   * Add support for insert/replace when performing completion. When using


### PR DESCRIPTION
This is the `lsp-mode` equivalent to `sql-send-paragraph`. Slightly generalizes `lsp-sql-execute-query` to ease construction of this and other similar equivalent functions (possibly an equivalent to `sql-send-line-and-next`?)