### PR TITLE
add missing option in texlab install command (documentation)

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -632,7 +632,7 @@
     "full-name": "TeX, LaTeX, etc.",
     "server-name": "texlab",
     "server-url": "https://github.com/latex-lsp/texlab",
-    "installation": "cargo install --git https://github.com/latex-lsp/texlab.git",
+    "installation": "cargo install --locked --git https://github.com/latex-lsp/texlab.git",
     "debugger": "Not available"
   },
   {


### PR DESCRIPTION
I think the same option (`--locked`) should be added to l.619, but have not tested.
Please see also see https://github.com/latex-lsp/texlab/issues/474 that points to https://github.com/latex-lsp/texlab#building-from-source