### PR TITLE
Fix inlay hints being added to wrong buffer (lsp-javascript, lsp-rust)

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -938,18 +938,19 @@ meaning."
        (lsp-make-rust-analyzer-inlay-hints-params
         :text-document (lsp--text-document-identifier))
        (lambda (res)
-         (remove-overlays (point-min) (point-max) 'lsp-rust-analyzer-inlay-hint t)
-         (dolist (hint res)
-           (-let* (((&rust-analyzer:InlayHint :position :label :kind :padding-left :padding-right) hint)
-                   (pos (lsp--position-to-point position))
-                   (overlay (make-overlay pos pos nil 'front-advance 'end-advance)))
-             (overlay-put overlay 'lsp-rust-analyzer-inlay-hint t)
-             (overlay-put overlay 'before-string
-                          (format "%s%s%s"
-                                  (if padding-left " " "")
-                                  (propertize (lsp-rust-analyzer-format-inlay label kind)
-                                              'font-lock-face (lsp-rust-analyzer-face-for-inlay kind))
-                                  (if padding-right " " ""))))))
+         (with-current-buffer buffer
+           (remove-overlays (point-min) (point-max) 'lsp-rust-analyzer-inlay-hint t)
+           (dolist (hint res)
+             (-let* (((&rust-analyzer:InlayHint :position :label :kind :padding-left :padding-right) hint)
+                     (pos (lsp--position-to-point position))
+                     (overlay (make-overlay pos pos nil 'front-advance 'end-advance)))
+               (overlay-put overlay 'lsp-rust-analyzer-inlay-hint t)
+               (overlay-put overlay 'before-string
+                            (format "%s%s%s"
+                                    (if padding-left " " "")
+                                    (propertize (lsp-rust-analyzer-format-inlay label kind)
+                                                'font-lock-face (lsp-rust-analyzer-face-for-inlay kind))
+                                    (if padding-right " " "")))))))
        :mode 'tick))
   nil)
 


### PR DESCRIPTION
Fixes #3459

The async handlers for both clients’ inlay hints were operating on the active buffer, which could differ from the original buffer. This PR ensures both operate only on the latter.