### PR TITLE
[lens] Add `lsp-lens-place-position`

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -41,6 +41,7 @@
   * Add 2 rust-analyzer LSP extension function ~lsp-rust-analyzer-related-tests~ and
     ~lsp-rust-analyzer-open-cargo-toml~
   * Work around bug in NPM versions 7.0.0 through 7.4.1 that prevented ~lsp-install-server~ from working for NPM-based language servers.
+  * Add ~lsp-lens-place-position~ with option to place code lens at end of line.
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -88,8 +88,10 @@ Results are meaningful only if FROM and TO are on the same line."
                                        (save-excursion
                                          (beginning-of-line-text)
                                          (point))))
-         (str (concat (make-string offset ?\s)
-                      (overlay-get ov 'lsp--lens-contents))))
+         (str (if (eq 'end-of-line lsp-lens-place-position)
+                  (overlay-get ov 'lsp--lens-contents)
+                (concat (make-string offset ?\s)
+                        (overlay-get ov 'lsp--lens-contents)))))
     (save-excursion
       (goto-char (overlay-start ov))
       (if (eq 'end-of-line lsp-lens-place-position)

--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -34,6 +34,13 @@
   :group 'lsp-lens
   :type 'number)
 
+(defcustom lsp-lens-place-position 'above-line
+  "The position to place lens relative to returned lens position."
+  :group 'lsp-lens
+  :type '(choice (const above-line)
+                 (const end-of-line))
+  :package-version '(lsp-mode . "7.1"))
+
 (defface lsp-lens-mouse-face
   '((t :height 0.8 :inherit link))
   "The face used for code lens overlays."
@@ -82,18 +89,21 @@ Results are meaningful only if FROM and TO are on the same line."
                                          (beginning-of-line-text)
                                          (point))))
          (str (concat (make-string offset ?\s)
-                      (overlay-get ov 'lsp--lens-contents)
-                      "\n")))
+                      (overlay-get ov 'lsp--lens-contents))))
     (save-excursion
       (goto-char (overlay-start ov))
-      (overlay-put ov 'before-string str)
+      (if (eq 'end-of-line lsp-lens-place-position)
+          (overlay-put ov 'after-string (concat " " str))
+        (overlay-put ov 'before-string (concat str "\n")))
       (overlay-put ov 'lsp-original str))))
 
 (defun lsp-lens--overlay-ensure-at (pos)
   "Find or create a lens for the line at POS."
   (-doto (save-excursion
            (goto-char pos)
-           (make-overlay (point-at-bol) (1+ (point-at-eol)) nil t t))
+           (if (eq 'end-of-line lsp-lens-place-position)
+               (make-overlay (point-at-eol) -1 nil t t)
+             (make-overlay (point-at-bol) (1+ (point-at-eol)) nil t t)))
     (overlay-put 'lsp-lens t)
     (overlay-put 'evaporate t)
     (overlay-put 'lsp-lens-position pos)))


### PR DESCRIPTION
This should allow lsp-lens to be placed at end of line like neovim and IDEA:

Before (`'above-line`):
![image](https://user-images.githubusercontent.com/7820865/118405081-37827b80-b64c-11eb-922c-85246593dd86.png)

After (`'end-of-line`):
![image](https://user-images.githubusercontent.com/7820865/118405070-1faaf780-b64c-11eb-9969-3d0d1934bd31.png)

Note: I kept the default as `'above-line` but maybe we should consider changing the default before release lens as enabled to users as the `'above-line` adds an extra unnecessary line on the lens position as you can see in the print.