### PR TITLE
Miscellaneous ESLint client changes and additions

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -45,6 +45,13 @@
   * Add ~lsp-lens-place-position~ with option to place code lens at end of line as default.
   * Add LanguageTool support.
   * Add Beancount support.
+  * Update the ESLint server to 2.1.23
+  * Add ~lsp-eslint-warn-on-ignored-files~ and ~lsp-eslint-rules-customizations~
+    options to the ESLint client
+  * Change interface for configuring ESLint code actions - see documentation of
+    ~lsp-eslint-code-action-disable-rule-comment~ and
+    ~lsp-eslint-code-action-show-documentation~ for details
+
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.
   * Safe renamed ~lsp-flycheck-default-level~ -> ~lsp-diagnostics-flycheck-default-level~

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -118,10 +118,10 @@ source.fixAll code action."
   :type 'lsp-string-vector
   :package-version '(lsp-mode . "6.3"))
 
-(defcustom lsp-eslint-validate ["javascript" "javascriptreact"]
-  "An array of language ids which should be validated by ESLint"
-  :type 'lsp-string-vector
-  :package-version '(lsp-mode . "6.3"))
+(defcustom lsp-eslint-validate '()
+  "An array of language ids which should always be validated by eslint."
+  :type '(repeat string)
+  :package-version '(lsp-mode . "7.1"))
 
 (defcustom lsp-eslint-provide-lint-task nil
   "Controls whether a task for linting the whole workspace will be available."
@@ -254,7 +254,7 @@ stored."
                                (buffer (find-buffer-visiting file))
                                (workspace-folder (lsp-find-session-folder (lsp-session) file)))
                     (with-current-buffer buffer
-                      (list :validate "probe"
+                      (list :validate (if (member (lsp-buffer-language) lsp-eslint-validate) "on" "probe")
                             :packageManager lsp-eslint-package-manager
                             :codeAction (list
                                          :disableRuleComment (list

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -118,7 +118,7 @@ source.fixAll code action."
   :type 'lsp-string-vector
   :package-version '(lsp-mode . "6.3"))
 
-(defcustom lsp-eslint-validate '()
+(defcustom lsp-eslint-validate '("svelte")
   "An array of language ids which should always be validated by eslint."
   :type '(repeat string)
   :package-version '(lsp-mode . "7.1"))
@@ -352,9 +352,9 @@ to allow or deny it.")
   :activation-fn (lambda (filename &optional _)
                    (when lsp-eslint-enable
                      (or (string-match-p (rx (one-or-more anything) "."
-                                             (or "ts" "js" "jsx" "tsx" "html" "vue")eos)
+                                             (or "ts" "js" "jsx" "tsx" "html" "vue" "svelte")eos)
                                          filename)
-                         (derived-mode-p 'js-mode 'js2-mode 'typescript-mode 'html-mode))))
+                         (derived-mode-p 'js-mode 'js2-mode 'typescript-mode 'html-mode 'svelte-mode))))
   :priority -1
   :completion-in-comments? t
   :add-on? t

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -36,7 +36,7 @@
   :group 'lsp-mode
   :link '(url-link "https://github.com/Microsoft/vscode-eslint"))
 
-(defcustom lsp-eslint-unzipped-path (f-join lsp-server-install-dir "eslint/unzipped")
+(defcustom lsp-eslint-unzipped-path (f-join lsp-server-install-dir "eslint-2.1.23/unzipped")
   "The path to the file in which `eslint' will be stored."
   :type 'file
   :group 'lsp-eslint

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -329,7 +329,9 @@ to allow or deny it.")
            (remembered-answer (gethash library-path lsp-eslint--stored-libraries)))
       (funcall callback remembered-answer)
     (lsp-ask-question
-     (format "Allow lsp-mode to execute %s?" library-path)
+     (format
+      "Allow lsp-mode to execute %s? Note: The latest versions of the ESLint language server no longer create this prompt."
+      library-path)
      (mapcar 'car option-alist)
      (lambda (response)
        (let ((option (cdr (assoc response option-alist))))

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -390,7 +390,7 @@ to allow or deny it.")
                                    (funcall callback))
                                (error (funcall error-callback err))))
                            error-callback
-                           :url (lsp-vscode-extension-url "dbaeumer" "vscode-eslint" "2.1.14")
+                           :url (lsp-vscode-extension-url "dbaeumer" "vscode-eslint" "2.1.23")
                            :store-path tmp-zip)))))
 
 (lsp-consistency-check lsp-eslint)


### PR DESCRIPTION
A few changes to the ESLint config to support more configurations options, and tidy up customs.

- Support running the ESLint client on Svelte files
- Use `lsp-eslint-validate` to force enabling validation for files with given language ids. The variable was previously unused, and the functionality added was used for Svelte support.
- Give `lsp-eslint-code-action-disable-rule-comment` and `lsp-eslint-code-action-show-documentation` a nicer configuration interface:
  - `lsp-eslint-code-action-disable-rule-comment` is now only a boolean value for toggling it's associated code action
  - `lsp-eslint-code-action-disable-rule-comment-location` is used to specify the location of the comment
  - `lsp-eslint-code-action-show-documentation` is now only a boolean value for toggling it's associated code action, instead of an unnecessary alist
- Update the ESLint server downloaded (2.1.14 -> 2.1.23)
- Add 2 new configuration options:
  - `lsp-eslint-warn-on-ignored-files`: Controls if a warning should be emitted when a file is ignored.
  - `lsp-eslint-rules-customizations`: Defines severity overrides for ESLint rules.

A note: In server version 2.1.22, the `eslint/confirmESLintExecution` command was removed, meaning a large portion of [this commit](https://github.com/emacs-lsp/lsp-mode/commit/a0c41e489c656bc69a3cdd0d04ee549f45e42a59) could be reverted. Do we still want to keep it in order to support older versions?