### PR TITLE
lsp-completion: support InsertTextMode

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -530,8 +530,7 @@ Others: CANDIDATES"
                        'lsp-completion-prefix prefix)
                (text-properties-at 0 candidate))
               ((&CompletionItem? :label :insert-text? :text-edit? :insert-text-format?
-                                 :additional-text-edits? :keep-whitespace?
-                                 :command?)
+                                 :additional-text-edits? :insert-text-mode? :command?)
                item))
         (cond
          (text-edit?
@@ -553,12 +552,11 @@ Others: CANDIDATES"
           (delete-region start-point (point))
           (insert (or (unless (lsp-falsy? insert-text?) insert-text?) label))))
 
+        (lsp--indent-lines start-point (point) insert-text-mode?)
         (when (equal insert-text-format? lsp/insert-text-format-snippet)
           (lsp--expand-snippet (buffer-substring start-point (point))
                                start-point
-                               (point)
-                               nil
-                               keep-whitespace?))
+                               (point)))
 
         (when lsp-completion-enable-additional-text-edit
           (if (or (get-text-property 0 'lsp-completion-resolved candidate)

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -472,6 +472,10 @@ See `-let' for a description of the destructuring mechanism."
   [nil PlainText Snippet])
 (defconst lsp/insert-text-format-plain-text 1)
 (defconst lsp/insert-text-format-snippet 2)
+(defvar lsp/insert-text-mode-lookup
+  [nil AsIs AdjustIndentation])
+(defconst lsp/insert-text-mode-as-it 1)
+(defconst lsp/insert-text-mode-adjust-indentation 2)
 (defvar lsp/message-type-lookup
   [nil Error Warning Info Log])
 (defconst lsp/message-type-error 1)
@@ -559,7 +563,7 @@ See `-let' for a description of the destructuring mechanism."
  (Command (:title :command) (:arguments))
  (CompletionCapabilities nil (:completionItem :completionItemKind :contextSupport :dynamicRegistration))
  (CompletionContext (:triggerKind) (:triggerCharacter))
- (CompletionItem (:label) (:additionalTextEdits :command :commitCharacters :data :deprecated :detail :documentation :filterText :insertText :insertTextFormat :kind :preselect :sortText :tags :textEdit :score :keepWhitespace))
+ (CompletionItem (:label) (:additionalTextEdits :command :commitCharacters :data :deprecated :detail :documentation :filterText :insertText :insertTextFormat :insertTextMode :kind :preselect :sortText :tags :textEdit :score))
  (CompletionItemCapabilities nil (:commitCharactersSupport :deprecatedSupport :documentationFormat :preselectSupport :snippetSupport :tagSupport :insertReplaceSupport :resolveSupport))
  (CompletionItemKindCapabilities nil (:valueSet))
  (CompletionItemTagSupportCapabilities (:valueSet) nil)


### PR DESCRIPTION
Implement #2325 
The behavior will be:
- if the completion item provide `insertTextMode`
  - The value is `adjustIndentation`, we will use relative indentation for multiline insert text. I.e., the next line will be indented relatively to the first line where text is inserted.
  - The value is `asIs`, we will not do any indentation, just insert text with all of its spaces
- if the `insertTextMode` is not provided, we will call the major mode's `indent-line-function` for each inserted line.

Ref:
``` ts
/**
 * How whitespace and indentation is handled during completion
 * item insertion.
 *
 * @since 3.16.0
 */
export namespace InsertTextMode {
	/**
	 * The insertion or replace strings is taken as it is. If the
	 * value is multi line the lines below the cursor will be
	 * inserted using the indentation defined in the string value.
	 * The client will not apply any kind of adjustments to the
	 * string.
	 */
	export const asIs: 1 = 1;

	/**
	 * The editor adjusts leading whitespace of new lines so that
	 * they match the indentation up to the cursor of the line for
	 * which the item is accepted.
	 *
	 * Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a
	 * multi line completion item is indented using 2 tabs and all
	 * following lines inserted will be indented using 2 tabs as well.
	 */
	export const adjustIndentation: 2 = 2;
}

	/**
	 * How whitespace and indentation is handled during completion
	 * item insertion. If not provided the client's default value is used.
	 *
	 * @since 3.16.0
	 */
	insertTextMode?: InsertTextMode;
}
```