### PR TITLE
Make enum behave as type in semantic highlighting

### DIFF
--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -129,7 +129,7 @@ unless overridden by a more specific face association."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-enum
-  '((t (:inherit font-lock-variable-name-face)))
+  '((t (:inherit font-lock-type-face)))
   "Face used for enums."
   :group 'lsp-semantic-tokens)
 


### PR DESCRIPTION
According to [lsp spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_semanticTokens), 'enum' means an enum type, not an enum constant. It should have the same face as type.

Below are two screenshots showing the differences in highlighting.

Before:
![cpp-before](https://user-images.githubusercontent.com/30191901/124622529-c6be4980-dead-11eb-8298-6861a6f8a5b5.png)

After:
![cpp-after](https://user-images.githubusercontent.com/30191901/124622563-cde55780-dead-11eb-8eee-fd76830d0d76.png)
