### PR TITLE
require lsp-mode to remove native complation warnings and errors

### DIFF
--- a/lsp-icons.el
+++ b/lsp-icons.el
@@ -20,6 +20,7 @@
 ;;  LSP icons management
 ;;
 ;;; Code:
+(require 'lsp-mode)
 
 (defgroup lsp-icons nil
   "LSP icons"


### PR DESCRIPTION
more details in issue [#2896](https://github.com/emacs-lsp/lsp-mode/issues/2896)