### PR TITLE
Fix phpactor URL & remove installation

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -438,8 +438,7 @@
     "full-name": "Phpactor",
     "server-name": "phpactor",
     "server-url": "https://github.com/phpactor/phpactor",
-    "installation-url": "https://phpactor.readthedocs.io/en/develop/usage/standalone.html#installation-global",
-    "installation": "composer g require phpactor/phpactor",
+    "installation-url": "https://phpactor.readthedocs.io/en/master/usage/standalone.html#installation-global",
     "debugger": "yes"
   },
   {


### PR DESCRIPTION
Existing installation instructions aren't recommended due to collisions with other libraries.