### PR TITLE
rust: add rust-analyzer option to unset #[cfg(test)] in specified crates

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -409,6 +409,12 @@ The command should include `--message=format=json` or similar option."
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "6.2.2"))
 
+(defcustom lsp-rust-analyzer-cargo-unset-test []
+  "force rust-analyzer to unset `#[cfg(test)]` for the specified crates."
+  :type 'lsp-string-vector
+  :group 'lsp-rust-analyzer
+  :package-version '(lsp-mode . "6.2.2"))
+
 (defcustom lsp-rust-analyzer-use-client-watching t
   "Use client watching"
   :type 'boolean
@@ -651,7 +657,8 @@ https://rust-analyzer.github.io/manual.html#auto-import.
             ; Obsolete, but used by old Rust-Analyzer versions
             :loadOutDirsFromCheck ,(lsp-json-bool lsp-rust-analyzer-cargo-run-build-scripts)
             :autoreload ,(lsp-json-bool lsp-rust-analyzer-cargo-auto-reload)
-            :useRustcWrapperForBuildScripts ,(lsp-json-bool lsp-rust-analyzer-use-rustc-wrapper-for-build-scripts))
+            :useRustcWrapperForBuildScripts ,(lsp-json-bool lsp-rust-analyzer-use-rustc-wrapper-for-build-scripts)
+            :unsetTest ,lsp-rust-analyzer-cargo-unset-test)
     :rustfmt (:extraArgs ,lsp-rust-analyzer-rustfmt-extra-args
               :overrideCommand ,lsp-rust-analyzer-rustfmt-override-command)
     :inlayHints (:typeHints ,(lsp-json-bool lsp-rust-analyzer-server-display-inlay-hints)


### PR DESCRIPTION
this allows the user to still enable #[cfg(test)] in rust-analyzer
globally while not breaking dependencies that have different (broken)
behavior when #[cfg(test)] is set.

see:
    - https://github.com/rust-analyzer/rust-analyzer/issues/7225
    - https://github.com/lf-/rust-analyzer/commit/86c9e7b5992912ea41979ebf2e1dbd469db43b6e