### PR TITLE
Ignore coded/changedSelectedWorkspace and coded/initDubTree

### DIFF
--- a/clients/lsp-d.el
+++ b/clients/lsp-d.el
@@ -25,10 +25,14 @@
 ;;; Code:
 
 (require 'lsp-mode)
+(require 'ht)
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection "serve-d")
                   :major-modes '(d-mode)
+                  :notification-handlers
+                  (ht ("coded/changedSelectedWorkspace" #'ignore)
+                      ("coded/initDubTree" #'ignore))
                   :server-id 'serve-d))
 
 (lsp-consistency-check lsp-d)


### PR DESCRIPTION
When I open *.d files these warnings in the warning buffer.

```
Warning (lsp-mode): Unknown notification: coded/changedSelectedWorkspace
Warning (lsp-mode): Unknown notification: coded/initDubTree
```

I hope to open the file without these warnings.