### PR TITLE
Create a more sane default for phpactor

### DIFF
--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -385,8 +385,8 @@ already present."
 
 (lsp-register-client
  (make-lsp-client
-  :new-connection (lsp-stdio-connection (list (or (executable-find "phpactor")
-                                                  (f-join (lsp-php-get-composer-dir) "vendor/phpactor/phpactor/bin/phpactor")) "language-server"))
+  :new-connection (lsp-stdio-connection (lambda () (list (or (executable-find "phpactor")
+                                                        (f-join (lsp-php-get-composer-dir) "vendor/phpactor/phpactor/bin/phpactor")) "language-server")))
   :activation-fn (lsp-activate-on "php")
   ;; `phpactor' is not really that feature-complete: it doesn't support
   ;; `textDocument/showOccurence' and sometimes errors (e.g. find references on

--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -378,15 +378,15 @@ already present."
   :link '(url-link "https://github.com/phpactor/phpactor")
   :group 'lsp-mode)
 
-(defcustom lsp-phpactor-path (or (executable-find "phpactor")
-                                 (f-join (lsp-php-get-composer-dir) "vendor/phpactor/phpactor/bin/phpactor"))
+(defcustom lsp-phpactor-path nil
   "Path to the `phpactor' command."
   :group 'lsp-phpactor
   :type "string")
 
 (lsp-register-client
  (make-lsp-client
-  :new-connection (lsp-stdio-connection `(,lsp-phpactor-path "language-server"))
+  :new-connection (lsp-stdio-connection (list (or (executable-find "phpactor")
+                                                  (f-join (lsp-php-get-composer-dir) "vendor/phpactor/phpactor/bin/phpactor")) "language-server"))
   :activation-fn (lsp-activate-on "php")
   ;; `phpactor' is not really that feature-complete: it doesn't support
   ;; `textDocument/showOccurence' and sometimes errors (e.g. find references on

--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -385,8 +385,14 @@ already present."
 
 (lsp-register-client
  (make-lsp-client
-  :new-connection (lsp-stdio-connection (lambda () (list (or (executable-find "phpactor")
-                                                        (f-join (lsp-php-get-composer-dir) "vendor/phpactor/phpactor/bin/phpactor")) "language-server")))
+  :new-connection (lsp-stdio-connection
+                   (lambda ()
+                     (unless lsp-php-composer-dir
+                       (setq lsp-php-composer-dir (lsp-php-get-composer-dir)))
+                     (unless lsp-phpactor-path
+                       (setq lsp-phpactor-path (or (executable-find "phpactor")
+                                                   (f-join lsp-php-composer-dir "vendor/phpactor/phpactor/bin/phpactor"))))
+                     (list lsp-phpactor-path "language-server")))
   :activation-fn (lsp-activate-on "php")
   ;; `phpactor' is not really that feature-complete: it doesn't support
   ;; `textDocument/showOccurence' and sometimes errors (e.g. find references on

--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -378,20 +378,15 @@ already present."
   :link '(url-link "https://github.com/phpactor/phpactor")
   :group 'lsp-mode)
 
-(defcustom lsp-phpactor-path nil
+(defcustom lsp-phpactor-path (or (executable-find "phpactor")
+                                 (f-join (lsp-php-get-composer-dir) "vendor/phpactor/phpactor/bin/phpactor"))
   "Path to the `phpactor' command."
   :group 'lsp-phpactor
   :type "string")
 
 (lsp-register-client
  (make-lsp-client
-  :new-connection (lsp-stdio-connection
-                   (lambda ()
-                     (unless lsp-php-composer-dir
-                       (setq lsp-php-composer-dir (lsp-php-get-composer-dir)))
-                     (unless lsp-phpactor-path
-                       (setq lsp-phpactor-path (f-join lsp-php-composer-dir "vendor/phpactor/phpactor/bin/phpactor")))
-                     (list lsp-phpactor-path "language-server")))
+  :new-connection (lsp-stdio-connection `(,lsp-phpactor-path "language-server"))
   :activation-fn (lsp-activate-on "php")
   ;; `phpactor' is not really that feature-complete: it doesn't support
   ;; `textDocument/showOccurence' and sometimes errors (e.g. find references on


### PR DESCRIPTION
The executable for phpactor doesn't need to be installed from composer, it can
just be added to `$PATH`, as such the default should be the result of
`executable-find`.

Personally, I think it's cleaner to just rely on `executable-find` & maybe add a note to the docs RE: installation