### PR TITLE
Improve lsp-install-server and add lsp-update-server

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7421,7 +7421,8 @@ Check `*lsp-install*' and `*lsp-log*' buffer."
 
 ;;;###autoload
 (defun lsp-install-server (update? &optional server-id)
-  "Interactively install or re-install server."
+  "Interactively install or re-install server.
+When prefix UPDATE? is t force installation even if the server is present."
   (interactive "P")
   (lsp--require-packages)
   (let* ((chosen-client (or (gethash server-id lsp-clients)


### PR DESCRIPTION
Related / fix? https://github.com/emacs-lsp/lsp-mode/issues/3159

The idea is to show already installed clients as option and if user choose it, we update it.
This should avoid users complaining about server not found on the servers list as well

![image](https://user-images.githubusercontent.com/7820865/138005750-7178c090-b69e-4ee5-80df-5af9ec0473ca.png)
