### PR TITLE
make fsautocomplete working without change user config

### DIFF
--- a/clients/lsp-fsharp.el
+++ b/clients/lsp-fsharp.el
@@ -194,7 +194,8 @@ Will invoke CALLBACK or ERROR-CALLBACK based on result. Will update if UPDATE? i
 
                                (t nil)))
         (fsautocomplete-exec (or (executable-find "fsautocomplete")
-                                 "fsautocomplete")))
+                                 (f-join (or (getenv "USERPROFILE") (getenv "HOME"))
+                                         ".dotnet" "tools" "fsautocomplete"))))
     (append startup-wrapper
             (list fsautocomplete-exec "--background-service-enabled")
             lsp-fsharp-server-args)))


### PR DESCRIPTION
There is no need to force user update their configuration if we already know where to find executable.

@razzmatazz 

Relates #3350 