### PR TITLE
Set view-inhibit-help-message in gfm-view-mode to silence view message

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4759,6 +4759,8 @@ Stolen from `org-copy-visible'."
   "Holds the major mode when fontification function is running.
 See #2588")
 
+(defvar view-inhibit-help-message)
+
 (defun lsp--render-markdown ()
   "Render markdown."
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4773,7 +4773,8 @@ See #2588")
 
     ;; markdown-mode v2.3 does not yet provide gfm-view-mode
     (if (fboundp 'gfm-view-mode)
-        (gfm-view-mode)
+        (let ((view-inhibit-help-message t))
+          (gfm-view-mode))
       (gfm-mode))
 
     (lsp--setup-markdown lsp-buffer-major-mode)))


### PR DESCRIPTION
This avoids the renderer spamming *Messages* with:

  View mode: type C-h for help, h for commands, q to quit.

gfm-view-mode shows this message when view-read-only is t and
view-inhibit-help-message is nil.