### PR TITLE
Disable `lsp--completing-read` sort

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1320,14 +1320,18 @@ the lists according to METHOD."
 (defun lsp--completing-read (prompt collection transform-fn &optional predicate
                                     require-match initial-input
                                     hist def inherit-input-method)
-  "Wrap `completing-read' to provide transformation function.
+  "Wrap `completing-read' to provide transformation function and disable sort.
 
 TRANSFORM-FN will be used to transform each of the items before displaying.
 
 PROMPT COLLECTION PREDICATE REQUIRE-MATCH INITIAL-INPUT HIST DEF
 INHERIT-INPUT-METHOD will be proxied to `completing-read' without changes."
   (let* ((col (--map (cons (funcall transform-fn it) it) collection))
-         (completion (completing-read prompt col
+         (completion (completing-read prompt
+                                      (lambda (string pred action)
+                                        (if (eq action 'metadata)
+                                            `(metadata (display-sort-function . identity))
+                                          (complete-with-action action col string pred)))
                                       predicate require-match initial-input hist
                                       def inherit-input-method)))
     (cdr (assoc completion col))))


### PR DESCRIPTION
doom-emacs changed from ivy to vertico some months ago, I realized that code actions retrieved by server were shown in completely wrong order, after some debugging it seems that vertico has a default `display-sort-function` of sorting by length, and alphabetically.
For LSP, **regardless of the search engine**, I think we should stick to no sorting as most of the cases we want the passed coll as the correct order, this PR passes a custom metadata for completing-read that completing engines check when displaying content, disabling the sorting on `lsp--completing-read`.

Quick repro:
``` elisp
(setq actions '("Add require [clojure.parallel :refer [a]]"
                "Create private function"
                "Cycle privacy"
                "Extract function"
                "Move coll entry up"
                "Move coll entry down"
                "Suppress diagnostic"
                "Create test for"
                "Clean namespace"))

(completing-read "Vertico test" (lambda (string predicate action)
                                  (if (eq action 'metadata)
                                      `(metadata (display-sort-function . identity))
                                    (complete-with-action action actions string predicate)))
                 nil t)
```
 