### PR TITLE
Strip emacs version information provided as clientInfo

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7006,7 +7006,7 @@ SESSION is the active session."
         (list :processId nil
               :rootPath (lsp-file-local-name (expand-file-name root))
               :clientInfo (list :name "emacs"
-                                :version (emacs-version))
+                                :version (string-trim emacs-version))
               :rootUri (lsp--path-to-uri root)
               :capabilities (lsp--client-capabilities custom-capabilities)
               :initializationOptions initialization-options


### PR DESCRIPTION
Some JSON parsers like the one used by ccls do not like new-line characters. The
Emacs flavor provided by Flathub does include a new-line, (emacs-version)
evaluates to:

"GNU Emacs 27.2 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.21)
 of 2021-03-26"