### PR TITLE
Add `lsp-steep-server-path` custom variable

### DIFF
--- a/clients/lsp-steep.el
+++ b/clients/lsp-steep.el
@@ -47,12 +47,17 @@
   :safe #'booleanp
   :group 'lsp-steep)
 
+(defcustom lsp-steep-server-path nil
+  "Path of the Steep language server executable.
+If specified, `lsp-steep-use-bundler' is ignored."
+  :type 'file
+  :group 'lsp-steep)
+
 (defun lsp-steep--build-command ()
   "Build a command to start the Steep language server."
   (append
-    (if lsp-steep-use-bundler '("bundle" "exec"))
-    '("steep" "langserver")
-    (list (concat "--log-level=" lsp-steep-log-level))))
+   (if (and lsp-steep-use-bundler (not lsp-steep-server-path)) '("bundle" "exec"))
+   (list (or lsp-steep-server-path "steep") "langserver" "--log-level" lsp-steep-log-level)))
 
 (lsp-register-client
  (make-lsp-client

--- a/clients/lsp-steep.el
+++ b/clients/lsp-steep.el
@@ -51,7 +51,8 @@
   "Path of the Steep language server executable.
 If specified, `lsp-steep-use-bundler' is ignored."
   :type 'file
-  :group 'lsp-steep)
+  :group 'lsp-steep
+  :package-version '(lsp-mode . "7.1"))
 
 (defun lsp-steep--build-command ()
   "Build a command to start the Steep language server."


### PR DESCRIPTION
This change adds a new custom variable to the Steep client: `lsp-steep-server-path`.
This variable aims to help users who want to specify any `steep` executable path.

For example, the [ruby/rbs](https://github.com/ruby/rbs) repository uses the `bin/steep` script,
instead of `bundle exec steep` or globally `steep`.

In such a case, I think users want to custom the variable like this:

```elisp
;; .dir-locals.el
((enh-ruby-mode . ((lsp-steep-server-path . "/Users/ybiquitous/git/rbs/bin/steep"))))
```