### PR TITLE
[lsp-diagnostics] Don't run flycheck-buffer when flycheck is not enabled in current buffer

### DIFF
--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -177,7 +177,8 @@ CALLBACK is the status callback passed by Flycheck."
 (defun lsp-diagnostics--flycheck-buffer ()
   "Trigger flyckeck on buffer."
   (remove-hook 'lsp-on-idle-hook #'lsp-diagnostics--flycheck-buffer t)
-  (flycheck-buffer))
+  (when (bound-and-true-p flycheck-mode)
+    (flycheck-buffer)))
 
 (defun lsp-diagnostics--flycheck-report ()
   "Report flycheck.


### PR DESCRIPTION
Fixes https://github.com/hlissner/doom-emacs/issues/5424