### PR TITLE
Use run-with-idle-timer for lsp-deferred

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8320,11 +8320,11 @@ This avoids overloading the server with many files when starting Emacs."
   (let ((buffer (current-buffer)))
     ;; Avoid false positives as desktop-mode restores buffers by deferring
     ;; visibility check until the stack clears.
-    (run-with-timer 0 nil (lambda ()
-                            (when (buffer-live-p buffer)
-                              (with-current-buffer buffer
-                                (unless (lsp--init-if-visible)
-                                  (add-hook 'window-configuration-change-hook #'lsp--init-if-visible nil t))))))))
+    (run-with-idle-timer 0 nil (lambda ()
+                                 (when (buffer-live-p buffer)
+                                   (with-current-buffer buffer
+                                     (unless (lsp--init-if-visible)
+                                       (add-hook 'window-configuration-change-hook #'lsp--init-if-visible nil t))))))))
 
 
 


### PR DESCRIPTION
`run-with-timer` triggers immediately after the buffer is visible. But
the environment is not set for the remote files at the time when LSP
binary is looked up.  This results in `matching-clients` to be nil.

Changing it to `run-with-idle-timer` ensures the buffer is done with
loading remote file and setting the environment and runs immediately
after the file is loaded in the buffer.

FIX #3033