### PR TITLE
Remove godoc.org from lsp-go-link-target

### DIFF
--- a/clients/lsp-go.el
+++ b/clients/lsp-go.el
@@ -229,10 +229,9 @@ $GOPATH/pkg/mod along with the value of
         (mapcar (lambda (path) (concat (file-remote-p default-directory) path)) library-dirs)
       library-dirs)))
 
-(defcustom lsp-go-link-target "godoc.org"
+(defcustom lsp-go-link-target "pkg.go.dev"
   "Which website to use for displaying Go documentation."
-  :type '(choice (const "godoc.org")
-		 (const "pkg.go.dev")
+  :type '(choice (const "pkg.go.dev")
 		 (string :tag "A custom website"))
   :group 'lsp-go
   :package-version '(lsp-mode "7.0.1"))


### PR DESCRIPTION
All requests to godoc.org redirect to pkg.go.dev, see https://github.com/golang/go/issues/43178.