### PR TITLE
Stop polluting homedir with intelephense folder

### DIFF
--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -201,7 +201,7 @@ language server."
   "Optional absolute path to global storage dir."
   :type 'directory
   :group 'lsp-intelephense
-  :package-version '(lsp-mode . "6.1"))
+  :package-version '(lsp-mode . "8.0.1"))
 
 (defcustom lsp-intelephense-clear-cache nil
   "Optional flag to clear server state."


### PR DESCRIPTION
Currently its creating a ~/intelephense folder whenever intelephense is initialized 
so i just changed the default folder path to emacs-folder/.local/etc/intelephense

Ref
https://github.com/bmewburn/intelephense-docs/blob/master/installation.md#initialisation-options