### PR TITLE
Add  to completion items when insert-text

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -143,10 +143,13 @@ This will help minimize popup flickering issue in `company-mode'."
 (cl-defun lsp-completion--make-item (item &key markers prefix)
   "Make completion item from lsp ITEM and with MARKERS and PREFIX."
   (-let (((&CompletionItem :label
+                           :insert-text?
                            :sort-text?
                            :_emacsStartPoint start-point)
           item))
-    (propertize label
+    (propertize (if insert-text?
+                    (concat label "~")
+                  label)
                 'lsp-completion-item item
                 'lsp-sort-text sort-text?
                 'lsp-completion-start-point start-point


### PR DESCRIPTION
This is a simple modification to enhance completion doing the same neovim does, showing a `~` on the end of the completion item if it will insert some kind of text rather than just the `label`, this is useful to user know that this completion item will do something other than just complete with the label.

Note: We can rely only on snippet kind since it's possible and IMO makes sense for example to return a completion item saying that a item is of type function but will insert some other kind of text, example:

__lsp-mode__
![image](https://user-images.githubusercontent.com/7820865/141695326-8428fb76-c6cb-4ce3-8bd0-f282c42eef5d.png)

__neovim__
![image](https://user-images.githubusercontent.com/7820865/141695373-52990fcd-4178-4598-b70d-55dee24c6f73.png)

c/c @kiennq @yyoncho 