### PR TITLE
lsp-rust-analyzer: fix download link to gzip files

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -611,9 +611,9 @@ them with `crate` or the crate name they refer to."
 (defcustom lsp-rust-analyzer-download-url
   (format "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/%s"
           (pcase system-type
-            ('gnu/linux "rust-analyzer-linux")
-            ('darwin "rust-analyzer-mac")
-            ('windows-nt "rust-analyzer-windows.exe")))
+            ('gnu/linux "rust-analyzer-x86_64-unknown-linux-gnu.gz")
+            ('darwin "rust-analyzer-x86_64-apple-darwin.gz")
+            ('windows-nt "rust-analyzer-x86_64-pc-windows-msvc.gz")))
   "Automatic download url for Rust Analyzer"
   :type 'string
   :group 'lsp-rust
@@ -632,6 +632,7 @@ them with `crate` or the crate name they refer to."
 (lsp-dependency
  'rust-analyzer
  `(:download :url lsp-rust-analyzer-download-url
+             :decompress :gzip
              :store-path lsp-rust-analyzer-store-path
              :set-executable? t)
  '(:system "rust-analyzer"))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7398,6 +7398,8 @@ nil."
            (progn
              (when (f-exists? download-path)
                (f-delete download-path))
+             (when (f-exists? store-path)
+               (f-delete store-path))
              (lsp--info "Starting to download %s to %s..." url download-path)
              (mkdir (f-parent download-path) t)
              (url-copy-file url download-path)


### PR DESCRIPTION
It seems that the `rust-analyzer` bare binary isn't being uploaded to [release build](https://github.com/rust-analyzer/rust-analyzer/releases) anymore. Fortunately, we can still use the gzip compressed version and extract it for `rust-analyzer` binary.