### PR TITLE
Add installer for elixir-ls

### DIFF
--- a/clients/lsp-elixir.el
+++ b/clients/lsp-elixir.el
@@ -105,6 +105,22 @@ Leave as default to let `executable-find' search for it."
   :type '(repeat string)
   :package-version '(lsp-mode . "8.0.0"))
 
+(defcustom lsp-elixir-ls-version "v0.9.0"
+  "Elixir-Ls version to download.
+It has to be set before `lsp-elixir.el' is loaded and it has to
+be available here: https://github.com/elixir-lsp/elixir-ls/releases/"
+  :type 'string
+  :group 'lsp-elixir
+  :package-version '(lsp-mode . "8.0.0"))
+
+(defcustom lsp-elixir-ls-download-url
+  (format "https://github.com/elixir-lsp/elixir-ls/releases/download/%s/elixir-ls.zip"
+          lsp-elixir-ls-version)
+  "Automatic download url for elixir-ls"
+  :type 'string
+  :group 'lsp-elixir
+  :package-version '(lsp-mode . "8.0.0"))
+
 
 (defconst lsp-elixir-ls-server-dir
   (f-join lsp-server-install-dir "elixir-ls")
@@ -145,8 +161,13 @@ Leave as default to let `executable-find' search for it."
              " --no-color"))
     file-path))
 
-(lsp-dependency 'elixir-ls
-                '(:system "elixir-ls"))
+(lsp-dependency
+ 'elixir-ls
+ `(:download :url lsp-elixir-ls-download-url
+             :decompress :zip
+             :store-path ,(f-join lsp-server-install-dir "elixir-ls" "elixir-ls.zip")
+             :binary-path lsp-elixir-server-command
+             :set-executable? t))
 
 (lsp-register-custom-settings
  '(("elixirLS.dialyzerEnabled" lsp-elixir-dialyzer-enabled t)
@@ -174,6 +195,8 @@ Leave as default to let `executable-find' search for it."
                   :priority -1
                   :server-id 'elixir-ls
                   :action-handlers (ht ("elixir.lens.test.run" 'lsp-elixir--run-test))
+                  :download-server-fn (lambda (_client callback error-callback _update?)
+                                        (lsp-package-ensure 'elixir-ls callback error-callback))
                   :initialized-fn (lambda (workspace)
                                     (with-lsp-workspace workspace
                                       (lsp--set-configuration


### PR DESCRIPTION
Hello,
This PR adds an installer for the [Elixir-LS](https://github.com/elixir-lsp/elixir-ls) language server.

With the current approach it fetches the configured release (`v0.9.0` by default) from GitHub, similarly to how other clients do it (I took most of the inspiration from the `clangd` installer).

It works on my Emacs, but my knowledge of Emacs Lisp is pretty limited so I might have missed something :)

Hope this may be helpful!