### PR TITLE
Remove archived ocaml-language-server project

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,7 +89,6 @@ nav:
     - MSSQL: https://emacs-lsp.github.io/lsp-mssql
     - Nim: page/lsp-nim.md
     - Nix: page/lsp-nix.md
-    - OCaml (ocaml): page/lsp-ocaml.md
     - OCaml (ocaml-lsp): page/lsp-ocaml-lsp-server.md
     - Pascal/Object Pascal: page/lsp-pascal.md
     - Perl: page/lsp-perl.md


### PR DESCRIPTION
The [ocaml-language-server](https://github.com/ocaml-lsp/ocaml-language-server) is marked as archived.
Active development is occurring on [ocaml-lsp](https://github.com/ocaml/ocaml-lsp) so that should be the main up to date link provided. 