### PR TITLE
expose Rust Analyzer: Move item up/down functionality

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -51,6 +51,7 @@
   * Change interface for configuring ESLint code actions - see documentation of
     ~lsp-eslint-code-action-disable-rule-comment~ and
     ~lsp-eslint-code-action-show-documentation~ for details
+  * Add interactive ~lsp-rust-analyzer-move-item-up~ and ~lsp-rust-analyzer-move-item-down~ functions to move Rust items / statements
 
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1107,7 +1107,7 @@ https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensio
     (lsp--info "There are no tests related to the symbol at point")))
 
 (defun lsp-rust-analyzer-move-item (direction)
-  "Move item under cursor or selection in some direction"
+  "Move item under cursor or selection in some DIRECTION"
   (let* ((params (lsp-make-rust-analyzer-move-item-params
                   :text-document (lsp--text-document-identifier)
                   :range (if (use-region-p)

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1114,8 +1114,8 @@ https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensio
                              (lsp--region-to-range (region-beginning) (region-end))
                            (lsp--region-to-range (point) (point)))
                   :direction direction))
-         (result (lsp-send-request (lsp-make-request "experimental/moveItem" params))))
-    (lsp--apply-text-edits result 'code-action)))
+         (edits (lsp-request "experimental/moveItem" params)))
+    (lsp--apply-text-edits edits 'code-action)))
 
 (defun lsp-rust-analyzer-move-item-up ()
   "Move item under cursor or selection up"

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1106,6 +1106,26 @@ https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensio
       (lsp-rust-analyzer--common-runner runnable)
     (lsp--info "There are no tests related to the symbol at point")))
 
+(defun lsp-rust-analyzer-move-item (direction)
+  "Move item under cursor or selection in some direction"
+  (let* ((params (lsp-make-rust-analyzer-move-item-params
+                  :text-document (lsp--text-document-identifier)
+                  :range (if (use-region-p)
+                             (lsp--region-to-range (region-beginning) (region-end))
+                           (lsp--region-to-range (point) (point)))
+                  :direction direction))
+         (result (lsp-send-request (lsp-make-request "experimental/moveItem" params))))
+    (lsp--apply-text-edits result 'code-action)))
+
+(defun lsp-rust-analyzer-move-item-up ()
+  "Move item under cursor or selection up"
+  (interactive)
+  (funcall 'lsp-rust-analyzer-move-item "Up"))
+
+(defun lsp-rust-analyzer-move-item-down ()
+  "Move item under cursor or selection down"
+  (interactive)
+  (funcall 'lsp-rust-analyzer-move-item "Down"))
 
 (lsp-consistency-check lsp-rust)
 

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1120,12 +1120,12 @@ https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensio
 (defun lsp-rust-analyzer-move-item-up ()
   "Move item under cursor or selection up"
   (interactive)
-  (funcall 'lsp-rust-analyzer-move-item "Up"))
+  (lsp-rust-analyzer-move-item "Up"))
 
 (defun lsp-rust-analyzer-move-item-down ()
   "Move item under cursor or selection down"
   (interactive)
-  (funcall 'lsp-rust-analyzer-move-item "Down"))
+  (lsp-rust-analyzer-move-item "Down"))
 
 (lsp-consistency-check lsp-rust)
 

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -405,6 +405,7 @@ See `-let' for a description of the destructuring mechanism."
                (rust-analyzer:OpenCargoTomlParams (:textDocument) nil)
                (rust-analyzer:ResovedCodeActionParams (:id :codeActionParams) nil)
                (rust-analyzer:JoinLinesParams (:textDocument :ranges) nil)
+               (rust-analyzer:MoveItemParams (:textDocument :range :direction) nil)
                (rust-analyzer:RunnablesParams (:textDocument) (:position))
                (rust-analyzer:Runnable (:label :kind :args) (:location))
                (rust-analyzer:RunnableArgs (:cargoArgs :executableArgs) (:workspaceRoot))


### PR DESCRIPTION
forewarning: I know little Lisp; apologies in advance for any unidiomatic code (+)

this PR adds 2 interactive functions that match VS Code "Rust Analyzer: Move item up/down" code actions (see GIF below).
- `lsp-rust-analyzer-move-item-up`
- `lsp-rust-analyzer-move-item-down`

(+) I used `lsp-rust-analyzer-join-lines` as a reference

the functions are *not* bound to keyboard shortcuts out of the box

![](https://user-images.githubusercontent.com/48062697/113065576-04298180-91b1-11eb-91ce-4505e99ed598.gif)

NOTE: I actually haven't manage to test my branch because I couldn't figure how to override the `lsp-mode` package in spacemacs (without breaking the interaction between the `rust` and `lsp` layers) BUT copy-pasting this PR diff into my `.spacemacs` file and reloading it produces working functions so :crossed_fingers: 
