### PR TITLE
Add Roblox Lua Language Server

### DIFF
--- a/clients/lsp-lua.el
+++ b/clients/lsp-lua.el
@@ -631,14 +631,14 @@ and `../lib` ,exclude `../lib/temp`.
 
 (defcustom lsp-lua-roblox-server-download-url
   (lsp-vscode-extension-url "Nightrains" "robloxlsp" "0.15.8")
-  "Download url for Roblox Lua vscode extension"
+  "Download url for Roblox Lua vscode extension."
   :group 'lsp-lua-roblox-language-server
   :version "7.1"
   :type 'string)
 
-(defcustom lsp-lua-roblox-server-store-url
+(defcustom lsp-lua-roblox-server-store-path
   (expand-file-name "vs-lua-roblox" lsp-lua-roblox-language-server-install-dir)
-  "Server file name for the vscode extension"
+  "Server file name for the vscode extension."
   :group 'lsp-lua-roblox-language-server
   :version "7.1"
   :type 'string)
@@ -648,13 +648,17 @@ and `../lib` ,exclude `../lib/temp`.
   (and (f-exists? lsp-lua-roblox-language-server-main-location)
        (f-exists? lsp-lua-roblox-language-server-bin)))
 
-(lsp-dependency
- 'lua-roblox-lsp
- `(:download :url lsp-lua-roblox-server-download-url
-   :store-path lsp-lua-roblox-server-store-url
-   :set-executable? t
-   :decompress :zip)
- '(:system "lua-roblox-lsp"))
+(defun lsp-lua-roblox-language-server-install (_client callback error-callback _update?)
+  "Download the latest version of lua-language-server and extract it to
+`lsp-lua-roblox-language-server-download-url'."
+  (lsp-download-install
+    (lambda (&rest _)
+     (set-file-modes lsp-lua-roblox-language-server-bin #o0700)
+     (funcall callback))
+     error-callback
+     :url lsp-lua-roblox-server-download-url
+     :store-path lsp-lua-roblox-server-store-path
+     :decompress :zip))
 
 (lsp-register-client
  (make-lsp-client
@@ -666,8 +670,7 @@ and `../lib` ,exclude `../lib/temp`.
   :major-modes '(lua-mode)
   :priority -4
   :server-id 'lua-roblox-language-server
-  :download-server-fn (lambda (_client callback error-callback _update?)
-                        (lsp-package-ensure 'lua-roblox-lsp callback error-callback))))
+  :download-server-fn #'lsp-lua-roblox-language-server-install))
 
 (lsp-consistency-check lsp-lua)
 

--- a/clients/lsp-lua.el
+++ b/clients/lsp-lua.el
@@ -593,72 +593,80 @@ and `../lib` ,exclude `../lib/temp`.
   :server-id 'lsp-lua-lsp))
 
 ;;; lua-roblox-language-server
-(defgroup lsp-roblox-lua-language-server nil
+(defgroup lsp-lua-roblox-language-server nil
   "Roblox Lua LSP client, provided by the Roblox Lua Language Server."
   :group 'lsp-mode
   :version "7.1"
   :link '(url-link "https://github.com/NightrainsRbx/RobloxLsp"))
 
-(defcustom lsp-clients-roblox-lua-language-server-install-dir (f-join lsp-server-install-dir "roblox-lua-language-server/")
+(defcustom lsp-lua-roblox-language-server-install-dir (f-join lsp-server-install-dir "lua-roblox-language-server/")
   "Installation directory for Lua Language Server."
-  :group 'lsp-roblox-lua-language-server
+  :group 'lsp-lua-roblox-language-server
   :version "7.1"
   :risky t
   :type 'directory)
 
-(defcustom lsp-clients-roblox-lua-language-server-bin
-  (f-join lsp-clients-roblox-lua-language-server-install-dir
+(defcustom lsp-lua-roblox-language-server-bin
+  (f-join lsp-lua-roblox-language-server-install-dir
           "extension/server/bin/"
           (pcase system-type
             ('gnu/linux "Linux/lua-language-server")
             ('darwin "macOS/lua-language-server")
             ('windows-nt "Windows/lua-language-server.exe")
             (_ "Linux/lua-language-server")))
-  "Location of Lua Language Server."
-  :group 'lsp-roblox-lua-language-server
-  :version "7.1"
-  :risky t
-  :type 'fil)
-
-(defcustom lsp-clients-roblox-lua-language-server-main-location
-  (f-join lsp-clients-roblox-lua-language-server-install-dir
-          "extension/server/main.lua")
-  "Location of Roblox Lua Language Server main.lua."
-  :group 'lsp-roblox-lua-language-server
+  "Location of Roblox Lua Language Server."
+  :group 'lsp-lua-roblox-language-server
   :version "7.1"
   :risky t
   :type 'file)
 
-(defun lsp-clients-roblox-lua-language-server-test ()
-  "Test Lua language server binaries and files."
-  (and (f-exists? lsp-clients-roblox-lua-language-server-main-location)
-       (f-exists? lsp-clients-roblox-lua-language-server-bin)))
+(defcustom lsp-lua-roblox-language-server-main-location
+  (f-join lsp-lua-roblox-language-server-install-dir
+          "extension/server/main.lua")
+  "Location of Roblox Lua Language Server main.lua."
+  :group 'lsp-lua-roblox-language-server
+  :version "7.1"
+  :risky t
+  :type 'file)
 
-(defun lsp-roblox-lua-language-server-install (client callback error-callback update?)
-  "Download the latest version of roblox-lua-language-server and extract it to
-`lsp-roblox-lua-language-server-install-dir'."
-  (ignore client update?)
-  (let ((store-path (expand-file-name "vs-roblox-lua" lsp-clients-roblox-lua-language-server-install-dir)))
-    (lsp-download-install
-     (lambda (&rest _)
-       (set-file-modes lsp-clients-roblox-lua-language-server-bin #o0700)
-       (funcall callback))
-     error-callback
-     :url (lsp-vscode-extension-url "Nightrains" "robloxlsp" "0.15.8")
-     :store-path store-path
-     :decompress :zip)))
+(defcustom lsp-lua-roblox-server-download-url
+  (lsp-vscode-extension-url "Nightrains" "robloxlsp" "0.15.8")
+  "Download url for Roblox Lua vscode extension"
+  :group 'lsp-lua-roblox-language-server
+  :version "7.1"
+  :type 'string)
+
+(defcustom lsp-lua-roblox-server-store-url
+  (expand-file-name "vs-lua-roblox" lsp-lua-roblox-language-server-install-dir)
+  "Server file name for the vscode extension"
+  :group 'lsp-lua-roblox-language-server
+  :version "7.1"
+  :type 'string)
+
+(defun lsp-lua-roblox-language-server-test ()
+  "Test Lua language server binaries and files."
+  (and (f-exists? lsp-lua-roblox-language-server-main-location)
+       (f-exists? lsp-lua-roblox-language-server-bin)))
+
+(lsp-dependency
+ 'lua-roblox-lsp
+ `(:download :url lsp-lua-roblox-server-download-url
+   :store-path lsp-lua-roblox-server-store-url
+   :decompress :zip)
+ '(:system "lua-roblox-language-server"))
 
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection (lambda () (or lsp-clients-lua-language-server-command
-                                                       `(,lsp-clients-roblox-lua-language-server-bin
+                                                       `(,lsp-lua-roblox-language-server-bin
                                                          ,@lsp-clients-lua-language-server-args
-                                                         ,lsp-clients-roblox-lua-language-server-main-location)))
-                                        #'lsp-clients-roblox-lua-language-server-test)
+                                                         ,lsp-lua-roblox-language-server-main-location)))
+                                        #'lsp-lua-roblox-language-server-test)
   :major-modes '(lua-mode)
   :priority -4
-  :server-id 'roblox-lua-language-server
-  :download-server-fn #'lsp-roblox-lua-language-server-install))
+  :server-id 'lua-roblox-language-server
+  :download-server-fn (lambda (_client callback error-callback _update?)
+                        (lsp-package-ensure 'lsp-lua-roblox-language-server callback error-callback))))
 
 (lsp-consistency-check lsp-lua)
 

--- a/clients/lsp-lua.el
+++ b/clients/lsp-lua.el
@@ -592,6 +592,73 @@ and `../lib` ,exclude `../lib/temp`.
   :priority -3
   :server-id 'lsp-lua-lsp))
 
+;;; lua-roblox-language-server
+(defgroup lsp-roblox-lua-language-server nil
+  "Roblox Lua LSP client, provided by the Roblox Lua Language Server."
+  :group 'lsp-mode
+  :version "7.1"
+  :link '(url-link "https://github.com/NightrainsRbx/RobloxLsp"))
+
+(defcustom lsp-clients-roblox-lua-language-server-install-dir (f-join lsp-server-install-dir "roblox-lua-language-server/")
+  "Installation directory for Lua Language Server."
+  :group 'lsp-roblox-lua-language-server
+  :version "7.1"
+  :risky t
+  :type 'directory)
+
+(defcustom lsp-clients-roblox-lua-language-server-bin
+  (f-join lsp-clients-roblox-lua-language-server-install-dir
+          "extension/server/bin/"
+          (pcase system-type
+            ('gnu/linux "Linux/lua-language-server")
+            ('darwin "macOS/lua-language-server")
+            ('windows-nt "Windows/lua-language-server.exe")
+            (_ "Linux/lua-language-server")))
+  "Location of Lua Language Server."
+  :group 'lsp-roblox-lua-language-server
+  :version "7.1"
+  :risky t
+  :type 'fil)
+
+(defcustom lsp-clients-roblox-lua-language-server-main-location
+  (f-join lsp-clients-roblox-lua-language-server-install-dir
+          "extension/server/main.lua")
+  "Location of Roblox Lua Language Server main.lua."
+  :group 'lsp-roblox-lua-language-server
+  :version "7.1"
+  :risky t
+  :type 'file)
+
+(defun lsp-clients-roblox-lua-language-server-test ()
+  "Test Lua language server binaries and files."
+  (and (f-exists? lsp-clients-roblox-lua-language-server-main-location)
+       (f-exists? lsp-clients-roblox-lua-language-server-bin)))
+
+(defun lsp-roblox-lua-language-server-install (client callback error-callback update?)
+  "Download the latest version of roblox-lua-language-server and extract it to
+`lsp-roblox-lua-language-server-install-dir'."
+  (ignore client update?)
+  (let ((store-path (expand-file-name "vs-roblox-lua" lsp-clients-roblox-lua-language-server-install-dir)))
+    (lsp-download-install
+     (lambda (&rest _)
+       (set-file-modes lsp-clients-roblox-lua-language-server-bin #o0700)
+       (funcall callback))
+     error-callback
+     :url (lsp-vscode-extension-url "Nightrains" "robloxlsp" "0.15.8")
+     :store-path store-path
+     :decompress :zip)))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection (lambda () (or lsp-clients-lua-language-server-command
+                                                       `(,lsp-clients-roblox-lua-language-server-bin
+                                                         ,@lsp-clients-lua-language-server-args
+                                                         ,lsp-clients-roblox-lua-language-server-main-location)))
+                                        #'lsp-clients-roblox-lua-language-server-test)
+  :major-modes '(lua-mode)
+  :priority -4
+  :server-id 'roblox-lua-language-server
+  :download-server-fn #'lsp-roblox-lua-language-server-install))
 
 (lsp-consistency-check lsp-lua)
 

--- a/clients/lsp-lua.el
+++ b/clients/lsp-lua.el
@@ -652,8 +652,9 @@ and `../lib` ,exclude `../lib/temp`.
  'lua-roblox-lsp
  `(:download :url lsp-lua-roblox-server-download-url
    :store-path lsp-lua-roblox-server-store-url
+   :set-executable? t
    :decompress :zip)
- '(:system "lua-roblox-language-server"))
+ '(:system "lua-roblox-lsp"))
 
 (lsp-register-client
  (make-lsp-client
@@ -666,7 +667,7 @@ and `../lib` ,exclude `../lib/temp`.
   :priority -4
   :server-id 'lua-roblox-language-server
   :download-server-fn (lambda (_client callback error-callback _update?)
-                        (lsp-package-ensure 'lsp-lua-roblox-language-server callback error-callback))))
+                        (lsp-package-ensure 'lua-roblox-lsp callback error-callback))))
 
 (lsp-consistency-check lsp-lua)
 

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -510,6 +510,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "roblox-lua",
+    "full-name": "Roblox Lua",
+    "server-name": "roblox-lua-language-server",
+    "installation-url": "https://github.com/NightrainsRbx/RobloxLsp",
+    "server-url": "https://github.com/NightrainsRbx/RobloxLsp",
+    "debugger": "Not available"
+  },
+  {
     "name": "robot",
     "full-name": "robot framework",
     "server-name": "rf-intellisense",

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -330,6 +330,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "lua-roblox",
+    "full-name": "Lua Roblox",
+    "server-name": "lua-roblox-language-server",
+    "installation-url": "https://github.com/NightrainsRbx/RobloxLsp",
+    "server-url": "https://github.com/NightrainsRbx/RobloxLsp",
+    "debugger": "Not available"
+  },
+  {
     "name": "markdown",
     "full-name": "Markdown",
     "server-name": "unified-language-server",
@@ -507,14 +515,6 @@
     "server-name": "racket-language-server",
     "server-url": "https://github.com/theia-ide/racket-language-server",
     "installation": "raco pkg install racket-language-server",
-    "debugger": "Not available"
-  },
-  {
-    "name": "roblox-lua",
-    "full-name": "Roblox Lua",
-    "server-name": "roblox-lua-language-server",
-    "installation-url": "https://github.com/NightrainsRbx/RobloxLsp",
-    "server-url": "https://github.com/NightrainsRbx/RobloxLsp",
     "debugger": "Not available"
   },
   {


### PR DESCRIPTION
Hey all :wave:

This PR bases the Roblox Lua LS on the `lua-language-server` from `sumneko`, which is already a client of `lsp-mode`. The Roblox LS source code is actually based on the work from `sumneko`, as well. The Roblox Lua LS can be found here: https://github.com/NightrainsRbx/RobloxLsp

This PR adds the lsp-mode Roblox Lua client as well as the client configuration in `docs/lsp-clients.json`. I ran this code in my local emacs installation and didn't find any issues.

Thanks!