### PR TITLE
Make installation-buffer removable by pressing Q.

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7513,6 +7513,7 @@ When prefix UPDATE? is t force installation even if the server is present."
                                             (lambda (&rest _)
                                               (generate-new-buffer-name (format "*lsp-install: %s*" name))))
       (lsp-installation-buffer-mode +1)
+      (view-mode +1)
       (add-hook
        'compilation-finish-functions
        (lambda (_buf status)


### PR DESCRIPTION
Currently, after installation is complete, you kinda of expect to be able to dismiss the `*lsp-install*` buffer by pressing Q (like compilation-mode buffers, occur-buffers, etc).

But when you do that, you find that the buffer is open to all kinds of input and editing, which IMO doesn't make much sense.

This PR changes `*lsp-install*` buffers to have `view-mode` enabled, and thus be easily dismissable.