### PR TITLE
Fix #3064

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3346,7 +3346,10 @@ disappearing, unset all the variables related to it."
                    ,@(when lsp-enable-file-watchers '((didChangeWatchedFiles . ((dynamicRegistration . t)))))
                    (workspaceFolders . t)
                    (configuration . t)
-                   ,@(when lsp-semantic-tokens-enable '((semanticTokens . ((refreshSupport . t)))))
+                   ,@(when lsp-semantic-tokens-enable
+                       `((semanticTokens . ((refreshSupport . ,(or (and (boundp 'lsp-semantic-tokens-honor-refresh-requests)
+                                                                        lsp-semantic-tokens-honor-refresh-requests)
+                                                                   :json-false))))))
                    ,@(when lsp-lens-enable '((codeLens . ((refreshSupport . t)))))
                    (fileOperations . ((didCreate . :json-false)
                                       (willCreate . :json-false)

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -306,9 +306,9 @@ If FONTIFY-IMMEDIATELY is non-nil, fontification will be performed immediately
          (substrings))
     (cl-loop
      for edit across edits
-     when (< old-token-index (lsp-get edit :start))
      do
-     (push (substring old-data old-token-index (lsp-get edit :start)) substrings)
+     (when (< old-token-index (lsp-get edit :start))
+       (push (substring old-data old-token-index (lsp-get edit :start)) substrings))
      (push (lsp-get edit :data) substrings)
      (setq old-token-index (+ (lsp-get edit :start) (lsp-get edit :deleteCount)))
      finally do (push (substring old-data old-token-index old-token-count) substrings))


### PR DESCRIPTION
this PR should fix mishandled token deltas (issue #3064). Also, since clangd spews out a large number of token refresh requests, I changed capability registration to declare refresh requests unsupported if `lsp-semantic-tokens-honor-refresh-requests` is `nil`.
Tested briefly with clangd, will try with rust-analyzer later; further testing (with clojure-lsp, for example) would be much appreciated