### PR TITLE
Filter code actions by prefix, not equality

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5409,7 +5409,7 @@ It will filter by KIND if non nil."
   "Execute code action by COMMAND-KIND."
   (if-let ((action (->> (lsp-get-or-calculate-code-actions command-kind)
                         (-filter (-lambda ((&CodeAction :kind?))
-                                   (and kind? (equal command-kind kind?))))
+                                   (and kind? (s-prefix? command-kind kind?))))
                         lsp--select-action)))
       (lsp-execute-code-action action)
     (signal 'lsp-no-code-actions '(command-kind))))


### PR DESCRIPTION
It's quite unclear in the spec, but the idea seems to generally be to
filter code actions by their kinds *hierarchically*, so if the user asks
for `refactor` actions, the server can return `refactor.inline` actions.

This is usually what you want: for example, HLS has a variety of
import-fixing actions which use sub-kinds of `quickfix.import`. These
can be requested by just asking for the kind `quickfix.import`, which is
very nice.

However, in `lsp-mode` we then filter these down to those that match
*exactly*. I think we should also do a prefix match.

(My end goal is to be able to do `(lsp-make-interactive-code-action
haskell-fix-imports "quickfix.import")` and have it actually select all
the import-fixing actions and let the user pick one!)

I don't think this will affect any existing users much. Since it
currently doesn't work if you pass a kind expecting actions with
sub-kinds, presumably current users are only passing maximally-specific
kinds, and won't see any different behaviour.