### PR TITLE
Support all `initializationOptions` in `typescript-language-server`

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -26,6 +26,7 @@
   * Disable ~lsp-steep-use-bundler~ by default.
   * Add [[https://github.com/idris-community/idris2-lsp][idris2-lsp]]
   * Add [[https://github.com/aca/emmet-ls][emmet-ls]]
+  * Support all ~initializationOptions~ in ~typescript-language-server~
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.


### PR DESCRIPTION
- Adds the following customizable variables:
  - `lsp-clients-typescript-disable-automatic-typing-acquisition`
  - `lsp-clients-typescript-max-ts-server-memory`
  - `lsp-clients-typescript-npm-location`
- Refines the available choices for `lsp-clients-typescript-log-verbosity`
- Renames `lsp-clients-typescript-init-opts` to `lsp-clients-typescript-preferences` to avoid confusion with `initializationOptions`
- Removes passing `tsServerPath` as an `initializationOption` (the option doesn't actually exist, it's handled through command line arguments)

See https://github.com/typescript-language-server/typescript-language-server#initializationoptions