### PR TITLE
lsp-pwsh-dir: update path to match with new version of PSES

### DIFF
--- a/clients/lsp-pwsh.el
+++ b/clients/lsp-pwsh.el
@@ -231,7 +231,7 @@ extension."
   :group 'lsp-pwsh
   :package-version '(lsp-mode . "6.2"))
 
-(defcustom lsp-pwsh-dir (expand-file-name "PowerShellEditorServices" lsp-pwsh-ext-path)
+(defcustom lsp-pwsh-dir lsp-pwsh-ext-path
   "Path to PowerShellEditorServices without last slash."
   :type 'string
   :group 'lsp-pwsh


### PR DESCRIPTION
The new PowerShellEditorServices' [release](https://github.com/PowerShell/PowerShellEditorServices/releases/download/v2.5.1/PowerShellEditorServices.zip) has different structure.
We need to update the path to accommodate that.