### PR TITLE
Fix spinner not showing on some cases

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7820,7 +7820,8 @@ IGNORE-MULTI-FOLDER to ignore multi folder server."
            (lsp--find-workspace session client project-root)
            (unless ignore-multi-folder
              (lsp--find-multiroot-workspace session client project-root))
-           (lsp--start-connection session client project-root)))
+           (lsp--start-connection session client project-root))
+          (lsp--find-workspace session client project-root))
         clients))
 
 (defun lsp--spinner-stop ()


### PR DESCRIPTION
I always had this issue where the spinner doesn't show up when starting/restarting the workspace, after some debugging I confirmed [this code](https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-mode.el#L6930) is called but nothing happens. The easiest/only one solution I found was to check for running workspaces again after starting it