### PR TITLE
Add emmet-ls support

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -25,6 +25,7 @@
   * Add Ansible support.
   * Disable ~lsp-steep-use-bundler~ by default.
   * Add [[https://github.com/idris-community/idris2-lsp][idris2-lsp]]
+  * Add [[https://github.com/aca/emmet-ls][emmet-ls]]
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-emmet.el
+++ b/clients/lsp-emmet.el
@@ -1,0 +1,65 @@
+;;; lsp-emmet.el --- lsp-mode Emmet integration -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022 emacs-lsp maintainers
+
+;; Author: lsp-mode maintainers
+;; Keywords: lsp, emmet
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP Client for Emmet
+
+;;; Code:
+
+(require 'lsp-mode)
+
+;;; emmet-ls
+(defgroup lsp-emmet-ls nil
+  "Settings for emmet-ls."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/aca/emmet-ls")
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-emmet-ls-command '("emmet-ls" "--stdio")
+  "The command that starts emmet-ls."
+  :type '(repeat :tag "List of string values" string)
+  :group 'lsp-emmet-ls
+  :package-version '(lsp-mode . "8.0.1"))
+
+(lsp-dependency 'emmet-ls
+                '(:system "emmet-ls")
+                '(:npm :package "emmet-ls"
+                       :path "emmet-ls"))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection
+                   (lambda ()
+                     `(,(or (executable-find (cl-first lsp-emmet-ls-command))
+                            (lsp-package-path 'emmet-ls))
+                       ,@(cl-rest lsp-emmet-ls-command))))
+  :activation-fn (lsp-activate-on "html" "css" "scss" "less" "javascriptreact" "typescriptreact")
+  :priority -1
+  :add-on? t
+  :multi-root t
+  :server-id 'emmet-ls
+  :download-server-fn (lambda (_client callback error-callback _update?)
+                        (lsp-package-ensure 'emmet-ls callback error-callback))))
+
+(lsp-consistency-check lsp-emmet)
+
+(provide 'lsp-emmet)
+;;; lsp-emmet.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -167,6 +167,15 @@
     "debugger": "Not available"
   },
   {
+    "name": "emmet",
+    "full-name": "Emmet",
+    "server-name": "emmet-ls",
+    "server-url": "https://github.com/aca/emmet-ls",
+    "installation": "npm i -g emmet-ls",
+    "lsp-install-server": "emmet-ls",
+    "debugger": "Not available"
+  },
+  {
     "name": "erlang",
     "full-name": "Erlang",
     "server-name": "erlang_ls",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -175,13 +175,13 @@ As defined by the Language Server Protocol 3.16."
 (defcustom lsp-client-packages
   '(ccls lsp-actionscript lsp-ada lsp-angular lsp-ansible lsp-bash lsp-beancount lsp-clangd lsp-clojure
          lsp-cmake lsp-crystal lsp-csharp lsp-css lsp-d lsp-dart lsp-dhall lsp-docker lsp-dockerfile
-         lsp-elm lsp-elixir lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript lsp-go lsp-graphql
-         lsp-hack lsp-grammarly lsp-groovy lsp-haskell lsp-haxe lsp-idris lsp-java lsp-javascript lsp-json
-         lsp-kotlin lsp-latex lsp-ltex lsp-lua lsp-markdown lsp-nginx lsp-nim lsp-nix lsp-magik
+         lsp-elm lsp-elixir lsp-emmet lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript lsp-go
+         lsp-graphql lsp-hack lsp-grammarly lsp-groovy lsp-haskell lsp-haxe lsp-idris lsp-java lsp-javascript
+         lsp-json lsp-kotlin lsp-latex lsp-ltex lsp-lua lsp-markdown lsp-nginx lsp-nim lsp-nix lsp-magik
          lsp-metals lsp-mssql lsp-ocaml lsp-pascal lsp-perl lsp-php lsp-pwsh lsp-pyls lsp-pylsp
          lsp-pyright lsp-python-ms lsp-purescript lsp-r lsp-remark lsp-rf lsp-rust lsp-solargraph
          lsp-sorbet lsp-sourcekit lsp-sonarlint lsp-tailwindcss lsp-tex lsp-terraform lsp-toml
-         lsp-ttcn3 lsp-typeprof lsp-v lsp-vala lsp-verilog lsp-vetur lsp-volar lsp-vhdl lsp-vimscript 
+         lsp-ttcn3 lsp-typeprof lsp-v lsp-vala lsp-verilog lsp-vetur lsp-volar lsp-vhdl lsp-vimscript
          lsp-xml lsp-yaml lsp-sqls lsp-svelte lsp-steep lsp-zig)
   "List of the clients to be automatically required."
   :group 'lsp-mode

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
     - Dockerfile: page/lsp-dockerfile.md
     - Elixir: page/lsp-elixir.md
     - Elm: page/lsp-elm.md
+    - Emmet: page/lsp-emmet.md
     - Erlang: page/lsp-erlang.md
     - Eslint: page/lsp-eslint.md
     - F#: page/lsp-fsharp.md


### PR DESCRIPTION
Implements #3381.

Add [emmet-ls](https://github.com/aca/emmet-ls) support.