### PR TITLE
Add org-mode to language id

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -803,7 +803,7 @@ Changes take effect only when a new session is started."
                                         (gfm-mode . "markdown")
                                         (beancount-mode . "beancount")
                                         (conf-toml-mode . "toml")
-                                        (org-mode . "org"))
+                                        (org-mode . "plaintext"))
   "Language id configuration.")
 
 (defvar lsp--last-active-workspaces nil

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -802,7 +802,8 @@ Changes take effect only when a new session is started."
                                         (markdown-mode . "markdown")
                                         (gfm-mode . "markdown")
                                         (beancount-mode . "beancount")
-                                        (conf-toml-mode . "toml"))
+                                        (conf-toml-mode . "toml")
+                                        (org-mode . "org"))
   "Language id configuration.")
 
 (defvar lsp--last-active-workspaces nil


### PR DESCRIPTION
Not sure if this is required for org-mode to work correctly with `lsp-grammarly` and `lsp-ltex`? 😕 

#### Related issue

* https://github.com/emacs-languagetool/lsp-ltex/issues/10
* https://github.com/emacs-grammarly/lsp-grammarly/issues/23
