### PR TITLE
feat: use `name` instead of `description` for bettter readability

### DIFF
--- a/clients/lsp-yaml.el
+++ b/clients/lsp-yaml.el
@@ -225,7 +225,7 @@ Set FORCE-DOWNLOADING to non-nil to force re-download the database."
   (let* ((schema (lsp--completing-read "Select buffer schema: "
                                        (lsp-yaml--get-supported-schemas)
                                        (lambda (schema)
-                                         (alist-get 'name schema))
+                                         (format "%s: %s" (alist-get 'name schema)(alist-get 'description schema)))
                                        nil t))
          (uri (alist-get 'url schema)))
     (lsp-yaml-set-buffer-schema uri)))

--- a/clients/lsp-yaml.el
+++ b/clients/lsp-yaml.el
@@ -225,7 +225,7 @@ Set FORCE-DOWNLOADING to non-nil to force re-download the database."
   (let* ((schema (lsp--completing-read "Select buffer schema: "
                                        (lsp-yaml--get-supported-schemas)
                                        (lambda (schema)
-                                         (alist-get 'description schema))
+                                         (alist-get 'name schema))
                                        nil t))
          (uri (alist-get 'url schema)))
     (lsp-yaml-set-buffer-schema uri)))


### PR DESCRIPTION
This is more of a ui-enhancement when working with lsp-yaml

Previously:

![image](https://user-images.githubusercontent.com/26849064/124101265-08657500-da14-11eb-9bd1-14fd2b9d3836.png)

Updated:
![image](https://user-images.githubusercontent.com/26849064/124101379-24691680-da14-11eb-98ff-cd06ef9f1a27.png)

Maybe this is more in line with what people see on the schemastore and might be easier to search but I will leave that up to yall.