### PR TITLE
lsp-completion: Fix triggerKind on manual invokation

### DIFF
--- a/Cask
+++ b/Cask
@@ -25,4 +25,5 @@
  (depends-on "espuds")
  (depends-on "ecukes")
  (depends-on "undercover")
- (depends-on "deferred"))
+ (depends-on "deferred")
+ (depends-on "el-mock"))

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -370,10 +370,12 @@ The MARKERS and PREFIX value will be attached to each candidate."
 
 (defun lsp-completion--get-context (trigger-characters)
   "Get completion context with provided TRIGGER-CHARACTERS."
-  (let* (trigger-char
+  (let* ((triggered-by-char (equal last-command 'self-insert-command))
+         (trigger-char (when triggered-by-char
+                           (lsp-completion--looking-back-trigger-characterp
+                            trigger-characters)))
          (trigger-kind (cond
-                        ((setq trigger-char (lsp-completion--looking-back-trigger-characterp
-                                             trigger-characters))
+                        (trigger-char
                          lsp/completion-trigger-kind-trigger-character)
                         ((equal (cl-second lsp-completion--cache) :incomplete)
                          lsp/completion-trigger-kind-trigger-for-incomplete-completions)

--- a/test/windows-bootstrap.el
+++ b/test/windows-bootstrap.el
@@ -30,7 +30,7 @@
 
 (let* ((package-archives '(("melpa" . "https://melpa.org/packages/")
                            ("gnu" . "https://elpa.gnu.org/packages/")))
-       (pkgs '(dash f lv ht spinner markdown-mode deferred)))
+       (pkgs '(dash f lv ht spinner markdown-mode deferred el-mock)))
   (package-initialize)
   (package-refresh-contents)
 


### PR DESCRIPTION
Related to issue #2857.

If **space** is among a servers **triggerCharacters** for completion, it does not return any results after a **space**.

This happens because `lsp-completion--get-context` returns `CompletionTriggerKind = 2` when completion is invoked manually but the previous character is one of **triggerCharacters**.

## Steps to Reproduce

See [example project](https://github.com/gexplorer/veturpack)

* Inside a **vue** file

### Failed completion

* Try completion with cursor separated one **space** from the curly bracket:
```js
import { | } from 'vue';
```
* The request is:
```json
Params: {
  "textDocument": {
    "uri": "file:///Users/eder/Projects/veturpack/src/Test.vue"
  },
  "position": {
    "line": 7,
    "character": 9
  },
  "context": {
    "triggerKind": 2,
    "triggerCharacter": " "
  }
}
```
* It won't return results

### Correct completion

* Try completion with cursor right after the curly bracket
```js
import {|  } from 'vue';
```
* The request is:
```json
Params: {
  "textDocument": {
    "uri": "file:///Users/eder/Projects/veturpack/src/Test.vue"
  },
  "position": {
    "line": 7,
    "character": 8
  },
  "context": {
    "triggerKind": 1
  }
}
```