### PR TITLE
Lsp fsharp installation update

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -17,6 +17,7 @@
   * Fix csharp-ls startup on emacs@master (and emacs@emacs-28 on macOS) due to a switch posix_spawn and not setting proper sigmask on child processes.
   * Fix incorrect ~lsp-fsharp~ defcustom types.
   * Add ~lsp-fsharp-generate-binlog~.
+  * Update installation mechanism for fsautocomplete (lsp-fsharp) to use ~dotnet tool install -g~.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -16,6 +16,7 @@
   * Made it possible to disable ~lsp-response-timeout~ entirely.
   * Fix csharp-ls startup on emacs@master (and emacs@emacs-28 on macOS) due to a switch posix_spawn and not setting proper sigmask on child processes.
   * Fix incorrect ~lsp-fsharp~ defcustom types.
+  * Add ~lsp-fsharp-generate-binlog~.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -18,6 +18,8 @@
   * Fix incorrect ~lsp-fsharp~ defcustom types.
   * Add ~lsp-fsharp-generate-binlog~.
   * Update installation mechanism for fsautocomplete (lsp-fsharp) to use ~dotnet tool install -g~.
+  * Fix fsautocomplete (lsp-fsharp) startup on emacs@master (and emacs@emacs-28 on macOS) due to
+    a switch ~posix_spawn~ and not setting proper sigmask on child processes.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,6 +15,7 @@
   * Deprecate unified-languge-server in favor of remark-language-server
   * Made it possible to disable ~lsp-response-timeout~ entirely.
   * Fix csharp-ls startup on emacs@master (and emacs@emacs-28 on macOS) due to a switch posix_spawn and not setting proper sigmask on child processes.
+  * Fix incorrect ~lsp-fsharp~ defcustom types.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-fsharp.el
+++ b/clients/lsp-fsharp.el
@@ -32,14 +32,6 @@
   :group 'lsp-mode
   :package-version '(lsp-mode . "6.1"))
 
-(defcustom lsp-fsharp-server-runtime 'net-core
-  "The .NET runtime to use."
-  :group 'lsp-fsharp
-  :type '(choice (const :tag "Use .Net Core" net-core)
-                 (const :tag "Use Mono" mono)
-                 (const :tag "Use .Net Framework" net-framework))
-  :package-version '(lsp-mode . "6.1"))
-
 (defcustom lsp-fsharp-server-install-dir (f-join lsp-server-install-dir "fsautocomplete/")
   "Install directory for fsautocomplete server.
 The slash is expected at the end."
@@ -166,86 +158,24 @@ with test projects are not autoloaded by FSharpAutoComplete."
   :type 'boolean
   :package-version '(lsp-mode . "8.0.1"))
 
-(defun lsp-fsharp--fsac-runtime-cmd ()
-  "Get the command required to run fsautocomplete based off of the
-current runtime."
-  (pcase lsp-fsharp-server-runtime
-    ('net-core "dotnet")
-    ('mono "mono")
-    ('net-framework nil)))
+(defun lsp-fsharp--fsac-install (_client callback error-callback update?)
+  "Install/update fsautocomplete language server using `dotnet tool'.
 
-(defun lsp-fsharp--fsac-cmd ()
-  "The location of fsautocomplete executable."
-  (let ((file-ext (if (eq lsp-fsharp-server-runtime 'net-core)
-                      ".dll"
-                    ".exe")))
-    (expand-file-name (concat "fsautocomplete" file-ext) lsp-fsharp-server-install-dir)))
-
-(defun lsp-fsharp--version-list-latest (lst)
-  "Return latest version from LST (if any)."
-  (->> lst
-       (-map (lambda (x) (car (s-split " " x))))
-       (-filter (lambda (x) (> (length x) 0)))
-       (-sort (lambda (a b) (not (version<= (substring a 1)
-                                            (substring b 1)))))
-       cl-first))
-
-(defun lsp-fsharp--fetch-json (url)
-  "Retrieve and parse JSON from URL."
-  (with-temp-buffer
-    (url-insert-file-contents url)
-    (let ((json-false :false))
-      (json-read))))
-
-(defun lsp-fsharp--latest-version-from-github ()
-  "Return latest version of the server available from github."
-   (lsp-fsharp--version-list-latest
-    (seq-map (lambda (elt) (s-trim (cdr (assq 'name elt))))
-             (lsp-fsharp--fetch-json "https://api.github.com/repos/fsharp/FsAutoComplete/releases"))))
-
-(defun lsp-fsharp--server-download-url (version)
-  "Return url for .zip file to download for given VERSION, depending on `lsp-fsharp-server-runtime'."
-  (concat "https://github.com/fsharp/FsAutoComplete/releases/download"
-          "/" version
-          "/" (if (eq lsp-fsharp-server-runtime 'net-core)
-                  "fsautocomplete.netcore.zip"
-                "fsautocomplete.zip")))
-
-(defun lsp-fsharp--change-permissions (install-dir-full)
-  (unless (eq system-type 'windows-nt) ; Windows does not have chmod
-      (lsp--info "Altering permissions")
-      (dolist (file (directory-files-recursively install-dir-full ""))
-	(if (file-directory-p file)
-	    (chmod file #o755)
-	  (chmod file #o644)))
-      (lsp--info "Finished altering permissions")))
-
-(defun lsp-fsharp--fsac-install (_client callback _error-callback _update?)
-  "Download the latest version of fsautocomplete and extract it to `lsp-fsharp-server-install-dir'."
-  (let* ((temp-file (make-temp-file "fsautocomplete" nil ".zip"))
-         (install-dir-full (expand-file-name lsp-fsharp-server-install-dir))
-         (unzip-script (cond ((executable-find "unzip") (format "mkdir -p %s && unzip -qq %s -d %s" install-dir-full temp-file install-dir-full))
-                             ((executable-find "powershell") (format "powershell -noprofile -noninteractive -nologo -ex bypass Expand-Archive -path '%s' -dest '%s'" temp-file install-dir-full))
-                             (t (user-error (format "Unable to unzip server - file %s cannot be extracted, please extract it manually" temp-file)))))
-         (latest-version (lsp-fsharp--latest-version-from-github))
-         (server-download-url (lsp-fsharp--server-download-url latest-version)))
-    (url-copy-file server-download-url temp-file t)
-    (shell-command unzip-script)
-    (lsp-fsharp--change-permissions install-dir-full)
-    (shell-command (format "%s %s --version" (lsp-fsharp--fsac-runtime-cmd) (lsp-fsharp--fsac-cmd)))
-    (funcall callback)))
-
-(defun lsp-fsharp-update-fsac ()
-  "Update fsautocomplete to the latest version."
-  (interactive)
-  (-let [install-dir (f-expand lsp-fsharp-server-install-dir)]
-    (f-delete install-dir t)
-    (lsp-fsharp--fsac-install nil #'ignore #'lsp--error t)))
+Will invoke CALLBACK or ERROR-CALLBACK based on result. Will update if UPDATE? is t"
+  (lsp-async-start-process
+   callback
+   error-callback
+   "dotnet" "tool" (if update? "update" "install") "-g" "fsautocomplete"))
 
 (defun lsp-fsharp--make-launch-cmd ()
   "Build the command required to launch fsautocomplete."
-  (append (list (lsp-fsharp--fsac-runtime-cmd) (lsp-fsharp--fsac-cmd) "--background-service-enabled")
+  (append (list "fsautocomplete" "--background-service-enabled")
           lsp-fsharp-server-args))
+
+(defun lsp-fsharp--test-fsautocomplete-present ()
+  "Return non-nil if dotnet tool fsautocomplete is installed globally."
+  (string-match-p "fsautocomplete"
+                  (shell-command-to-string "dotnet tool list -g")))
 
 (defun lsp-fsharp--project-list ()
   "Get the list of files we need to send to fsharp/workspaceLoad."
@@ -298,7 +228,7 @@ current runtime."
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection
                                    #'lsp-fsharp--make-launch-cmd
-                                   (lambda () (f-exists? (lsp-fsharp--fsac-cmd))))
+                                   #'lsp-fsharp--test-fsautocomplete-present)
                   :major-modes '(fsharp-mode)
                   :notification-handlers (ht ("fsharp/notifyCancel" #'ignore)
                                              ("fsharp/notifyWorkspace" #'ignore)

--- a/clients/lsp-fsharp.el
+++ b/clients/lsp-fsharp.el
@@ -179,6 +179,10 @@ Will invoke CALLBACK or ERROR-CALLBACK based on result. Will update if UPDATE? i
   ;; (on linux) and "/bin/ksh -c" (on macos) so it launches with proper sigmask
   ;;
   ;; see https://lists.gnu.org/archive/html/emacs-devel/2022-02/msg00461.html
+  ;; --
+  ;; we also try to resolve full path to fsautocomplete using `executable-find' as
+  ;; our `startup-wrapper' may use $PATH to interpret the location of fsautocomplete
+  ;; and we want to actually use `exec-path' here
 
   (let ((startup-wrapper (cond ((and (eq 'darwin system-type)
                                      (version<= "28.0" emacs-version))
@@ -188,9 +192,11 @@ Will invoke CALLBACK or ERROR-CALLBACK based on result. Will update if UPDATE? i
                                      (version<= "29.0" emacs-version))
                                 (list "/usr/bin/env" "--default-signal"))
 
-                               (t nil))))
+                               (t nil)))
+        (fsautocomplete-exec (or (executable-find "fsautocomplete")
+                                 "fsautocomplete")))
     (append startup-wrapper
-            (list "fsautocomplete" "--background-service-enabled")
+            (list fsautocomplete-exec "--background-service-enabled")
             lsp-fsharp-server-args)))
 
 (defun lsp-fsharp--test-fsautocomplete-present ()

--- a/clients/lsp-fsharp.el
+++ b/clients/lsp-fsharp.el
@@ -57,27 +57,27 @@ The slash is expected at the end."
 (defcustom lsp-fsharp-keywords-autocomplete t
   "Provides keywords in autocomplete list."
   :group 'lsp-fsharp
-  :type 'bool
+  :type 'boolean
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-fsharp-external-autocomplete nil
   "Provides autocompletion for symbols from not opened namespaces/modules;
 inserts open on accept."
   :group 'lsp-fsharp
-  :type 'bool
+  :type 'boolean
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-fsharp-linter t
   "Enables FSharpLint integration, provides additional warnings and code
 action fixes."
   :group 'lsp-fsharp
-  :type 'bool
+  :type 'boolean
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-fsharp-union-case-stub-generation t
   "Enables a code action to generate pattern matching cases."
   :group 'lsp-fsharp
-  :type 'bool
+  :type 'boolean
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-fsharp-union-case-stub-generation-body "failwith \"Not Implemented\""
@@ -90,7 +90,7 @@ action fixes."
 (defcustom lsp-fsharp-record-stub-generation t
   "Enables code action to generate record stub."
   :group 'lsp-fsharp
-  :type 'bool
+  :type 'boolean
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-fsharp-record-stub-generation-body "failwith \"Not Implemented\""
@@ -103,7 +103,7 @@ action fixes."
 (defcustom lsp-fsharp-interface-stub-generation t
   "Enables code action to generate an interface stub."
   :group 'lsp-fsharp
-  :type 'bool
+  :type 'boolean
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-fsharp-interface-stub-generation-object-identifier "this"
@@ -123,33 +123,33 @@ e.g. `this' or `self'."
 (defcustom lsp-fsharp-unused-opens-analyzer t
   "Enables unused open detection."
   :group 'lsp-fsharp
-  :type 'bool
+  :type 'boolean
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-fsharp-unused-declarations-analyzer t
   "Enables unused symbol detection."
   :group 'lsp-fsharp
-  :type 'bool
+  :type 'boolean
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-fsharp-simplify-name-analyzer nil
   "Enables simplify name analyzer and remove redundant qualifier quick fix."
   :group 'lsp-fsharp
-  :type 'bool
+  :type 'boolean
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-fsharp-resolve-namespaces t
   "Enables resolve namespace quick fix; adds `open' if symbol is from not yet
 opened module/namespace."
   :group 'lsp-fsharp
-  :type 'bool
+  :type 'boolean
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-fsharp-enable-reference-code-lens t
   "Enables reference count code lenses.
-It is recommended to disable if `--backgorund-service-enabled' is not used."
+It is recommended to disable if `--background-service-enabled' is not used."
   :group 'lsp-fsharp
-  :type 'bool
+  :type 'boolean
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-fsharp-auto-workspace-init nil
@@ -157,7 +157,7 @@ It is recommended to disable if `--backgorund-service-enabled' is not used."
 Do note that this can cause unexpected or challenging behaviors, as solutions
 with test projects are not autoloaded by FSharpAutoComplete."
   :group 'lsp-fsharp
-  :type 'bool
+  :type 'boolean
   :risky t)
 
 (defun lsp-fsharp--fsac-runtime-cmd ()

--- a/clients/lsp-fsharp.el
+++ b/clients/lsp-fsharp.el
@@ -160,6 +160,12 @@ with test projects are not autoloaded by FSharpAutoComplete."
   :type 'boolean
   :risky t)
 
+(defcustom lsp-fsharp-generate-binlog nil
+  "Generate a binlog for debugging project cracking."
+  :group 'lsp-fsharp
+  :type 'boolean
+  :package-version '(lsp-mode . "8.0.1"))
+
 (defun lsp-fsharp--fsac-runtime-cmd ()
   "Get the command required to run fsautocomplete based off of the
 current runtime."
@@ -286,7 +292,8 @@ current runtime."
    ("FSharp.UnusedDeclarationsAnalyzer" lsp-fsharp-unused-declarations-analyzer t)
    ("FSharp.SimplifyNameAnalyzer" lsp-fsharp-simplify-name-analyzer t)
    ("FSharp.ResolveNamespaces" lsp-fsharp-resolve-namespaces t)
-   ("FSharp.EnableReferenceCodeLens" lsp-fsharp-enable-reference-code-lens t)))
+   ("FSharp.EnableReferenceCodeLens" lsp-fsharp-enable-reference-code-lens t)
+   ("FSharp.GenerateBinlog" lsp-fsharp-generate-binlog t)))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection


### PR DESCRIPTION
This PR builds on top of https://github.com/emacs-lsp/lsp-mode/pull/3327 by @drvink

- This includes all changes from #3327 sans the startup code changes
- Updates installation mechanism for fsautocomplete as FsAutoComplete has switched to `dotnet tool`-based distribution mechanism completely;
- Provides a workaround for statup on emacs-29 (and emacs-28 on macOS) -- see #3349