### PR TITLE
Update to just use yas-minor-mode for rust analyzer

### DIFF
--- a/docs/manual-language-docs/lsp-rust-analyzer.md
+++ b/docs/manual-language-docs/lsp-rust-analyzer.md
@@ -70,8 +70,7 @@ like this:
 ``` emacs-lisp
 (use-package yasnippet
   :ensure t
-  :hook ((lsp-mode . yasnippet)
-         (lsp-mode . yas-minor-mode)))
+  :hook ((lsp-mode . yas-minor-mode)))
 ```
 
 ### Open Cargo.toml


### PR DESCRIPTION
There is no `yasnippet` mode.