### PR TITLE
[org] Use more appropriate identification for org-mode file (#3258)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -10,6 +10,7 @@
   * Add TOML support.
   * Add Nginx support.
   * Disable noisy features from ~lsp-ui~: ~lsp-ui-sideline-show-code-actions~ and ~lsp-ui-doc-show-with-cursor~.
+  * Fix org mode support. #3258
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -804,7 +804,7 @@ Changes take effect only when a new session is started."
                                         (gfm-mode . "markdown")
                                         (beancount-mode . "beancount")
                                         (conf-toml-mode . "toml")
-                                        (org-mode . "plaintext")
+                                        (org-mode . "org")
                                         (nginx-mode . "nginx"))
   "Language id configuration.")
 


### PR DESCRIPTION
Use "org" instead of "plaintext" to make sure the server understand
all the org mode idiosyncrasy.