### PR TITLE
lsp-csharp.el: fix breakage with the latest emacs

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -14,6 +14,7 @@
   * Add [[https://github.com/remarkjs/remark-language-server][remark-language-server]]
   * Deprecate unified-languge-server in favor of remark-language-server
   * Made it possible to disable ~lsp-response-timeout~ entirely.
+  * Fix csharp-ls startup on emacs@master (and emacs@emacs-28 on macOS) due to a switch posix_spawn and not setting proper sigmask on child processes.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -427,10 +427,15 @@ is returned so lsp-mode can display this file."
   ;;
   ;; see https://lists.gnu.org/archive/html/emacs-devel/2022-02/msg00461.html
 
-  (let ((startup-wrapper (pcase system-type
-                           ('gnu/linux (list "/usr/bin/env" "--default-signal"))
-                           ('darwin (list "/bin/ksh" "-c"))
-                           (_ nil)))
+  (let ((startup-wrapper (cond ((and (eq 'darwin system-type)
+                                     (version<= "28.0" emacs-version))
+                                (list "/bin/ksh" "-c"))
+
+                               ((and (eq 'gnu/linux system-type)
+                                     (version<= "29.0" emacs-version))
+                                (list "/usr/bin/env" "--default-signal"))
+
+                               (t nil)))
         (solution-file-params (when lsp-csharp-solution-file
                                 (list "-s" lsp-csharp-solution-file))))
     (append startup-wrapper

--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -442,6 +442,11 @@ is returned so lsp-mode can display this file."
             (list "csharp-ls")
             solution-file-params)))
 
+(defun lsp-csharp--cls-test-csharp-ls-present ()
+  "Return non-nil if dotnet tool csharp-ls is installed globally."
+  (string-match-p "csharp-ls"
+                  (shell-command-to-string "dotnet tool list -g")))
+
 (defun lsp-csharp--cls-download-server (_client callback error-callback update?)
   "Install/update csharp-ls language server using `dotnet tool'.
 
@@ -452,7 +457,8 @@ Will invoke CALLBACK or ERROR-CALLBACK based on result. Will update if UPDATE? i
    "dotnet" "tool" (if update? "update" "install") "-g" "csharp-ls"))
 
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection #'lsp-csharp--cls-make-launch-cmd)
+ (make-lsp-client :new-connection (lsp-stdio-connection #'lsp-csharp--cls-make-launch-cmd
+                                                        #'lsp-csharp--cls-test-csharp-ls-present)
                   :priority -2
                   :server-id 'csharp-ls
                   :major-modes '(csharp-mode csharp-tree-sitter-mode)


### PR DESCRIPTION
See https://lists.gnu.org/archive/html/emacs-devel/2022-02/msg00461.html
for more context.

I will provide a corresponding PR for lsp-fsharp later too.

I didn't hear other runtimes than dotnet experiencing issues with a switch to posix_spawn in emacs, but just FYI -- the latest emacs@master (@emacs-28 on macos too) launches subprocesses with SIGCHLD and other signals masked and unless subprocess fixes it up by itself, that may cause problems.