### PR TITLE
Allow error when fontlock

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4965,7 +4965,7 @@ In addition, each can have property:
           (insert str)
           (delay-mode-hooks (funcall mode))
           (cl-flet ((window-body-width () lsp-window-body-width))
-            (font-lock-ensure)
+            (ignore-errors (font-lock-ensure))
             (lsp--display-inline-image mode))
           (lsp--buffer-string-visible))
       (error str))))


### PR DESCRIPTION
If function `font-lock-ensure` file an error then it will stop the current execution.

---

### Before

![Image 5](https://user-images.githubusercontent.com/8685505/124388518-eb7fb900-dd15-11eb-86fa-8f16e9375ad7.png)

### After

![Image 4](https://user-images.githubusercontent.com/8685505/124388520-ee7aa980-dd15-11eb-8b44-2ac95d03a4ab.png)

---

As you can see, the font-lock isn't working but it removes the annoying markdown.