### PR TITLE
Add action-handler for lsp-sql-execute-paragraph

### DIFF
--- a/clients/lsp-sqls.el
+++ b/clients/lsp-sqls.el
@@ -170,7 +170,8 @@ use the current region if set, otherwise the entire buffer."
  (make-lsp-client :new-connection (lsp-stdio-connection #'lsp-sqls--make-launch-cmd)
                   :major-modes '(sql-mode)
                   :priority -1
-                  :action-handlers (ht ("executeQuery" #'lsp-sql-execute-query)
+                  :action-handlers (ht ("executeParagraph" #'lsp-sql-execute-paragraph)
+                                       ("executeQuery" #'lsp-sql-execute-query)
                                        ("showDatabases" #'lsp-sql-show-databases)
                                        ("showSchemas" #'lsp-sql-show-schemas)
                                        ("showConnections" #'lsp-sql-show-connections)


### PR DESCRIPTION
Client lsp-sqls is missing a reference to to `lsp-sql-execute-paragraph` function in [action-handlers](https://github.com/emacs-lsp/lsp-mode/blob/9b3a9215807af0727b514e8c7cf440bcc0bdad44/clients/lsp-sqls.el#L173). This PR tries to fix that.   