### PR TITLE
[lsp-magik] Add LSP client for Magik

### DIFF
--- a/clients/lsp-magik.el
+++ b/clients/lsp-magik.el
@@ -1,0 +1,117 @@
+;;; lsp-magik.el --- Language server client for Magik  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022 Keronic
+
+;; Author: <robin.putters@keronic.com>
+;; Keywords: lsp, magik
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP client for the Magik programming language
+;; https://github.com/StevenLooman/magik-tools
+
+;;; Code:
+
+(require `lsp-mode)
+
+(defgroup lsp-magik nil
+  "LSP support for Magik."
+  :link '(url-link "https://github.com/StevenLooman/magik-tools")
+  :group 'lsp-mode
+  :tag "Lsp Magik"
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-magik-java-home nil
+  "Path to Java Runtime, Java 11 minimum."
+  :type `string
+  :group `lsp-magik
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-magik-smallworld-gis nil
+  "Path to Smallworld Core."
+  :type `string
+  :group `lsp-magik
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-magik-aliases nil
+  "Path to gis_aliases file."
+  :type `string
+  :group `lsp-magik
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-magik-environment nil
+  "Path to environment file."
+  :type `string
+  :group `lsp-magik
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-magik-typing-type-database-paths []
+  "Paths to type databases."
+  :type `lsp-string-vector
+  :group `lsp-magik
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-magik-typing-enable-checks nil
+  "Enable typing checks."
+  :type `boolean
+  :group `lsp-magik
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-magik-trace-server "off"
+  "Traces the communication between VS Code and the Magik language server."
+  :type `(choice (const "off") (const "message") (const "verbose"))
+  :group `lsp-magik
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-magik-java-path (cond ((eq system-type 'windows-nt) "$JAVA_HOME/bin/java")
+                                     (t "java"))
+  "Path of the java executable."
+  :type 'string
+  :group `lsp-magik
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-magik-lsp-path (expand-file-name "magik-lsp/magik-language-server-0.5.1.jar" user-emacs-directory)
+  "Path of the language server."
+  :type 'string
+  :group `lsp-magik
+  :package-version '(lsp-mode . "8.0.1"))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   (lambda ()
+                                     (list
+                                      (substitute-in-file-name lsp-magik-java-path)
+                                      "-jar"
+                                      (substitute-in-file-name lsp-magik-lsp-path)
+                                      "--debug")))
+                  :activation-fn (lsp-activate-on "magik")
+                  :initialized-fn (lambda (workspace)
+                                    (with-lsp-workspace workspace
+                                      (lsp--set-configuration (lsp-configuration-section "magik"))))
+                  :server-id 'magik))
+
+(lsp-register-custom-settings `(("magik.javaHome" lsp-magik-java-home)
+                                ("magik.smallworldGis" lsp-magik-smallworld-gis)
+                                ("magik.aliases" lsp-magik-aliases)
+                                ("magik.environment" lsp-magik-environment)
+                                ("magik.typing.typeDatabasePaths" lsp-magik-typing-type-database-paths)
+                                ("magik.typing.enableChecks" lsp-magik-typing-enable-checks)
+                                ("magik.trace.server" lsp-magik-trace-server)))
+
+(lsp-consistency-check lsp-magik)
+
+(provide 'lsp-magik)
+;;; lsp-magik.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -359,6 +359,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "magik",
+    "full-name": "GE Smallworld Magik",
+    "server-name": "magik-language-server",
+    "server-url": "https://github.com/StevenLooman/magik-tools",
+    "installation": "https://github.com/StevenLooman/magik-tools/releases",
+    "debugger": "Not implemented"
+  },
+  {
     "name": "markdown",
     "full-name": "Markdown",
     "server-name": "unified-language-server (deprecated in favor of remark-language-server)",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -177,9 +177,11 @@ As defined by the Language Server Protocol 3.16."
          lsp-crystal lsp-csharp lsp-css lsp-d lsp-dart lsp-dhall lsp-docker lsp-dockerfile lsp-elm
          lsp-elixir lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript lsp-go lsp-graphql
          lsp-hack lsp-grammarly lsp-groovy lsp-haskell lsp-haxe lsp-java lsp-javascript lsp-json
-         lsp-kotlin lsp-latex lsp-ltex lsp-lua lsp-markdown lsp-nginx lsp-nim lsp-nix lsp-metals lsp-mssql lsp-ocaml lsp-pascal lsp-perl lsp-php lsp-pwsh
-         lsp-pyls lsp-pylsp lsp-pyright lsp-python-ms lsp-purescript lsp-r lsp-remark lsp-rf lsp-rust lsp-solargraph lsp-sorbet lsp-sourcekit lsp-sonarlint
-         lsp-tailwindcss lsp-tex lsp-terraform lsp-toml lsp-ttcn3 lsp-typeprof lsp-v lsp-vala lsp-verilog lsp-vetur lsp-vhdl lsp-vimscript lsp-xml
+         lsp-kotlin lsp-latex lsp-ltex lsp-lua lsp-markdown lsp-nginx lsp-nim lsp-nix lsp-magik
+         lsp-metals lsp-mssql lsp-ocaml lsp-pascal lsp-perl lsp-php lsp-pwsh lsp-pyls lsp-pylsp
+         lsp-pyright lsp-python-ms lsp-purescript lsp-r lsp-remark lsp-rf lsp-rust lsp-solargraph
+         lsp-sorbet lsp-sourcekit lsp-sonarlint lsp-tailwindcss lsp-tex lsp-terraform lsp-toml
+         lsp-ttcn3 lsp-typeprof lsp-v lsp-vala lsp-verilog lsp-vetur lsp-vhdl lsp-vimscript lsp-xml
          lsp-yaml lsp-sqls lsp-svelte lsp-steep lsp-zig)
   "List of the clients to be automatically required."
   :group 'lsp-mode
@@ -812,7 +814,8 @@ Changes take effect only when a new session is started."
                                         (beancount-mode . "beancount")
                                         (conf-toml-mode . "toml")
                                         (org-mode . "org")
-                                        (nginx-mode . "nginx"))
+                                        (nginx-mode . "nginx")
+                                        (magik-mode . "magik"))
   "Language id configuration.")
 
 (defvar lsp--last-active-workspaces nil

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
     - Lua (EmmyLua): page/lsp-emmy-lua.md
     - Lua (Lua Language Server): page/lsp-lua-language-server.md
     - Lua (Lua-Lsp): page/lsp-lua-lsp.md
+    - Magik: page/lsp-magik.md
     - Markdown: page/lsp-markdown.md
     - MSSQL: https://emacs-lsp.github.io/lsp-mssql
     - Nginx: page/lsp-nginx.md


### PR DESCRIPTION
LSP client for the Magik programming language.
LSP server used is https://github.com/StevenLooman/magik-tools 