### PR TITLE
Revert "Fix spinner not showing on some cases"

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7939,8 +7939,7 @@ IGNORE-MULTI-FOLDER to ignore multi folder server."
            (lsp--find-workspace session client project-root)
            (unless ignore-multi-folder
              (lsp--find-multiroot-workspace session client project-root))
-           (lsp--start-connection session client project-root))
-          (lsp--find-workspace session client project-root))
+           (lsp--start-connection session client project-root)))
         clients))
 
 (defun lsp--spinner-stop ()


### PR DESCRIPTION
Reverts emacs-lsp/lsp-mode#2871

I noticed this is causing duplicated `didOpen` requests in some cases, we need a better fix for that