### PR TITLE
Disable lsp-steep-use-bundler by default

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -21,6 +21,7 @@
   * Fix fsautocomplete (lsp-fsharp) startup on emacs@master (and emacs@emacs-28 on macOS) due to
     a switch ~posix_spawn~ and not setting proper sigmask on child processes.
   * Add TypeProf support.
+  * Disable ~lsp-steep-use-bundler~ by default.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-steep.el
+++ b/clients/lsp-steep.el
@@ -41,7 +41,7 @@
           (const "debug"))
   :group 'lsp-steep)
 
-(defcustom lsp-steep-use-bundler t
+(defcustom lsp-steep-use-bundler nil
   "Run Steep using Bunder."
   :type 'boolean
   :safe #'booleanp


### PR DESCRIPTION
When `lsp-steep-use-bundler` is `non-nil`, `lsp-steep` is enabled even so `steep` command does not exists, because a first value of `lsp-steep--build-command` is `bundle` instead of `steep`. I think this is not default behavior.

https://github.com/emacs-lsp/lsp-mode/blob/cf87368054f32f9ecd3960f79f0815fbf97d798b/clients/lsp-steep.el#L57-L61