### PR TITLE
lsp-csharp.el: introduce support for csharp-ls (alternative) language server

### DIFF
--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -343,7 +343,8 @@ using the `textDocument/references' request."
                                        (f-exists? binary))))
 
                   :major-modes '(csharp-mode csharp-tree-sitter-mode)
-                  :server-id 'csharp
+                  :server-id 'omnisharp
+                  :priority -1
                   :action-handlers (ht ("omnisharp/client/findReferences" 'lsp-csharp--action-client-find-references))
                   :notification-handlers (ht ("o#/projectadded" 'ignore)
                                              ("o#/projectchanged" 'ignore)
@@ -358,6 +359,74 @@ using the `textDocument/references' request."
                                              ("o#/projectconfiguration" 'ignore)
                                              ("o#/projectdiagnosticstatus" 'ignore))
                   :download-server-fn #'lsp-csharp--download-server))
+
+;;
+;; Alternative "csharp-ls" language server support
+;; see https://github.com/razzmatazz/csharp-language-server
+;;
+(lsp-defun lsp-csharp--csharp-ls-metadata-uri-handler (uri)
+  "Handle `csharp:/(metadata)' uri from csharp-ls server.
+
+'csharp/metadata' request is issued to retrieve metadata from the server.
+A cache file is created on project root dir that stores this metadata and filename
+is returned so lsp-mode can display this file."
+
+  (-when-let* ((metadata-req (lsp-make-csharp-ls-c-sharp-metadata
+                              :text-document (lsp-make-text-document-identifier :uri uri)))
+               (metadata (lsp-request "csharp/metadata" metadata-req))
+               ((&csharp-ls:CSharpMetadataResponse :project-name
+                                                   :assembly-name
+                                                   :symbol-name
+                                                   :source) metadata)
+               (filename (f-join ".cache"
+                                 "lsp-csharp"
+                                 "metadata"
+                                 "projects" project-name
+                                 "assemblies" assembly-name
+                                 (concat symbol-name ".cs")))
+               (file-location (expand-file-name filename (lsp--suggest-project-root)))
+               (metadata-file-location (concat file-location ".metadata-uri"))
+               (path (f-dirname file-location)))
+
+    (unless (find-buffer-visiting file-location)
+      (unless (file-directory-p path)
+        (make-directory path t))
+
+      (with-temp-file metadata-file-location
+        (insert uri))
+
+      (with-temp-file file-location
+        (insert source)))
+
+    file-location))
+
+(defun lsp-csharp--csharp-ls-before-file-open (_workspace)
+  "Set `lsp-buffer-uri' variable after C# file is open from *.metadata-uri file."
+
+  (let ((metadata-file-name (concat buffer-file-name ".metadata-uri")))
+    (setq-local lsp-buffer-uri
+                (when (file-exists-p metadata-file-name)
+                  (with-temp-buffer (insert-file-contents metadata-file-name)
+                                    (buffer-string))))))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection '(lambda () "csharp-ls"))
+                  :priority -2
+                  :server-id 'csharp-ls
+                  :major-modes '(csharp-mode csharp-tree-sitter-mode)
+                  :before-file-open-fn #'lsp-csharp--csharp-ls-before-file-open
+                  :uri-handlers (ht ("csharp" #'lsp-csharp--csharp-ls-metadata-uri-handler))
+                  :download-server-fn (lambda (_client callback error-callback update?)
+                                        (let* ((csharp-ls-version "0.1.1-alpha")
+                                               (exit-code (call-process "dotnet" nil nil nil
+                                                                        "tool"
+                                                                        (if update? "update" "install")
+                                                                        "-g"
+                                                                        "csharp-ls"
+                                                                        "--version" csharp-ls-version)))
+                                          (if (zerop exit-code)
+                                              (funcall callback)
+                                            (funcall error-callback))))))
 
 (lsp-consistency-check lsp-csharp)
 

--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -384,11 +384,11 @@ is returned so lsp-mode can display this file."
                                  "projects" project-name
                                  "assemblies" assembly-name
                                  (concat symbol-name ".cs")))
-               (file-location (expand-file-name filename (lsp--suggest-project-root)))
+               (file-location (expand-file-name filename (lsp-workspace-root)))
                (metadata-file-location (concat file-location ".metadata-uri"))
                (path (f-dirname file-location)))
 
-    (unless (find-buffer-visiting file-location)
+    (unless (file-exists-p file-location)
       (unless (file-directory-p path)
         (make-directory path t))
 

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -43,12 +43,21 @@
     "debugger": "Not available"
   },
   {
-    "name": "csharp",
-    "full-name": "C#",
+    "name": "csharp-ls",
+    "full-name": "C# (csharp-ls)",
+    "server-name": "csharp-ls",
+    "server-url": "https://github.com/razzmatazz/csharp-language-server",
+    "installation": "Automatic by lsp-mode with `dotnet tool install -g`",
+    "lsp-install-server": "csharp-ls",
+    "debugger": "Not available"
+  },
+  {
+    "name": "omnisharp",
+    "full-name": "C# (Omnisharp-Roslyn)",
     "server-name": "OmniSharp-Roslyn",
     "server-url": "https://github.com/OmniSharp/omnisharp-roslyn",
     "installation": "Supports automatic installation.",
-    "lsp-install-server": "csharp",
+    "lsp-install-server": "omnisharp",
     "debugger": "Not available"
   },
   {

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -392,6 +392,9 @@ See `-let' for a description of the destructuring mechanism."
                (omnisharp:TestMessageEvent (:MessageLevel :Message))
                (omnisharp:DotNetTestResult (:MethodName :Outcome :ErrorMessage :ErrorStackTrace :StandardOutput :StandardError)))
 
+(lsp-interface (csharp-ls:CSharpMetadata (:textDocument))
+               (csharp-ls:CSharpMetadataResponse (:source :projectName :assemblyName :symbolName)))
+
 (lsp-interface (rls:Cmd (:args :binary :env :cwd) nil))
 
 (defconst lsp/rust-analyzer-inlay-hint-kind-type-hint "TypeHint")


### PR DESCRIPTION
after reluctant upstream omnisharp-roslyn acceptance of my PRs I have decided to hack my own server -- how hard it can be? -- not so hard apparently :)

this also introduces support for go-to-definition for code in metadata
using the new language server (I will cancel https://github.com/emacs-lsp/lsp-mode/pull/2573)

follow up on https://github.com/emacs-lsp/lsp-mode/pull/2573