### PR TITLE
Minor semantic tokens cleanup

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6176,7 +6176,7 @@ WORKSPACE is the active workspace."
                      ((equal method "workspace/semanticTokens/refresh")
                       (when (and lsp-semantic-tokens-enable
                                  (fboundp 'lsp--semantic-tokens-on-refresh))
-                        (lsp--semantic-tokens-on-refresh))
+                        (lsp--semantic-tokens-on-refresh workspace))
                       nil)
                      (t (lsp-warn "Unknown request method: %s" method) nil))))
     ;; Send response to the server.

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -621,10 +621,7 @@ IS-RANGE-PROVIDER is non-nil when server supports range requests."
   (when (and lsp-semantic-tokens-enable
              (lsp-feature? "textDocument/semanticTokens"))
     (lsp-semantic-tokens--warn-about-deprecated-setting)
-    (lsp-semantic-tokens-mode 1)
-    (mapc #'lsp--semantic-tokens-initialize-workspace
-          (lsp--find-workspaces-for "textDocument/semanticTokens"))
-    (lsp--semantic-tokens-initialize-buffer)))
+    (lsp-semantic-tokens-mode 1)))
 
 (defun lsp-semantic-tokens--disable ()
   "Disable semantic tokens mode."
@@ -639,6 +636,8 @@ IS-RANGE-PROVIDER is non-nil when server supports range requests."
    (lsp-semantic-tokens-mode
     (add-hook 'lsp-configure-hook #'lsp-semantic-tokens--enable nil t)
     (add-hook 'lsp-unconfigure-hook #'lsp-semantic-tokens--disable nil t)
+    (mapc #'lsp--semantic-tokens-initialize-workspace
+          (lsp--find-workspaces-for "textDocument/semanticTokens"))
     (lsp--semantic-tokens-initialize-buffer))
    (t
     (remove-hook 'lsp-configure-hook #'lsp-semantic-tokens--enable t)


### PR DESCRIPTION
this should fix bug #2920 (not the original issue, the one discussed further down in the issue thread), and removes one unneeded call to `lsp--semantic-tokens-initialize-buffer`.