### PR TITLE
Feature/ts-ls init opts

### DIFF
--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -89,7 +89,8 @@
   :type 'string)
 
 (defcustom lsp-clients-typescript-init-opts nil
-  "Configuration options provided to tsserver."
+  "Configuration options provided to tsserver.
+See the UserPreferences interface at https://github.com/microsoft/TypeScript/blob/main/lib/protocol.d.ts for the list of options available in the latest version of TypeScript."
   :group 'lsp-typescript
   :type 'plist)
 


### PR DESCRIPTION
the typescript-language-server initialization options object contains a field named preferences which allows clients to configure the underlying tsserver process. lsp-mode does not seem to be providing this field in its initialize requests.  this PR adds a `defcustom` to allow users to define the contents of this field, and updates the `:initialization-options` passed to `make-lsp-client` to provide it to ts-ls.

addresses #3140 .