### PR TITLE
Remove duplicate highlights for iedit

### DIFF
--- a/lsp-iedit.el
+++ b/lsp-iedit.el
@@ -24,6 +24,7 @@
 ;;; Code:
 
 (require 'lsp-mode)
+(require 'dash)
 
 (declare-function iedit-make-occurrence-overlay "iedit-lib" (begin end))
 (declare-function iedit-start-buffering "iedit-lib" ())
@@ -73,8 +74,12 @@ language server doesn't support renaming.
 See also `lsp-enable-symbol-highlighting'."
   (interactive)
   (let ((highlights (lsp-request "textDocument/documentHighlight"
-                                 (lsp--text-document-position-params))))
-    (lsp-iedit--on-ranges (mapcar #'lsp:document-highlight-range highlights))))
+                                 (lsp--text-document-position-params)))
+        (-compare-fn (-lambda ((&Location :range (&Range :start l-start :end l-end))
+                                          (&Location :range (&Range :start r-start :end r-end)))
+                               (and (lsp--position-equal l-start r-start)
+                                    (lsp--position-equal l-end   r-end)))))
+    (lsp-iedit--on-ranges (mapcar #'lsp:document-highlight-range (-distinct highlights)))))
 
 ;;;###autoload
 (defun lsp-evil-multiedit-highlights ()


### PR DESCRIPTION
If a language server reports the same symbol multiple times (ccls can
behave like this for template functions, see https://github.com/MaskRay/ccls/issues/769),
 lsp-iedit will select the same region multiple times, so each modification to an area will be
duplicated.  For example, deleting a character will delete multiple
characters.  This PR filters duplicate symbols.

Note I'm not a lisp programmer, I'm not sure this is the best way to do this. But it seems to work for me.