### PR TITLE
Add svelte to lsp-language-id-configuration

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -691,6 +691,7 @@ Changes take effect only when a new session is started."
                                         (".*\\.json$" . "json")
                                         (".*\\.jsonc$" . "jsonc")
                                         (".*\\.php$" . "php")
+                                        (".*\\.svelte$" . "svelte")
                                         (ada-mode . "ada")
                                         (nxml-mode . "xml")
                                         (sql-mode . "sql")


### PR DESCRIPTION
Fix for `Warning (lsp-mode): Unable to calculate the languageId for buffer ‘app.svelte’. Take a look at ‘lsp-language-id-configuration’. The ‘major-mode’ is web-mode`