### PR TITLE
[clojure] Refresh semantic tokens after cider disconnected

### DIFF
--- a/clients/lsp-clojure.el
+++ b/clients/lsp-clojure.el
@@ -309,7 +309,8 @@ If there are more arguments expected after the line and column numbers."
 
 (defun lsp-clojure-semantic-tokens-refresh ()
   "Force refresh semantic tokens."
-  (when (lsp-workspaces)
+  (when (and lsp-semantic-tokens-enable
+             (lsp-find-workspace 'clojure-lsp (buffer-file-name)))
     (lsp-semantic-tokens--enable)))
 
 (with-eval-after-load 'cider

--- a/clients/lsp-clojure.el
+++ b/clients/lsp-clojure.el
@@ -304,5 +304,19 @@ If there are more arguments expected after the line and column numbers."
 
 (lsp-consistency-check lsp-clojure)
 
+;; Cider integration
+
+(declare-function lsp-semantic-tokens--enable "lsp-semantic-tokens")
+
+(defun lsp-clojure-semantic-tokens-refresh ()
+  "Force refresh semantic tokens."
+  (when (lsp-workspaces)
+    (lsp-semantic-tokens--enable)))
+
+(with-eval-after-load 'cider
+  (when lsp-semantic-tokens-enable
+    ;; refresh tokens as cider flush font-faces after disconnected
+    (add-hook 'cider-mode-hook #'lsp-clojure-semantic-tokens-refresh)))
+
 (provide 'lsp-clojure)
 ;;; lsp-clojure.el ends here

--- a/clients/lsp-clojure.el
+++ b/clients/lsp-clojure.el
@@ -27,6 +27,7 @@
 (require 'lsp-mode)
 (require 'lsp-protocol)
 (require 'cl-lib)
+(require 'lsp-semantic-tokens)
 
 (defgroup lsp-clojure nil
   "LSP support for Clojure."
@@ -305,8 +306,6 @@ If there are more arguments expected after the line and column numbers."
 (lsp-consistency-check lsp-clojure)
 
 ;; Cider integration
-
-(declare-function lsp-semantic-tokens--enable "lsp-semantic-tokens")
 
 (defun lsp-clojure-semantic-tokens-refresh ()
   "Force refresh semantic tokens."


### PR DESCRIPTION
When using cider with lsp-mode, after the REPL is disconnected cider flush the font-faces, removing the tokens from semantic-tokens, adding the need to edit the file or `M-x` `lsp`.