### PR TITLE
Fix issue that caused vls server not to run

### DIFF
--- a/clients/lsp-v.el
+++ b/clients/lsp-v.el
@@ -41,8 +41,8 @@ finding the executable with variable `exec-path'."
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection (lambda () lsp-v-vls-executable))
-  :activation-fn (lsp-activate-on "V")
-  :server-id 'v-ls))
+  :major-modes '(v-mode)
+  :server-id 'vls))
 
 (lsp-consistency-check lsp-v)
 


### PR DESCRIPTION
When I tried to run `M-x lsp` in a [`v-mode`](https://github.com/damon-kwok/v-mode) buffer, I would consistently get an error as follows:

```
LSP :: There are no language servers supporting current mode `v-mode' registered with `lsp-mode'.
This issue might be caused by:
1. The language you are trying to use does not have built-in support in `lsp-mode'. You must install the required support manually. Examples of this are `lsp-java' or `lsp-metals'.
2. The language server that you expect to run is not configured to run for major mode `v-mode'. You may check that by checking the `:major-modes' that are passed to `lsp-register-client'.
3. `lsp-mode' doesn't have any integration for the language behind `v-mode'. Refer to https://emacs-lsp.github.io/lsp-mode/page/languages and https://langserver.org/ .
4. You are over `tramp'. In this case follow https://emacs-lsp.github.io/lsp-mode/page/remote/.
5. You have disabled the `lsp-mode' clients for that file. (Check `lsp-enabled-clients' and `lsp-disabled-clients').
You can run the command ‘lsp’ with s-l w s
```

This was fixed by setting `major-modes` instead of `activation-fn`, as given in https://github.com/emacs-lsp/lsp-mode/pull/2956