### PR TITLE
Add client for Ruby's TypeProf

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,6 +15,7 @@
   * Deprecate unified-languge-server in favor of remark-language-server
   * Made it possible to disable ~lsp-response-timeout~ entirely.
   * Fix csharp-ls startup on emacs@master (and emacs@emacs-28 on macOS) due to a switch posix_spawn and not setting proper sigmask on child processes.
+  * Add TypeProf support.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-typeprof.el
+++ b/clients/lsp-typeprof.el
@@ -1,0 +1,60 @@
+;;; lsp-typeprof.el --- TypeProf server configuration  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022  Taiki Sugawara
+
+;; Author: Taiki Sugawara <buzz.taiki@gmail.com>
+;; Keywords: lsp, ruby
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Client for TypeProf.
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-typeprof nil
+  "LSP support for Ruby, using the TypeProf language server."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/ruby/typeprof")
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-typeprof-use-bundler nil
+  "Run typeprof under bundler."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'lsp-typeprof
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defun lsp-typeprof--build-command ()
+  "Build typeprof command."
+  (let ((lsp-command '("typeprof" "--lsp" "--stdio")))
+    (if lsp-typeprof-use-bundler
+              (append '("bundle" "exec") lsp-command)
+            lsp-command)))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection
+                   #'lsp-typeprof--build-command)
+  :priority -4
+  :major-modes '(ruby-mode enh-ruby-mode)
+  :server-id 'typeprof-ls))
+
+(lsp-consistency-check lsp-typeprof)
+
+(provide 'lsp-typeprof)
+;;; lsp-typeprof.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -689,6 +689,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "typeprof",
+    "full-name": "Ruby (TypeProf)",
+    "server-name": "typeprof",
+    "server-url": "https://github.com/ruby/typeprof",
+    "installation": "It is included in Ruby >= 3.1",
+    "debugger": "Not available"
+  },
+  {
     "name": "v",
     "full-name": "V",
     "server-name": "vls",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -179,7 +179,7 @@ As defined by the Language Server Protocol 3.16."
          lsp-hack lsp-grammarly lsp-groovy lsp-haskell lsp-haxe lsp-java lsp-javascript lsp-json
          lsp-kotlin lsp-latex lsp-ltex lsp-lua lsp-markdown lsp-nginx lsp-nim lsp-nix lsp-metals lsp-mssql lsp-ocaml lsp-pascal lsp-perl lsp-php lsp-pwsh
          lsp-pyls lsp-pylsp lsp-pyright lsp-python-ms lsp-purescript lsp-r lsp-remark lsp-rf lsp-rust lsp-solargraph lsp-sorbet lsp-sourcekit lsp-sonarlint
-         lsp-tailwindcss lsp-tex lsp-terraform lsp-toml lsp-v lsp-vala lsp-verilog lsp-vetur lsp-vhdl lsp-vimscript lsp-xml
+         lsp-tailwindcss lsp-tex lsp-terraform lsp-toml lsp-typeprof lsp-v lsp-vala lsp-verilog lsp-vetur lsp-vhdl lsp-vimscript lsp-xml
          lsp-yaml lsp-sqls lsp-svelte lsp-steep lsp-zig)
   "List of the clients to be automatically required."
   :group 'lsp-mode
@@ -1850,7 +1850,7 @@ regex in IGNORED-FILES."
     lsp-go lsp-graphql lsp-groovy lsp-hack lsp-haxe lsp-html lsp-javascript lsp-json lsp-kotlin lsp-lua
     lsp-markdown lsp-nginx lsp-nim lsp-nix lsp-ocaml lsp-perl lsp-php lsp-prolog lsp-purescript lsp-pwsh
     lsp-pyls lsp-pylsp lsp-racket lsp-r lsp-rf lsp-rust lsp-solargraph lsp-sorbet lsp-sqls
-    lsp-steep lsp-svelte lsp-terraform lsp-tex lsp-toml lsp-v lsp-vala lsp-verilog lsp-vetur lsp-vhdl
+    lsp-steep lsp-svelte lsp-terraform lsp-tex lsp-toml lsp-typeprof lsp-v lsp-vala lsp-verilog lsp-vetur lsp-vhdl
     lsp-vimscript lsp-xml lsp-yaml lsp-zig)
   "List of downstream deps.")
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
     - Racket (jeapostrophe): page/lsp-racket-langserver.md
     - Racket (Theia): page/lsp-racket-language-server.md
     - Ruby: page/lsp-solargraph.md
+    - Ruby: page/lsp-typeprof.md
     - Rust (rust-analyzer): page/lsp-rust-analyzer.md
     - Rust (rls): page/lsp-rust-rls.md
     - Scala: https://emacs-lsp.github.io/lsp-metals


### PR DESCRIPTION
Add `lsp-typeprof` using https://github.com/ruby/typeprof.