### PR TITLE
Pass workspace to lsp diagnostics hook.

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -541,7 +541,7 @@ It contains the operation source."
 (defcustom lsp-after-diagnostics-hook nil
   "Hooks to run after diagnostics are received.
 Note: it runs only if the receiving buffer is open. Use
-`lsp-diagnostics-updated-hook'if you want to be notified when
+`lsp-diagnostics-updated-functions'if you want to be notified when
 diagnostics have changed."
   :type 'hook
   :group 'lsp-mode)
@@ -550,6 +550,14 @@ diagnostics have changed."
   'lsp-diagnostics-updated-hook "lsp-mode 6.4")
 
 (defcustom lsp-diagnostics-updated-hook nil
+  "Hooks to run after diagnostics are received."
+  :type 'hook
+  :group 'lsp-mode)
+
+(make-obsolete-variable
+ 'lsp-diagnostics-updated-hook "lsp-diagnostics-updated-functions" "7.1" 'set)
+
+(defcustom lsp-diagnostics-updated-functions nil
   "Hooks to run after diagnostics are received."
   :type 'hook
   :group 'lsp-mode)
@@ -2084,7 +2092,8 @@ WORKSPACE is the workspace that contains the diagnostics."
         (remhash file workspace-diagnostics)
       (puthash file (append diagnostics nil) workspace-diagnostics))
 
-    (run-hooks 'lsp-diagnostics-updated-hook)))
+    (run-hooks 'lsp-diagnostics-updated-hook)
+    (run-hook-with-args 'lsp-diagnostics-updated-functions workspace)))
 
 (defun lsp-diagnostics--workspace-cleanup (workspace)
   (->> workspace

--- a/lsp-modeline.el
+++ b/lsp-modeline.el
@@ -253,9 +253,9 @@ The `:global' workspace is global one.")
                                  (make-mode-line-mouse-map
                                   'mouse-1 #'lsp-treemacs-errors-list))))))
 
-(defun lsp-modeline--diagnostics-reset-modeline-cache ()
-  "Reset the modeline diagnostics cache."
-  (plist-put lsp-modeline--diagnostics-wks->strings (car (lsp-workspaces)) nil)
+(defun lsp-modeline--diagnostics-reset-modeline-cache (workspace)
+  "Reset the modeline diagnostics cache in the WORKSPACE."
+  (plist-put lsp-modeline--diagnostics-wks->strings workspace nil)
   (plist-put lsp-modeline--diagnostics-wks->strings :global nil)
   (setq lsp-modeline--diagnostics-string nil))
 
@@ -308,11 +308,11 @@ The `:global' workspace is global one.")
     (add-hook 'lsp-configure-hook #'lsp-modeline--enable-diagnostics nil t)
     (add-hook 'lsp-unconfigure-hook #'lsp-modeline--disable-diagnostics nil t)
     (add-to-list 'global-mode-string '(t (:eval (lsp-modeline--diagnostics-update-modeline))))
-    (add-hook 'lsp-diagnostics-updated-hook 'lsp-modeline--diagnostics-reset-modeline-cache))
+    (add-hook 'lsp-diagnostics-updated-functions 'lsp-modeline--diagnostics-reset-modeline-cache))
    (t
     (remove-hook 'lsp-configure-hook #'lsp-modeline--enable-diagnostics t)
     (remove-hook 'lsp-unconfigure-hook #'lsp-modeline--disable-diagnostics t)
-    (remove-hook 'lsp-diagnostics-updated-hook 'lsp-modeline--diagnostics-reset-modeline-cache)
+    (remove-hook 'lsp-diagnostics-updated-functions 'lsp-modeline--diagnostics-reset-modeline-cache)
     (setq global-mode-string (remove '(t (:eval (lsp-modeline--diagnostics-update-modeline))) global-mode-string)))))
 
 


### PR DESCRIPTION
This fixes diagnostics handling in case user switched to a non-lsp buffer.