### PR TITLE
Fix generate settings script

### DIFF
--- a/scripts/lsp-generate-settings.el
+++ b/scripts/lsp-generate-settings.el
@@ -79,7 +79,7 @@ FILE-NAME is path to package.json vscode manifest."
                         type
                         group
                         (symbol-name prop-name))))))
-         (s-join "\n\n")))))
+         (s-join "\n\n"))))
 
 (provide 'lsp-generate-settings)
 

--- a/scripts/lsp-generate-settings.el
+++ b/scripts/lsp-generate-settings.el
@@ -23,7 +23,7 @@
 ;; Functions for generating settings from package.json file
 
 ;; Usage
-;; (lsp-generate-settings "/home/kyoncho/Sources/vscode-java/package.json")
+;; (lsp-generate-settings "/home/kyoncho/Sources/vscode-java/package.json" 'lsp-java)
 
 ;;; Code:
 


### PR DESCRIPTION
This patch fixes the following in `lsp-generate-settings.el`:
- unbalanced parentheses of `lsp-generate-settings`
- incorrect usage example
