### PR TITLE
Add support for window/showDocument

### DIFF
--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -737,6 +737,8 @@ See `-let' for a description of the destructuring mechanism."
  (ResourceOperationKind nil nil)
  (SelectionRangeParams (:textDocument :positions) nil)
  (SemanticHighlightingParams (:textDocument :lines) nil)
+ (ShowDocumentParams (:uri) (:external :takeFocus :selection))
+ (ShowDocumentResult (:success) nil)
  (ShowMessageRequestParams (:type :message) (:actions))
  (SignatureHelpParams (:textDocument :position) (:context :uri))
  (SignatureHelpRegistrationOptions nil (:documentSelector :triggerCharacters))


### PR DESCRIPTION
Fixes #2459

I tested with clojure-lsp which I'm adding support to go to the test file after executing the code action `Create test for this function`