### PR TITLE
Improve the Angular client

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,7 @@
 * Changelog
 ** Release 7.1
+  * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
+  * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.
   * Add ~lsp-sql-execute-paragraph~ to execute the current paragraph (like ~sql-send-paragraph~).
   * Breaking change: bindings for commands under ~s~ (like ~lsp-workspace-shutdown~) were moved under ~w~ for better compatibility with =Spacemacs=
   * removed ~lsp-print-performance~

--- a/clients/lsp-angular.el
+++ b/clients/lsp-angular.el
@@ -62,14 +62,14 @@ Has no effects when `lsp-clients-angular-language-server-command' is set."
                                    (lambda () (if lsp-clients-angular-language-server-command
                                                   lsp-clients-angular-language-server-command
                                                 (let ((node-modules-path
-                                                       (concat (string-trim (shell-command-to-string lsp-clients-angular-node-get-prefix-command))
-                                                               "/lib/node_modules")))
+                                                       (f-join (string-trim (shell-command-to-string lsp-clients-angular-node-get-prefix-command))
+                                                               "lib/node_modules")))
                                                   ;; The shell command takes a significant time to run,
                                                   ;; so we "cache" its results after running once
                                                   (setq lsp-clients-angular-language-server-command
                                                         (list
                                                          "node"
-                                                         (concat node-modules-path "/@angular/language-server")
+                                                         (f-join node-modules-path "@angular/language-server")
                                                          "--ngProbeLocations"
                                                          node-modules-path
                                                          "--tsProbeLocations"

--- a/clients/lsp-angular.el
+++ b/clients/lsp-angular.el
@@ -58,33 +58,40 @@ Has no effects when `lsp-clients-angular-language-server-command' is set."
   (lsp--info "Finished loading project %s" params))
 
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection
-                                   (lambda () (if lsp-clients-angular-language-server-command
-                                                  lsp-clients-angular-language-server-command
-                                                (let ((node-modules-path
-                                                       (f-join (string-trim (shell-command-to-string lsp-clients-angular-node-get-prefix-command))
-                                                               "lib/node_modules")))
-                                                  ;; The shell command takes a significant time to run,
-                                                  ;; so we "cache" its results after running once
-                                                  (setq lsp-clients-angular-language-server-command
-                                                        (list
-                                                         "node"
-                                                         (f-join node-modules-path "@angular/language-server")
-                                                         "--ngProbeLocations"
-                                                         node-modules-path
-                                                         "--tsProbeLocations"
-                                                         node-modules-path
-                                                         "--stdio"))
-                                                  lsp-clients-angular-language-server-command))))
-                  :activation-fn (lambda (&rest _args)
-                                   (and (string-match-p "\\(\\.html\\|\\.ts\\)\\'" (buffer-file-name))
-                                        (lsp-workspace-root)
-                                        (file-exists-p (f-join (lsp-workspace-root) "angular.json"))))
-                  :priority -1
-                  :notification-handlers (ht ("angular/projectLoadingStart" #'lsp-client--angular-start-loading)
-                                             ("angular/projectLoadingFinish" #'lsp-client--angular-finished-loading))
-                  :add-on? t
-                  :server-id 'angular-ls))
+ (make-lsp-client
+  :new-connection
+  (lsp-stdio-connection
+   (lambda ()
+     (if lsp-clients-angular-language-server-command
+         lsp-clients-angular-language-server-command
+       (let ((node-modules-path
+              (f-join
+               (string-trim
+                (shell-command-to-string lsp-clients-angular-node-get-prefix-command))
+               "lib/node_modules")))
+         ;; The shell command takes a significant time to run,
+         ;; so we "cache" its results after running once
+         (setq lsp-clients-angular-language-server-command
+               (list
+                "node"
+                (f-join node-modules-path "@angular/language-server")
+                "--ngProbeLocations"
+                node-modules-path
+                "--tsProbeLocations"
+                node-modules-path
+                "--stdio"))
+         lsp-clients-angular-language-server-command))))
+  :activation-fn
+  (lambda (&rest _args)
+    (and (string-match-p "\\(\\.html\\|\\.ts\\)\\'" (buffer-file-name))
+         (lsp-workspace-root)
+         (file-exists-p (f-join (lsp-workspace-root) "angular.json"))))
+  :priority -1
+  :notification-handlers
+  (ht ("angular/projectLoadingStart" #'lsp-client--angular-start-loading)
+      ("angular/projectLoadingFinish" #'lsp-client--angular-finished-loading))
+  :add-on? t
+  :server-id 'angular-ls))
 
 
 (lsp-consistency-check lsp-angular)


### PR DESCRIPTION
* Set lsp-clients-angular-language-server-command after the first run
to avoid the lag introduced by running the shell command.

Previously, if I add `benchmark-progn` after `lsp-stdio-connection                   (lambda ()`

Then after each `revert-buffer` & new file opened:
```
Elapsed time: 0.221614s
Elapsed time: 0.220887s
Elapsed time: 0.228161s
```

Certainly it's not a good experience for users.

Now:

First connection:
```
Elapsed time: 0.220515s
Elapsed time: 0.000001s [2 times]
```
After that, for each `revert-buffer` & new file opened:
```
Elapsed time: 0.000002s [2 times]
Elapsed time: 0.000001s
```
That's a huge speedup!

* Make Angular server's NodeJS prefix path configurable.

Because sometimes we don't use npm, and maybe there are multiple
installed versions of NodeJS, too.

Edit: I don't know how to edit documentation on [Angular - LSP Mode - LSP support for Emacs ](https://emacs-lsp.github.io/lsp-mode/page/lsp-angular/)