### PR TITLE
Update docs.yml to use latest container registry

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,13 +27,19 @@ jobs:
 
       - name: Generate LSPs docs
         run: 'make docs'
-
+        
+      - name: Docker Login
+        uses: docker/login-action@v1.14.1
+        with:
+          registry: ghcr.io
+          username: $GITHUB_ACTOR
+          password: ${{ secrets.GITHUB_TOKEN }}
+    
       - name: MkDocs
         run: |
           cp -rf README.md examples docs
 
-          docker login docker.pkg.github.com --username $GITHUB_ACTOR --password ${{ secrets.GITHUB_TOKEN }}
-          docker run --rm -v ${PWD}:/docs docker.pkg.github.com/emacs-lsp/docs-image/docs-image -- build
+          docker run --rm -v ${PWD}:/docs ghcr.io/emacs-lsp/docs-image/docs-image:latest -- build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Struggling to test with `act` locally, but skimming through the docs it looks like we've been migrated to the new registry now.

I am kinda clutching at straws by now, but hopefully this is indeed the fix. It also uses the `:latest` image, just in case it was caching an incorrect version for some reason.