### PR TITLE
[js/eslint] Update vscode-eslint extension download url

### DIFF
--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -42,7 +42,7 @@
   :group 'lsp-eslint
   :package-version '(lsp-mode . "8.0.0"))
 
-(defcustom lsp-eslint-download-url "https://github.com/emacs-lsp/lsp-server-binaries/blob/master/dbaeumer.vscode-eslint-2.1.13.vsix?raw=true"
+(defcustom lsp-eslint-download-url "https://github.com/emacs-lsp/lsp-server-binaries/blob/master/dbaeumer.vscode-eslint-2.2.2.vsix?raw=true"
   "Eslint language server download url."
   :type 'string
   :group 'lsp-eslint


### PR DESCRIPTION
Update default vscode-eslint extension url. This hopefully fixes #3272 related to microsoft/vscode-eslint#972. I've tested it by this var `lsp-eslint-download-url "http://localhost:8000/dbaeumer.vscode-eslint-2.2.2.vsix"` and serving newer version to myself.

Here is a related PR which adds this file: emacs-lsp/lsp-server-binaries#1