### PR TITLE
Add python .venv folder to lsp-file-watch-ignored-directories

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -328,6 +328,7 @@ the server has requested that."
     "[/\\\\]target\\'"
     "[/\\\\]\\.ccls-cache\\'"
     "[/\\\\]\\.vscode\\'"
+    "[/\\\\]\\.venv\\'"
     ;; Autotools output
     "[/\\\\]\\.deps\\'"
     "[/\\\\]build-aux\\'"


### PR DESCRIPTION
The .venv folder stores project dependencies for a python project. 

Although there is no standard folder name in python for these currently,  .venv is the most common naming convention used when keeping the python virtual environment locally in the project folder.