### PR TITLE
Skip notification warning if method is nil

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5999,7 +5999,7 @@ textDocument/didOpen for the new file."
     (if-let ((handler (or (gethash method (lsp--client-notification-handlers client))
                           (gethash method lsp--default-notification-handlers))))
         (funcall handler workspace params)
-      (unless (string-prefix-p "$" method)
+      (when (and method (not (string-prefix-p "$" method)))
         (lsp-warn "Unknown notification: %s" method)))))
 
 (lsp-defun lsp--build-workspace-configuration-response ((&ConfigurationParams :items))


### PR DESCRIPTION
First, this issue only appears to occur when building Emacs using the `--with-native-compilation` option.

Starting lsp-mode with <kbd>M-x lsp</kbd> and the latest version of [pylsp](https://github.com/python-lsp/python-lsp-server). A warning pops up:

```
Warning (lsp-mode): Unknown notification: nil
```

And lsp-mode never appears to fully load.

This PR guards against the `nil` method, and the issue appears solved. I've tested it on an Emacs built with and without native-comp.