### PR TITLE
Fix `lsp-rust-analyzer-debug` hangs with long running processes

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1036,7 +1036,7 @@ and run a compilation"
   (-let (((&rust-analyzer:Runnable
            :args (&rust-analyzer:RunnableArgs :cargo-args :workspace-root? :executable-args)
            :label) runnable))
-    (cl-case (aref cargo-args 0)
+    (pcase (aref cargo-args 0)
       ("run" (aset cargo-args 0 "build"))
       ("test" (when (-contains? (append cargo-args ()) "--no-run")
                 (cl-callf append cargo-args (list "--no-run")))))


### PR DESCRIPTION
Calling this function `lsp-rust-analyzer-debug` to debug apps with long running processes, e.g. when debugging a web server, causes this function to hang due to `cargo run` being called here instead of `cargo build` as intended.

The use of `cl-case` here is inappropriate for string values because it uses `eql` according to the [docs](https://www.gnu.org/software/emacs/manual/html_node/elisp/Pattern_002dMatching-Conditional.html). Updating this line to use `pcase` fixes this issue.