### PR TITLE
capabilities: send correct "detail" property for completion items' resolveSupport

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3513,7 +3513,7 @@ disappearing, unset all the variables related to it."
                                                         (deprecatedSupport . t)
                                                         (resolveSupport
                                                          . ((properties . ["documentation"
-                                                                           "details"
+                                                                           "detail"
                                                                            "additionalTextEdits"
                                                                            "command"])))
                                                         (insertTextModeSupport . ((valueSet . [1 2])))))


### PR DESCRIPTION
According to [1], the client capability
CompletionClientCapabilities.completionItem.resolveSupport lists all
properties that can be filled in during a `completionItem/resolve`
request.  We send the property "details", but CompletionItem has no
such field[2]; there is a field called singular "detail". Fix our
capabilities to send that instead.

I don't have a practical manifestation of this bug [3]; I can
imagine servers just ignore this capability anyway (at least
typescript-language-server does, so no behavior change) but in theory
this fix could mean that we get more docs.

[1]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion
[2]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem
[3]: I found this while working on the completionItem/resolve feature for https://github.com/kak-lsp/kak-lsp/
