### PR TITLE
lsp-rust: Add support for opening external docs

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1094,6 +1094,18 @@ open in a new window."
         (lsp--warn "Couldn't find a Cargo.toml file or your version of rust-analyzer doesn't support this extension"))
     (lsp--error "OpenCargoToml is an extension available only with rust-analyzer")))
 
+(defun lsp-rust-analyzer-open-external-docs ()
+  "Open a URL for documentation related to the current TextDocumentPosition.
+
+Rust-Analyzer LSP protocol documented here
+https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#open-external-documentation"
+  (interactive)
+  (-if-let* ((params (lsp-make-rust-analyzer-open-external-docs-params
+                      :text-document (lsp--text-document-identifier)
+                      :position (lsp--cur-position)))
+             (url (lsp-request "experimental/externalDocs" params)))
+      (browse-url url)
+    (lsp--warn "Couldn't find documentation URL or your version of rust-analyzer doesn't support this extension")))
 
 (defun lsp-rust-analyzer--related-tests ()
   "Get runnable test items related to the current TextDocumentPosition.

--- a/docs/manual-language-docs/lsp-rust-analyzer.md
+++ b/docs/manual-language-docs/lsp-rust-analyzer.md
@@ -62,15 +62,21 @@ Get a list of possible auto import candidates with `lsp-execute-code-action`
 
 `lsp-rust-analyzer-open-cargo-toml` opens the Cargo.toml closest to the current file. Calling it with a universal argument will open the Cargo.toml in another window.
 
-Corresponds to [the rust-analyzer LSP extension](https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#open-cargotoml) 
+Corresponds to [the rust-analyzer LSP extension](https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#open-cargotoml)
 
 ![](../examples/lsp-rust-analyzer-open-cargo-toml.gif)
+
+### Open external documentation
+
+`lsp-rust-analyzer-open-external-docs` opens external documentation related to the current position in a browser.
+
+Corresponds to [the rust-analyzer LSP extension](https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#open-external-documentation)
 
 ### Find and execute tests related to current position
 
 `lsp-rust-analyzer-related-tests` find all tests related to the current position, asks for user completion and executes the selected test in a compilation buffer.
 
-Corresponds to [the rust-analyzer LSP extension](https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#related-tests) 
+Corresponds to [the rust-analyzer LSP extension](https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#related-tests)
 
 In the example below, first you see that:
    + On the left, the function `check_infer` is defined, on the right another

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -403,6 +403,7 @@ See `-let' for a description of the destructuring mechanism."
                (rust-analyzer:ExpandedMacro (:name :expansion) nil)
                (rust-analyzer:MatchingBraceParams (:textDocument :positions) nil)
                (rust-analyzer:OpenCargoTomlParams (:textDocument) nil)
+               (rust-analyzer:OpenExternalDocsParams (:textDocument :position) nil)
                (rust-analyzer:ResovedCodeActionParams (:id :codeActionParams) nil)
                (rust-analyzer:JoinLinesParams (:textDocument :ranges) nil)
                (rust-analyzer:MoveItemParams (:textDocument :range :direction) nil)


### PR DESCRIPTION
Add support for using the rust-analyzer 'experimental/externalDocs' request to get a URL for external documentation. These 'experimental' endpoints are used elsewhere in lsp-rust, so this isn't a change on that front.

An alternative here is that we just return the URL instead of using `browse-url`. I will change to that if you prefer.