### PR TITLE
Add lsp-face-semhl-method to lsp-semantic-token-faces

### DIFF
--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -190,6 +190,7 @@ unless overridden by a more specific face association."
     ("enum" . lsp-face-semhl-enum)
     ("typeParameter" . lsp-face-semhl-type-parameter)
     ("function" . lsp-face-semhl-function)
+    ("method" . lsp-face-semhl-method)
     ("member" . lsp-face-semhl-member)
     ("property" . lsp-face-semhl-property)
     ("macro" . lsp-face-semhl-macro)


### PR DESCRIPTION
I noticed that the method face wasn't added to `lsp-semantic-token-faces` which stopped the face from being used.