### PR TITLE
only update current buffer on refresh if it belongs to a workspace

### DIFF
--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -565,9 +565,9 @@ IS-RANGE-PROVIDER is non-nil when server supports range requests."
   "Invoked in response to workspace/semanticTokens/refresh requests."
   (cl-loop for workspace in (lsp-workspaces)
            for ws-buffer in (lsp--workspace-buffers workspace) do
-           (unless (equal (current-buffer) ws-buffer)
-             (setf (buffer-local-value 'lsp--semantic-tokens-cache ws-buffer) nil)))
-  (lsp--semantic-tokens-request-full-token-set-when-idle t))
+           (if (equal (current-buffer) ws-buffer)
+               (lsp--semantic-tokens-request-full-token-set-when-idle t)
+             (setf (buffer-local-value 'lsp--semantic-tokens-cache ws-buffer) nil))))
 
 ;;;###autoload
 (defun lsp--semantic-tokens-initialize-workspace (workspace)

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -570,9 +570,9 @@ IS-RANGE-PROVIDER is non-nil when server supports range requests."
   "Invoked in response to workspace/semanticTokens/refresh requests."
   (cl-loop for workspace in (lsp-workspaces)
            for ws-buffer in (lsp--workspace-buffers workspace) do
-           (if (equal (current-buffer) ws-buffer)
-               (lsp--semantic-tokens-request-full-token-set-when-idle t)
-             (setf (buffer-local-value 'lsp--semantic-tokens-cache ws-buffer) nil))))
+           (unless (equal (current-buffer) ws-buffer)
+             (setf (buffer-local-value 'lsp--semantic-tokens-cache ws-buffer) nil)))
+  (lsp--semantic-tokens-request-full-token-set-when-idle t))
 
 ;;;###autoload
 (defun lsp--semantic-tokens-initialize-workspace (workspace)

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -353,7 +353,12 @@ If FONTIFY-IMMEDIATELY is non-nil, fontification will be performed immediately
        (lsp--semantic-tokens-putcache :_documentVersion lsp--cur-version)
        (funcall response-handler response)
        (when fontify-immediately (font-lock-flush)))
-     :error-handler (lambda (&rest _) (lsp--semantic-tokens-request-full-token-set-when-idle t))
+     :error-handler ;; buffer is not captured in `error-handler', it is in `callback'
+     (let ((buf (current-buffer)))
+       (lambda (&rest _)
+         (when (buffer-live-p buf)
+           (with-current-buffer buf
+             (lsp--semantic-tokens-request-full-token-set-when-idle t)))))
      :mode 'tick
      :cancel-token (format "semantic-tokens-%s" (lsp--buffer-uri)))))
 


### PR DESCRIPTION
When I get a (rather delayed) `workspace/semanticTokens/refresh` while standing on a buffer outside of workspace, updating semantic tokens for this outside-of-workspace is still triggered.

this PR solves it so. At least it switches behaviour to "don't do anything outside of the refreshed workspace"