### PR TITLE
Add support for PureScript LSP settings

### DIFF
--- a/clients/lsp-purescript.el
+++ b/clients/lsp-purescript.el
@@ -50,6 +50,20 @@
             (lsp-package-path 'purescript-language-server))
         lsp-purescript-server-args))
 
+(defcustom-lsp lsp-purescript-add-spago-sources t
+  "Whether to add spago sources to the globs passed to the IDE server for source locations."
+  :type 'boolean
+  :group 'lsp-purescript
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "purescript.addSpagoSources")
+
+(defcustom-lsp lsp-purescript-add-npm-path nil
+  "Whether to add the local npm bin directory to the PATH."
+  :type 'boolean
+  :group 'lsp-purescript
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "purescript.addNpmPath")
+
 (lsp-dependency 'purescript-language-server
                 '(:system "purescript-language-server")
                 '(:npm :package "purescript-language-server"


### PR DESCRIPTION
Hello, 

I would like to add support for [purescript-language-server](https://github.com/nwolverson/purescript-language-server) commands `addSpagoSources` and `addNpmPath`. Similar configuration could be seen [here](https://github.com/nwolverson/purescript-language-server#vimcoc=). If there is anything that I would need to fix or change, please let me now.

Best wishes,
alternateved