### PR TITLE
lsp-openscad: Add OpenSCAD language server

### DIFF
--- a/clients/lsp-openscad.el
+++ b/clients/lsp-openscad.el
@@ -1,0 +1,49 @@
+;;; lsp-openscad.el --- openscad client         -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2021 Len Trigg
+
+;; Author: Len Trigg
+;; Keywords: openscad lsp
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; lsp-openscad client
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-openscad nil
+  "LSP support for openscad."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/dzhu/openscad-language-server"))
+
+(defcustom lsp-openscad-server
+  "openscad-language-server"
+  "Path to the openscad language server."
+  :group 'lsp-openscad
+  :risky t
+  :type 'file)
+
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection lsp-openscad-server)
+                  :major-modes '(scad-mode)
+                  :priority -1
+                  :server-id 'openscad))
+
+(provide 'lsp-openscad)
+;;; lsp-openscad.el ends here

--- a/clients/lsp-openscad.el
+++ b/clients/lsp-openscad.el
@@ -1,6 +1,6 @@
 ;;; lsp-openscad.el --- openscad client         -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021 Len Trigg
+;; Copyright (C) 2022 Len Trigg
 
 ;; Author: Len Trigg
 ;; Keywords: openscad lsp

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -448,6 +448,15 @@
     "debugger": "Not available"
   },
   {
+    "name": "openscad",
+    "full-name": "OpenSCAD",
+    "server-name": "openscad-language-server",
+    "server-url": "https://github.com/dzhu/openscad-language-server",
+    "installation-url": "https://github.com/dzhu/openscad-language-server",
+    "installation": "cargo install openscad-language-server",
+    "debugger": "Not available"
+  },
+  {
     "name": "pascal",
     "full-name": "Pascal/Object Pascal",
     "server-name": "pascal-language-server",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -178,7 +178,7 @@ As defined by the Language Server Protocol 3.16."
          lsp-elm lsp-elixir lsp-emmet lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript lsp-go
          lsp-graphql lsp-hack lsp-grammarly lsp-groovy lsp-haskell lsp-haxe lsp-idris lsp-java lsp-javascript
          lsp-json lsp-kotlin lsp-latex lsp-ltex lsp-lua lsp-markdown lsp-nginx lsp-nim lsp-nix lsp-magik
-         lsp-metals lsp-mssql lsp-ocaml lsp-pascal lsp-perl lsp-perlnavigator lsp-php lsp-pwsh lsp-pyls lsp-pylsp
+         lsp-metals lsp-mssql lsp-ocaml lsp-openscad lsp-pascal lsp-perl lsp-perlnavigator lsp-php lsp-pwsh lsp-pyls lsp-pylsp
          lsp-pyright lsp-python-ms lsp-purescript lsp-r lsp-remark lsp-rf lsp-rust lsp-solargraph
          lsp-sorbet lsp-sourcekit lsp-sonarlint lsp-tailwindcss lsp-tex lsp-terraform lsp-toml
          lsp-ttcn3 lsp-typeprof lsp-v lsp-vala lsp-verilog lsp-vetur lsp-volar lsp-vhdl lsp-vimscript
@@ -745,6 +745,7 @@ Changes take effect only when a new session is started."
                                         (sass-mode . "sass")
                                         (ssass-mode . "sass")
                                         (scss-mode . "scss")
+                                        (scad-mode . "openscad")
                                         (xml-mode . "xml")
                                         (c-mode . "c")
                                         (c++-mode . "cpp")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
     - Nim: page/lsp-nim.md
     - Nix: page/lsp-nix.md
     - OCaml (ocaml-lsp): page/lsp-ocaml-lsp-server.md
+    - OpenSCAD: page/lsp-openscad.md
     - Pascal/Object Pascal: page/lsp-pascal.md
     - Perl (Perl::LanguageServer): page/lsp-perl.md
     - Perl (Navigator): page/lsp-perlnavigator.md


### PR DESCRIPTION
Adds support for OpenSCAD language, using [openscad-language-server](https://github.com/dzhu/openscad-language-server)
