### PR TITLE
lsp-ansible: add missing variable in register settings

### DIFF
--- a/clients/lsp-ansible.el
+++ b/clients/lsp-ansible.el
@@ -156,7 +156,7 @@ Python virtual environment."
    ("ansible.executionEnvironment.enabled" lsp-ansible-execution-environment-enabled t)
    ("ansible.executionEnvironment.image" lsp-ansible-execution-environment-image)
    ("ansible.executionEnvironment.pullPolicy" lsp-ansible-execution-environment-pull-policy)
-   ("ansible.python.interpreterPath")
+   ("ansible.python.interpreterPath" lsp-ansible-python-interpreter-path)
    ("ansible.python.activationScript" lsp-ansible-python-activation-script)))
 
 (defun lsp-ansible-check-ansible-minor-mode (&rest _)


### PR DESCRIPTION
I realized that I forgot a variable in `lsp-register-custom-settings` for PR https://github.com/emacs-lsp/lsp-mode/pull/3376

This PR fixes that.