### PR TITLE
Update support for rust-analyzer's inlay hints

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -27,6 +27,7 @@
   * Add [[https://github.com/idris-community/idris2-lsp][idris2-lsp]]
   * Add [[https://github.com/aca/emmet-ls][emmet-ls]]
   * Support all ~initializationOptions~ in ~typescript-language-server~
+  * Update rust-analyzer's inlay hint protocol support.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -933,9 +933,8 @@ meaning."
          (dolist (hint res)
            (-let* (((&rust-analyzer:InlayHint :position :label :kind :padding-left :padding-right) hint)
                    (pos (lsp--position-to-point position))
-                   (overlay (make-overlay pos (+ pos 1) nil 'front-advance 'end-advance)))
+                   (overlay (make-overlay pos pos nil 'front-advance 'end-advance)))
              (overlay-put overlay 'lsp-rust-analyzer-inlay-hint t)
-             (overlay-put overlay 'evaporate t)
              (overlay-put overlay 'before-string
                           (format "%s%s%s"
                                   (if padding-left " " "")

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -850,7 +850,7 @@ https://rust-analyzer.github.io/manual.html#auto-import.
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.0"))
 
-(defcustom lsp-rust-analyzer-inlay-type-format ": %s"
+(defcustom lsp-rust-analyzer-inlay-type-format "%s"
   "Format string for variable inlays (part of the inlay face)."
   :type '(string :tag "String")
   :group 'lsp-rust-analyzer
@@ -869,7 +869,7 @@ https://rust-analyzer.github.io/manual.html#auto-import.
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.0"))
 
-(defcustom lsp-rust-analyzer-inlay-param-format "%s:"
+(defcustom lsp-rust-analyzer-inlay-param-format "%s"
   "Format string for parameter inlays (part of the inlay face)."
   :type '(string :tag "String")
   :group 'lsp-rust-analyzer
@@ -910,20 +910,20 @@ meaning."
   (if (and (lsp-rust-analyzer-initialized?)
            (eq buffer (current-buffer)))
       (lsp-request-async
-       "rust-analyzer/inlayHints"
+       "experimental/inlayHints"
        (lsp-make-rust-analyzer-inlay-hints-params
         :text-document (lsp--text-document-identifier))
        (lambda (res)
          (remove-overlays (point-min) (point-max) 'lsp-rust-analyzer-inlay-hint t)
          (dolist (hint res)
-           (-let* (((&rust-analyzer:InlayHint :range :label :kind) hint)
-                   ((&RangeToPoint :start :end) range)
-                   (overlay (make-overlay start end nil 'front-advance 'end-advance)))
+           (-let* (((&rust-analyzer:InlayHint :position :label :kind) hint)
+                   (pos (lsp--position-to-point position))
+                   (overlay (make-overlay pos (+ pos 1) nil 'front-advance 'end-advance)))
              (overlay-put overlay 'lsp-rust-analyzer-inlay-hint t)
              (overlay-put overlay 'evaporate t)
              (cond
               ((equal kind lsp/rust-analyzer-inlay-hint-kind-type-hint)
-               (overlay-put overlay 'after-string
+               (overlay-put overlay 'before-string
                             (format lsp-rust-analyzer-inlay-type-space-format
                                     (propertize (format lsp-rust-analyzer-inlay-type-format label)
                                                 'font-lock-face 'lsp-rust-analyzer-inlay-type-face))))
@@ -935,7 +935,7 @@ meaning."
                                                 'font-lock-face 'lsp-rust-analyzer-inlay-param-face))))
 
               ((equal kind lsp/rust-analyzer-inlay-hint-kind-chaining-hint)
-               (overlay-put overlay 'after-string
+               (overlay-put overlay 'before-string
                             (format lsp-rust-analyzer-inlay-chain-space-format
                                     (propertize (format lsp-rust-analyzer-inlay-chain-format label)
                                                 'font-lock-face 'lsp-rust-analyzer-inlay-chain-face))))))))

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -361,7 +361,8 @@ PARAMS progress report notification data."
   :package-version '(lsp-mode . "6.2.2"))
 
 (defcustom lsp-rust-analyzer-display-chaining-hints nil
-  "Whether to show inlay type hints for method chains."
+  "Whether to show inlay type hints for method chains.  These hints will be
+formatted with the type hint formatting options."
   :type 'boolean
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "6.2.2"))
@@ -665,7 +666,8 @@ https://rust-analyzer.github.io/manual.html#auto-import.
             :unsetTest ,lsp-rust-analyzer-cargo-unset-test)
     :rustfmt (:extraArgs ,lsp-rust-analyzer-rustfmt-extra-args
               :overrideCommand ,lsp-rust-analyzer-rustfmt-override-command)
-    :inlayHints (:typeHints ,(lsp-json-bool lsp-rust-analyzer-server-display-inlay-hints)
+    :inlayHints (:renderColons ,(lsp-json-bool nil)
+                 :typeHints ,(lsp-json-bool lsp-rust-analyzer-server-display-inlay-hints)
                  :chainingHints ,(lsp-json-bool lsp-rust-analyzer-display-chaining-hints)
                  :parameterHints ,(lsp-json-bool lsp-rust-analyzer-display-parameter-hints)
                  :maxLength ,lsp-rust-analyzer-max-inlay-hint-length)
@@ -850,7 +852,7 @@ https://rust-analyzer.github.io/manual.html#auto-import.
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.0"))
 
-(defcustom lsp-rust-analyzer-inlay-type-format "%s"
+(defcustom lsp-rust-analyzer-inlay-type-format ": %s"
   "Format string for variable inlays (part of the inlay face)."
   :type '(string :tag "String")
   :group 'lsp-rust-analyzer
@@ -869,26 +871,8 @@ https://rust-analyzer.github.io/manual.html#auto-import.
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.0"))
 
-(defcustom lsp-rust-analyzer-inlay-param-format "%s"
+(defcustom lsp-rust-analyzer-inlay-param-format "%s:"
   "Format string for parameter inlays (part of the inlay face)."
-  :type '(string :tag "String")
-  :group 'lsp-rust-analyzer
-  :package-version '(lsp-mode . "8.0.0"))
-
-(defface lsp-rust-analyzer-inlay-chain-face
-  '((t :inherit lsp-rust-analyzer-inlay-face))
-  "Face for inlay chaining hints (e.g. inferred chain intermediate types)."
-  :group 'lsp-rust-analyzer
-  :package-version '(lsp-mode . "8.0.0"))
-
-(defcustom lsp-rust-analyzer-inlay-chain-space-format "%s"
-  "Format string for spacing around chain inlays (not part of the inlay face)."
-  :type '(string :tag "String")
-  :group 'lsp-rust-analyzer
-  :package-version '(lsp-mode . "8.0.0"))
-
-(defcustom lsp-rust-analyzer-inlay-chain-format ": %s"
-  "Format string for chain inlays (part of the inlay face)."
   :type '(string :tag "String")
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.0"))
@@ -932,13 +916,7 @@ meaning."
                (overlay-put overlay 'before-string
                             (format lsp-rust-analyzer-inlay-param-space-format
                                     (propertize (format lsp-rust-analyzer-inlay-param-format label)
-                                                'font-lock-face 'lsp-rust-analyzer-inlay-param-face))))
-
-              ((equal kind lsp/rust-analyzer-inlay-hint-kind-chaining-hint)
-               (overlay-put overlay 'before-string
-                            (format lsp-rust-analyzer-inlay-chain-space-format
-                                    (propertize (format lsp-rust-analyzer-inlay-chain-format label)
-                                                'font-lock-face 'lsp-rust-analyzer-inlay-chain-face))))))))
+                                                'font-lock-face 'lsp-rust-analyzer-inlay-param-face))))))))
        :mode 'tick))
   nil)
 

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -342,6 +342,13 @@ PARAMS progress report notification data."
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "6.2"))
 
+(defcustom lsp-rust-analyzer-server-format-inlay-hints t
+  "Whether to ask rust-analyzer to format inlay hints itself.  If
+active, the various inlay format settings are not used."
+  :type 'boolean
+  :group 'lsp-rust-analyzer
+  :package-version '(lsp-mode . "8.0.1"))
+
 (defcustom lsp-rust-analyzer-server-display-inlay-hints nil
   "Show inlay hints."
   :type 'boolean
@@ -354,18 +361,41 @@ PARAMS progress report notification data."
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "6.2.2"))
 
+(defcustom lsp-rust-analyzer-display-chaining-hints nil
+  "Whether to show inlay type hints for method chains.  These
+hints will be formatted with the type hint formatting options, if
+the mode is not configured to ask the server to format them."
+  :type 'boolean
+  :group 'lsp-rust-analyzer
+  :package-version '(lsp-mode . "6.2.2"))
+
+(defcustom lsp-rust-analyzer-display-lifetime-elision-hints "never"
+  "Whether to show elided lifetime inlay hints."
+  :type '(choice
+          (const "never")
+          (const "always")
+          (const "skip_trivial"))
+  :group 'lsp-rust-analyzer
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-rust-analyzer-display-closure-return-type-hints nil
+  "Whether to show closure return type inlay hints for closures
+with block bodies."
+  :type 'boolean
+  :group 'lsp-rust-analyzer
+  :package-version '(lsp-mode . "8.0.1"))
+
 (defcustom lsp-rust-analyzer-display-parameter-hints nil
   "Whether to show function parameter name inlay hints at the call site."
   :type 'boolean
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "6.2.2"))
 
-(defcustom lsp-rust-analyzer-display-chaining-hints nil
-  "Whether to show inlay type hints for method chains.  These hints will be
-formatted with the type hint formatting options."
+(defcustom lsp-rust-analyzer-display-reborrow-hints nil
+  "Whether to show reborrowing inlay hints."
   :type 'boolean
   :group 'lsp-rust-analyzer
-  :package-version '(lsp-mode . "6.2.2"))
+  :package-version '(lsp-mode . "8.0.1"))
 
 (defcustom lsp-rust-analyzer-lru-capacity nil
   "Number of syntax trees rust-analyzer keeps in memory."
@@ -666,10 +696,13 @@ https://rust-analyzer.github.io/manual.html#auto-import.
             :unsetTest ,lsp-rust-analyzer-cargo-unset-test)
     :rustfmt (:extraArgs ,lsp-rust-analyzer-rustfmt-extra-args
               :overrideCommand ,lsp-rust-analyzer-rustfmt-override-command)
-    :inlayHints (:renderColons ,(lsp-json-bool nil)
+    :inlayHints (:renderColons ,(lsp-json-bool lsp-rust-analyzer-server-format-inlay-hints)
                  :typeHints ,(lsp-json-bool lsp-rust-analyzer-server-display-inlay-hints)
                  :chainingHints ,(lsp-json-bool lsp-rust-analyzer-display-chaining-hints)
+                 :closureReturnTypeHints ,(lsp-json-bool lsp-rust-analyzer-display-closure-return-type-hints)
+                 :lifetimeElisionHints ,lsp-rust-analyzer-display-lifetime-elision-hints
                  :parameterHints ,(lsp-json-bool lsp-rust-analyzer-display-parameter-hints)
+                 :reborrowHints ,(lsp-json-bool lsp-rust-analyzer-display-reborrow-hints)
                  :maxLength ,lsp-rust-analyzer-max-inlay-hint-length)
     :completion (:addCallParenthesis ,(lsp-json-bool lsp-rust-analyzer-completion-add-call-parenthesis)
                  :addCallArgumentSnippets ,(lsp-json-bool lsp-rust-analyzer-completion-add-call-argument-snippets)
@@ -846,14 +879,17 @@ https://rust-analyzer.github.io/manual.html#auto-import.
   :package-version '(lsp-mode . "8.0.0"))
 
 (defcustom lsp-rust-analyzer-inlay-type-space-format "%s"
-  "Format string for spacing around variable inlays
-\(not part of the inlay face)."
+  "Format string for spacing around variable inlays \(not part of
+the inlay face, used whether or not
+lsp-rust-analyzer-server-format-inlay-hints is non-nil)."
   :type '(string :tag "String")
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.0"))
 
 (defcustom lsp-rust-analyzer-inlay-type-format ": %s"
-  "Format string for variable inlays (part of the inlay face)."
+  "Format string for variable inlays (part of the inlay face,
+used only if lsp-rust-analyzer-server-format-inlay-hints is
+non-nil)."
   :type '(string :tag "String")
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.0"))
@@ -865,17 +901,42 @@ https://rust-analyzer.github.io/manual.html#auto-import.
   :package-version '(lsp-mode . "8.0.0"))
 
 (defcustom lsp-rust-analyzer-inlay-param-space-format "%s "
-  "Format string for spacing around parameter inlays
-\(not part of the inlay face)."
+  "Format string for spacing around parameter inlays \(not part
+of the inlay face, used whether or not
+lsp-rust-analyzer-server-format-inlay-hints is non-nil)."
   :type '(string :tag "String")
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.0"))
 
 (defcustom lsp-rust-analyzer-inlay-param-format "%s:"
-  "Format string for parameter inlays (part of the inlay face)."
+  "Format string for parameter inlays (part of the inlay face,
+used only if lsp-rust-analyzer-server-format-inlay-hints is
+non-nil)."
   :type '(string :tag "String")
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.0"))
+
+(defface lsp-rust-analyzer-inlay-nonstandard-face
+  '((t :inherit lsp-rust-analyzer-inlay-face))
+  "Face for non-standard inlay hints (e.g. reborrow hints)."
+  :group 'lsp-rust-analyzer
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-rust-analyzer-inlay-nonstandard-space-format "%s"
+  "Format string for spacing around non-standard inlays \(not part
+of the inlay face, used whether or not
+lsp-rust-analyzer-server-format-inlay-hints is non-nil)."
+  :type '(string :tag "String")
+  :group 'lsp-rust-analyzer
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-rust-analyzer-inlay-nonstandard-format "%s"
+  "Format string for non-standard inlays (part of the inlay face,
+used only if lsp-rust-analyzer-server-format-inlay-hints is
+non-nil)."
+  :type '(string :tag "String")
+  :group 'lsp-rust-analyzer
+  :package-version '(lsp-mode . "8.0.1"))
 
 (defcustom lsp-rust-analyzer-debug-lens-extra-dap-args
   '(:MIMode "gdb" :miDebuggerPath "gdb" :stopAtEntry t :externalConsole :json-false)
@@ -900,23 +961,35 @@ meaning."
        (lambda (res)
          (remove-overlays (point-min) (point-max) 'lsp-rust-analyzer-inlay-hint t)
          (dolist (hint res)
-           (-let* (((&rust-analyzer:InlayHint :position :label :kind) hint)
+           (-let* (((&rust-analyzer:InlayHint :position :label :kind :padding-left :padding-right) hint)
                    (pos (lsp--position-to-point position))
                    (overlay (make-overlay pos (+ pos 1) nil 'front-advance 'end-advance)))
              (overlay-put overlay 'lsp-rust-analyzer-inlay-hint t)
              (overlay-put overlay 'evaporate t)
-             (cond
-              ((equal kind lsp/rust-analyzer-inlay-hint-kind-type-hint)
-               (overlay-put overlay 'before-string
-                            (format lsp-rust-analyzer-inlay-type-space-format
-                                    (propertize (format lsp-rust-analyzer-inlay-type-format label)
-                                                'font-lock-face 'lsp-rust-analyzer-inlay-type-face))))
+             (if lsp-rust-analyzer-server-format-inlay-hints
+                 (overlay-put overlay 'before-string
+                              (format "%s%s%s"
+                                      (if padding-left " " "")
+                                      (propertize label 'font-lock-face 'lsp-rust-analyzer-inlay-face)
+                                      (if padding-right " " "")))
+               (cond
+                ((equal kind lsp/rust-analyzer-inlay-hint-kind-type-hint)
+                 (overlay-put overlay 'before-string
+                              (format lsp-rust-analyzer-inlay-type-space-format
+                                      (propertize (format lsp-rust-analyzer-inlay-type-format label)
+                                                  'font-lock-face 'lsp-rust-analyzer-inlay-type-face))))
 
-              ((equal kind lsp/rust-analyzer-inlay-hint-kind-param-hint)
-               (overlay-put overlay 'before-string
-                            (format lsp-rust-analyzer-inlay-param-space-format
-                                    (propertize (format lsp-rust-analyzer-inlay-param-format label)
-                                                'font-lock-face 'lsp-rust-analyzer-inlay-param-face))))))))
+                ((equal kind lsp/rust-analyzer-inlay-hint-kind-param-hint)
+                 (overlay-put overlay 'before-string
+                              (format lsp-rust-analyzer-inlay-param-space-format
+                                      (propertize (format lsp-rust-analyzer-inlay-param-format label)
+                                                  'font-lock-face 'lsp-rust-analyzer-inlay-param-face))))
+
+                ((equal kind lsp/rust-analyzer-inlay-hint-kind-nonstandard-hint)
+                 (overlay-put overlay 'before-string
+                              (format lsp-rust-analyzer-inlay-nonstandard-space-format
+                                      (propertize (format lsp-rust-analyzer-inlay-nonstandard-format label)
+                                                  'font-lock-face 'lsp-rust-analyzer-inlay-nonstandard-face)))))))))
        :mode 'tick))
   nil)
 

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -369,12 +369,19 @@ the mode is not configured to ask the server to format them."
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "6.2.2"))
 
-(defcustom lsp-rust-analyzer-display-lifetime-elision-hints "never"
+(defcustom lsp-rust-analyzer-display-lifetime-elision-hints-enable "never"
   "Whether to show elided lifetime inlay hints."
   :type '(choice
           (const "never")
           (const "always")
           (const "skip_trivial"))
+  :group 'lsp-rust-analyzer
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-rust-analyzer-display-lifetime-elision-hints-use-parameter-names nil
+  "When showing elided lifetime inlay hints, whether to use
+parameter names or numeric placeholder names for the lifetimes."
+  :type 'boolean
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.1"))
 
@@ -700,7 +707,8 @@ https://rust-analyzer.github.io/manual.html#auto-import.
                  :typeHints ,(lsp-json-bool lsp-rust-analyzer-server-display-inlay-hints)
                  :chainingHints ,(lsp-json-bool lsp-rust-analyzer-display-chaining-hints)
                  :closureReturnTypeHints ,(lsp-json-bool lsp-rust-analyzer-display-closure-return-type-hints)
-                 :lifetimeElisionHints ,lsp-rust-analyzer-display-lifetime-elision-hints
+                 :lifetimeElisionHints (:enable ,lsp-rust-analyzer-display-lifetime-elision-hints-enable
+                                        :useParameterNames ,(lsp-json-bool lsp-rust-analyzer-display-lifetime-elision-hints-use-parameter-names))
                  :parameterHints ,(lsp-json-bool lsp-rust-analyzer-display-parameter-hints)
                  :reborrowHints ,(lsp-json-bool lsp-rust-analyzer-display-reborrow-hints)
                  :maxLength ,lsp-rust-analyzer-max-inlay-hint-length)

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -878,14 +878,6 @@ https://rust-analyzer.github.io/manual.html#auto-import.
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.0"))
 
-(defcustom lsp-rust-analyzer-inlay-type-space-format "%s"
-  "Format string for spacing around variable inlays \(not part of
-the inlay face, used whether or not
-lsp-rust-analyzer-server-format-inlay-hints is non-nil)."
-  :type '(string :tag "String")
-  :group 'lsp-rust-analyzer
-  :package-version '(lsp-mode . "8.0.0"))
-
 (defcustom lsp-rust-analyzer-inlay-type-format ": %s"
   "Format string for variable inlays (part of the inlay face,
 used only if lsp-rust-analyzer-server-format-inlay-hints is
@@ -900,14 +892,6 @@ non-nil)."
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.0"))
 
-(defcustom lsp-rust-analyzer-inlay-param-space-format "%s "
-  "Format string for spacing around parameter inlays \(not part
-of the inlay face, used whether or not
-lsp-rust-analyzer-server-format-inlay-hints is non-nil)."
-  :type '(string :tag "String")
-  :group 'lsp-rust-analyzer
-  :package-version '(lsp-mode . "8.0.0"))
-
 (defcustom lsp-rust-analyzer-inlay-param-format "%s:"
   "Format string for parameter inlays (part of the inlay face,
 used only if lsp-rust-analyzer-server-format-inlay-hints is
@@ -915,28 +899,6 @@ non-nil)."
   :type '(string :tag "String")
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.0"))
-
-(defface lsp-rust-analyzer-inlay-nonstandard-face
-  '((t :inherit lsp-rust-analyzer-inlay-face))
-  "Face for non-standard inlay hints (e.g. reborrow hints)."
-  :group 'lsp-rust-analyzer
-  :package-version '(lsp-mode . "8.0.1"))
-
-(defcustom lsp-rust-analyzer-inlay-nonstandard-space-format "%s"
-  "Format string for spacing around non-standard inlays \(not part
-of the inlay face, used whether or not
-lsp-rust-analyzer-server-format-inlay-hints is non-nil)."
-  :type '(string :tag "String")
-  :group 'lsp-rust-analyzer
-  :package-version '(lsp-mode . "8.0.1"))
-
-(defcustom lsp-rust-analyzer-inlay-nonstandard-format "%s"
-  "Format string for non-standard inlays (part of the inlay face,
-used only if lsp-rust-analyzer-server-format-inlay-hints is
-non-nil)."
-  :type '(string :tag "String")
-  :group 'lsp-rust-analyzer
-  :package-version '(lsp-mode . "8.0.1"))
 
 (defcustom lsp-rust-analyzer-debug-lens-extra-dap-args
   '(:MIMode "gdb" :miDebuggerPath "gdb" :stopAtEntry t :externalConsole :json-false)
@@ -966,32 +928,28 @@ meaning."
                    (overlay (make-overlay pos (+ pos 1) nil 'front-advance 'end-advance)))
              (overlay-put overlay 'lsp-rust-analyzer-inlay-hint t)
              (overlay-put overlay 'evaporate t)
-             (if lsp-rust-analyzer-server-format-inlay-hints
-                 (overlay-put overlay 'before-string
-                              (format "%s%s%s"
-                                      (if padding-left " " "")
-                                      (propertize label 'font-lock-face 'lsp-rust-analyzer-inlay-face)
-                                      (if padding-right " " "")))
-               (cond
-                ((equal kind lsp/rust-analyzer-inlay-hint-kind-type-hint)
-                 (overlay-put overlay 'before-string
-                              (format lsp-rust-analyzer-inlay-type-space-format
-                                      (propertize (format lsp-rust-analyzer-inlay-type-format label)
-                                                  'font-lock-face 'lsp-rust-analyzer-inlay-type-face))))
-
-                ((equal kind lsp/rust-analyzer-inlay-hint-kind-param-hint)
-                 (overlay-put overlay 'before-string
-                              (format lsp-rust-analyzer-inlay-param-space-format
-                                      (propertize (format lsp-rust-analyzer-inlay-param-format label)
-                                                  'font-lock-face 'lsp-rust-analyzer-inlay-param-face))))
-
-                ((equal kind lsp/rust-analyzer-inlay-hint-kind-nonstandard-hint)
-                 (overlay-put overlay 'before-string
-                              (format lsp-rust-analyzer-inlay-nonstandard-space-format
-                                      (propertize (format lsp-rust-analyzer-inlay-nonstandard-format label)
-                                                  'font-lock-face 'lsp-rust-analyzer-inlay-nonstandard-face)))))))))
+             (overlay-put overlay 'before-string
+                          (format "%s%s%s"
+                                  (if padding-left " " "")
+                                  (propertize (lsp-rust-analyzer-format-inlay label kind)
+                                              'font-lock-face (lsp-rust-analyzer-face-for-inlay kind))
+                                  (if padding-right " " ""))))))
        :mode 'tick))
   nil)
+
+(defun lsp-rust-analyzer-format-inlay (label kind)
+  (if lsp-rust-analyzer-server-format-inlay-hints
+      label
+    (cond
+     ((eql kind lsp/rust-analyzer-inlay-hint-kind-type-hint) (format lsp-rust-analyzer-inlay-type-format label))
+     ((eql kind lsp/rust-analyzer-inlay-hint-kind-type-hint) (format lsp-rust-analyzer-inlay-param-format label))
+     (t label))))
+
+(defun lsp-rust-analyzer-face-for-inlay (kind)
+  (cond
+   ((eql kind lsp/rust-analyzer-inlay-hint-kind-type-hint) 'lsp-rust-analyzer-inlay-type-face)
+   ((eql kind lsp/rust-analyzer-inlay-hint-kind-type-hint) 'lsp-rust-analyzer-inlay-param-face)
+   (t 'lsp-rust-analyzer-inlay-face)))
 
 (defun lsp-rust-analyzer-initialized? ()
   (when-let ((workspace (lsp-find-workspace 'rust-analyzer (buffer-file-name))))

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -399,7 +399,6 @@ See `-let' for a description of the destructuring mechanism."
 
 (defconst lsp/rust-analyzer-inlay-hint-kind-type-hint 1)
 (defconst lsp/rust-analyzer-inlay-hint-kind-param-hint 2)
-(defconst lsp/rust-analyzer-inlay-hint-kind-chaining-hint nil)
 (lsp-interface (rust-analyzer:AnalyzerStatusParams (:textDocument))
                (rust-analyzer:SyntaxTreeParams (:textDocument) (:range))
                (rust-analyzer:ExpandMacroParams (:textDocument :position) nil)

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -397,9 +397,9 @@ See `-let' for a description of the destructuring mechanism."
 
 (lsp-interface (rls:Cmd (:args :binary :env :cwd) nil))
 
-(defconst lsp/rust-analyzer-inlay-hint-kind-type-hint "TypeHint")
-(defconst lsp/rust-analyzer-inlay-hint-kind-param-hint "ParameterHint")
-(defconst lsp/rust-analyzer-inlay-hint-kind-chaining-hint "ChainingHint")
+(defconst lsp/rust-analyzer-inlay-hint-kind-type-hint 1)
+(defconst lsp/rust-analyzer-inlay-hint-kind-param-hint 2)
+(defconst lsp/rust-analyzer-inlay-hint-kind-chaining-hint nil)
 (lsp-interface (rust-analyzer:AnalyzerStatusParams (:textDocument))
                (rust-analyzer:SyntaxTreeParams (:textDocument) (:range))
                (rust-analyzer:ExpandMacroParams (:textDocument :position) nil)
@@ -415,7 +415,7 @@ See `-let' for a description of the destructuring mechanism."
                (rust-analyzer:RunnableArgs (:cargoArgs :executableArgs) (:workspaceRoot))
                (rust-analyzer:RelatedTestsParams (:textDocument :position) nil)
                (rust-analyzer:RelatedTests (:runnable) nil)
-               (rust-analyzer:InlayHint (:range :label :kind) nil)
+               (rust-analyzer:InlayHint (:position :label :kind) nil)
                (rust-analyzer:InlayHintsParams (:textDocument) nil)
                (rust-analyzer:SsrParams (:query :parseOnly) nil)
                (rust-analyzer:CommandLink (:title :command) (:arguments :tooltip))

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -399,6 +399,7 @@ See `-let' for a description of the destructuring mechanism."
 
 (defconst lsp/rust-analyzer-inlay-hint-kind-type-hint 1)
 (defconst lsp/rust-analyzer-inlay-hint-kind-param-hint 2)
+(defconst lsp/rust-analyzer-inlay-hint-kind-nonstandard-hint nil)
 (lsp-interface (rust-analyzer:AnalyzerStatusParams (:textDocument))
                (rust-analyzer:SyntaxTreeParams (:textDocument) (:range))
                (rust-analyzer:ExpandMacroParams (:textDocument :position) nil)
@@ -414,7 +415,7 @@ See `-let' for a description of the destructuring mechanism."
                (rust-analyzer:RunnableArgs (:cargoArgs :executableArgs) (:workspaceRoot))
                (rust-analyzer:RelatedTestsParams (:textDocument :position) nil)
                (rust-analyzer:RelatedTests (:runnable) nil)
-               (rust-analyzer:InlayHint (:position :label :kind) nil)
+               (rust-analyzer:InlayHint (:position :label :kind :paddingLeft :paddingRight) nil)
                (rust-analyzer:InlayHintsParams (:textDocument) nil)
                (rust-analyzer:SsrParams (:query :parseOnly) nil)
                (rust-analyzer:CommandLink (:title :command) (:arguments :tooltip))


### PR DESCRIPTION
I believe that this is no longer actually rust-analyzer-specific and
instead will work with any LSP backend that supports the draft inlay
hint feature, but I have no other backend to try with.

Fixes #3403