### PR TITLE
Add support for rust-analyzer.linkedProjects in lsp-rust

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -624,6 +624,14 @@ https://rust-analyzer.github.io/manual.html#auto-import.
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.0"))
 
+(defcustom lsp-rust-analyzer-linked-projects []
+  "Disable project auto-discovery in favor of explicitly specified set of
+projects. Elements must be paths pointing to `Cargo.toml`, `rust-project.json`,
+or JSON objects in `rust-project.json` format."
+  :type 'lsp-string-vector
+  :group 'lsp-rust-analyzer
+  :package-version '(lsp-mode . "8.0.0"))
+
 (defcustom lsp-rust-analyzer-experimental-proc-attr-macros nil
   "Whether to enable experimental support for expanding proc macro attributes."
   :type 'boolean
@@ -677,6 +685,7 @@ https://rust-analyzer.github.io/manual.html#auto-import.
     :callInfo (:full ,(lsp-json-bool lsp-rust-analyzer-call-info-full))
     :procMacro (:enable ,(lsp-json-bool lsp-rust-analyzer-proc-macro-enable))
     :rustcSource ,lsp-rust-analyzer-rustc-source
+    :linkedProjects ,lsp-rust-analyzer-linked-projects
     :highlighting (:strings ,(lsp-json-bool lsp-rust-analyzer-highlighting-strings))
     :experimental (:procAttrMacros ,(lsp-json-bool lsp-rust-analyzer-experimental-proc-attr-macros))))
 

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -630,7 +630,7 @@ projects. Elements must be paths pointing to `Cargo.toml`, `rust-project.json`,
 or JSON objects in `rust-project.json` format."
   :type 'lsp-string-vector
   :group 'lsp-rust-analyzer
-  :package-version '(lsp-mode . "8.0.0"))
+  :package-version '(lsp-mode . "8.0.1"))
 
 (defcustom lsp-rust-analyzer-experimental-proc-attr-macros nil
   "Whether to enable experimental support for expanding proc macro attributes."


### PR DESCRIPTION
I tested locally by changing my `.emacs.d/elpa/lsp-mode-xxx/lsp-rust.el` in place and running `byte-compile-file` to update the `.elc`. Then I've set `lsp-log-io` to `t`, set `lsp-rust-analyzer-linked-projects`, restarted the workspace, and checked that it's correctly defined in `lsp-workspace-show-log`.

Note that in theory the variable is [an array of strings or objects](https://github.com/rust-analyzer/rust-analyzer/blob/b3cfa1986b559d4f74bf2709532c1401ebbdd759/editors/code/package.json#L868-L878). For simplicity I made it an array of strings because I don't know how to make it otherwise (I'm not familiar with elisp).

Fix #3414.