### PR TITLE
Specify correct emacs version for lint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: purcell/setup-emacs@master
         with:
-          version: 0.8.4
+          version: 27.1
 
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
Passing build: https://github.com/elken/lsp-mode/runs/5598664097?check_suite_focus=true