### PR TITLE
lsp-ansible: Silence byte-compiler

### DIFF
--- a/clients/lsp-ansible.el
+++ b/clients/lsp-ansible.el
@@ -164,7 +164,7 @@ Python virtual environment."
 This prevents the Ansible server from being turned on in all yaml files."
   (and (eq major-mode 'yaml-mode)
        ;; emacs-ansible provides ansible, not ansible-mode
-       (bound-and-true-p ansible)))
+       (with-no-warnings (bound-and-true-p ansible))))
 
 (lsp-register-client
  (make-lsp-client


### PR DESCRIPTION
```
In lsp-ansible-check-ansible-minor-mode:
lib/lsp-mode/clients/lsp-ansible.el:167:26:
Warning: global/dynamic var ‘ansible’ lacks a prefix
```