### PR TITLE
ensure callbacks and timers are called in "current tokenizing buffer" (fix #2858)

### DIFF
--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -253,13 +253,12 @@ ignoring the timer."
      `( :textDocument ,(lsp--text-document-identifier)
         ,@(if region (list :range (lsp--region-to-range (car region) (cdr region))) '()))
      (lambda (response)
-       (with-current-buffer semantic-tokenizing-buffer
-         (setq lsp--semantic-tokens-cache response)
-         (lsp-put lsp--semantic-tokens-cache :_documentVersion lsp--cur-version)
-         (lsp-put lsp--semantic-tokens-cache :_region region)
-         (when fontify-immediately (font-lock-flush))
-         ;; request full token set to improve fontification speed when scrolling
-         (when region (funcall request-full-token-set nil))))
+       (setq lsp--semantic-tokens-cache response)
+       (lsp-put lsp--semantic-tokens-cache :_documentVersion lsp--cur-version)
+       (lsp-put lsp--semantic-tokens-cache :_region region)
+       (when fontify-immediately (font-lock-flush))
+       ;; request full token set to improve fontification speed when scrolling
+       (when region (funcall request-full-token-set nil)))
      :error-handler (lambda (&rest _) (funcall request-full-token-set t))
      :mode 'tick
      :cancel-token (format "semantic-tokens-%s" (lsp--buffer-uri)))))


### PR DESCRIPTION
Fixes https://github.com/emacs-lsp/lsp-mode/issues/2858

Capture buffer that's being tokenized in closures/lambdas. This will ensure that they will be called in the proper buffer even if `(current-buffer)` changes for any reason.