### PR TITLE
fix: do not start eslint lsp in json file

### DIFF
--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -356,7 +356,8 @@ to allow or deny it.")
                      (or (string-match-p (rx (one-or-more anything) "."
                                              (or "ts" "js" "jsx" "tsx" "html" "vue" "svelte")eos)
                                          filename)
-                         (derived-mode-p 'js-mode 'js2-mode 'typescript-mode 'html-mode 'svelte-mode))))
+                         (and (derived-mode-p 'js-mode 'js2-mode 'typescript-mode 'html-mode 'svelte-mode)
+                           (not (string-match-p "\\.json\\'" filename))))))
   :priority -1
   :completion-in-comments? t
   :add-on? t


### PR DESCRIPTION
json-mode is a derived mode of js-mode but eslint cannot work on json file