### PR TITLE
Fix 3 different cases of stale semantic highlights

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4536,6 +4536,8 @@ Added to `after-change-functions'."
     (run-hooks 'lsp-on-change-hook)))
 
 (defun lsp--after-change (buffer)
+  (when (fboundp 'lsp--semantic-tokens-refresh-if-enabled)
+    (lsp--semantic-tokens-refresh-if-enabled buffer))
   (when lsp--on-change-timer
     (cancel-timer lsp--on-change-timer))
   (setq lsp--on-change-timer (run-with-idle-timer

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -568,6 +568,25 @@ chosen by `font-lock-fontify-region'."
                     (format " ; Alternative: %s" (prin1-to-string it))))))
       (insert ")"))))
 
+(declare-function tree-sitter-hl-mode "ext:tree-sitter-hl")
+
+(with-eval-after-load 'tree-sitter-hl
+  (add-hook
+   'tree-sitter-hl-mode-hook
+   (lambda ()
+     (when (and lsp-mode lsp--semantic-tokens-teardown
+                (boundp 'tree-sitter-hl-mode) tree-sitter-hl-mode)
+       (lsp-warn "It seems you have configured tree-sitter-hl to activate after lsp-mode.
+To prevent tree-sitter-hl from overriding lsp-mode's semantic token highlighting, lsp-mode
+will now disable both semantic highlighting and tree-sitter-hl mode and subsequently re-enable both,
+starting with tree-sitter-hl-mode.
+
+Please adapt your config to prevent unnecessary mode reinitialization in the future.")
+       (tree-sitter-hl-mode -1)
+       (funcall lsp--semantic-tokens-teardown)
+       (setq lsp--semantic-tokens-teardown nil)
+       (tree-sitter-hl-mode t)
+       (lsp--semantic-tokens-initialize-buffer)))))
 
 ;;;###autoload
 (defun lsp--semantic-tokens-initialize-buffer ()


### PR DESCRIPTION
this PR intends to solve issues #3155, #3154 and #2834.

#2834 was caused by late tree-sitter activation overriding lsp's semantic font-lock handlers; we now have lsp-semantic-tokens-mode watch out for late tree-sitter-hl activation and, if that happens, warn the user about the configuration issue, disable both modes and reenable them in the correct order. The fix has been verified, though I'd appreciate @theol0403 having another look at this PR, as the version I had previously proposed was slightly different (didn't disable in proper LIFO order).

#3154 was caused by aggressive font-lock region widening requested by some underlying font-lock mechanism (clojure-mode's font-lock, in the reported case), which would cause font-lock to clear token highlights within regions for which no new tokens were available (if ranged requests were being used). To fix that, we now enlarge ranged request regions by several font-lock chunks, and refontify with full responses if the resulting regions still remain too small to cover the underlying fontifier's fontification region.

#3155 was caused by workspace edits not resulting in semantic token flushes; to alleviate this (as workspace edits may affect a large number of buffers simultaneously), pending full-token requests are now maintained as a global queue and full token sets are requested (on an idle timer) within `lsp--after-change`. This is the commit most likely to cause problems, as it changes the way full token requests are handled, and the tighter coupling between lsp-mode proper and lsp-semantic-tokens isn't exactly pretty. Suggestions on how to better handle this are very welcome