### PR TITLE
lsp-find-implementation produces references not definitions

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5982,7 +5982,10 @@ REFERENCES? t when METHOD returns references."
 (cl-defun lsp-find-implementation (&key display-action)
   "Find implementations of the symbol under point."
   (interactive)
-  (lsp-find-locations "textDocument/implementation" nil :display-action display-action))
+  (lsp-find-locations "textDocument/implementation"
+                      nil
+                      :display-action display-action
+                      :references? t))
 
 (cl-defun lsp-find-references (&optional include-declaration &key display-action)
   "Find references of the symbol under point."


### PR DESCRIPTION
So third party 'xref-show-xrefs-functions' handlers such as `helm-xref` and
`ivy-xref` can pick up the result set.