### PR TITLE
Update versions of clangd to look for

### DIFF
--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -234,9 +234,9 @@ This must be set only once after loading the clang client.")
                       (-map (lambda (version)
                               (concat "clangd" version))
                             ;; Prefer `clangd` without a version number appended.
-                            (append (list "") (-map
-                                               (lambda (vernum) (format "-%d" vernum))
-                                               (number-sequence 14 6 -1)))))
+                            (cl-list* "" (-map
+                                          (lambda (vernum) (format "-%d" vernum))
+                                          (number-sequence 14 6 -1)))))
               (lsp-clients-executable-find "xcodebuild" "-find-executable" "clangd")
               (lsp-clients-executable-find "xcrun" "--find" "clangd"))))
 

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -233,7 +233,10 @@ This must be set only once after loading the clang client.")
               (-first #'executable-find
                       (-map (lambda (version)
                               (concat "clangd" version))
-                            '("" "-12" "-11" "-10" "-9" "-8" "-7" "-6")))
+                            ;; Prefer `clangd` without a version number appended.
+                            (append (list "") (-map
+                                               (lambda (vernum) (format "-%d" vernum))
+                                               (number-sequence 14 6 -1)))))
               (lsp-clients-executable-find "xcodebuild" "-find-executable" "clangd")
               (lsp-clients-executable-find "xcrun" "--find" "clangd"))))
 

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -47,7 +47,7 @@
 (declare-function flycheck-error-group "ext:flycheck" (err) t)
 (declare-function flycheck-error-message "ext:flycheck" (err) t)
 
-(defcustom lsp-clangd-version "12.0.0"
+(defcustom lsp-clangd-version "13.0.0"
   "Clangd version to download.
 It has to be set before `lsp-clangd.el' is loaded and it has to
 be available here: https://github.com/clangd/clangd/releases/"


### PR DESCRIPTION
https://apt.llvm.org/ has both 13 and 14.

This also replaces the hard-coded list with a reversed `number-sequence`.