### PR TITLE
Add Leiningen checkouts dirs to ignored dir paths

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -346,6 +346,7 @@ the server has requested that."
     "[/\\\\]\\.shadow-cljs\\'"
     "[/\\\\]\\.babel_cache\\'"
     "[/\\\\]\\.cpcache\\'"
+    "[/\\\\]\\checkouts\\'"
     ;; .Net Core build-output
     "[/\\\\]bin/Debug\\'"
     "[/\\\\]obj\\'"


### PR DESCRIPTION
Leiningen (a commonly-used Clojure project automation and build tool) offers a feature called "checkout dependencies", which creates symbolic links to other Leiningen projects that may be developed in tandem. When a large number of checkout dependencies are in use (say in the case of a monorepo), `lsp-mode` ends up watching the same files many times as it follows these directory symlinks. This can lead to Emacs running out of file handles and generally not functioning. By ignoring this directory, this case can be prevented.

https://github.com/technomancy/leiningen/blob/master/doc/TUTORIAL.md#checkout-dependencies