### PR TITLE
Dispatch each lsp--parser-on-message in next message loop

### DIFF
--- a/test/lsp-integration-test.el
+++ b/test/lsp-integration-test.el
@@ -84,6 +84,7 @@
      (lsp-workspace-folders-add (f-join lsp-test-location "fixtures"))
      (find-file (f-join lsp-test-location "fixtures/pyls/test.py"))
      (lsp)
+     (sleep-for 0.1)
      ,@body
 
      (find-file (f-join lsp-test-location "fixtures/pyls/test.py"))


### PR DESCRIPTION
Dispatch `lsp--parser-on-message` in a separated message loop so that the callback function can throw without affects others.
Fix #3079