### PR TITLE
Fix inlayHint request in latest rust-analyzer.

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -934,9 +934,12 @@ meaning."
   (if (and (lsp-rust-analyzer-initialized?)
            (eq buffer (current-buffer)))
       (lsp-request-async
-       "experimental/inlayHints"
+       "textDocument/inlayHint"
        (lsp-make-rust-analyzer-inlay-hints-params
-        :text-document (lsp--text-document-identifier))
+        :text-document (lsp--text-document-identifier)
+        :range (if (use-region-p)
+                   (lsp--region-to-range (region-beginning) (region-end))
+                 (lsp--region-to-range (point-min) (point-max))))
        (lambda (res)
          (remove-overlays (point-min) (point-max) 'lsp-rust-analyzer-inlay-hint t)
          (dolist (hint res)

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -416,7 +416,7 @@ See `-let' for a description of the destructuring mechanism."
                (rust-analyzer:RelatedTestsParams (:textDocument :position) nil)
                (rust-analyzer:RelatedTests (:runnable) nil)
                (rust-analyzer:InlayHint (:position :label :kind :paddingLeft :paddingRight) nil)
-               (rust-analyzer:InlayHintsParams (:textDocument) nil)
+               (rust-analyzer:InlayHintsParams (:textDocument :range) nil)
                (rust-analyzer:SsrParams (:query :parseOnly) nil)
                (rust-analyzer:CommandLink (:title :command) (:arguments :tooltip))
                (rust-analyzer:CommandLinkGroup (:commands) (:title)))


### PR DESCRIPTION
This message is now part of the upcoming LSP spec:

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlayHint