### PR TITLE
Only display JavaScript inlay hints for code in view

### DIFF
--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -825,7 +825,7 @@ name (e.g. `data' variable passed as `data' parameter)."
         :text-document (lsp--text-document-identifier))
        (lambda (res)
          (lsp--remove-overlays 'lsp-javascript-inlay-hint)
-         (-each (gethash "inlayHints" res)
+         (-each (lsp-get res :inlayHints)
            #'(lambda (hint)
                (-let* (((&javascript:InlayHint :text :position :kind :whitespace-before? :whitespace-after?) hint)
                        (pos (lsp--position-to-point position))

--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -857,8 +857,8 @@ name (e.g. `data' variable passed as `data' parameter)."
                                         (if (and whitespace-before? (not (string= kind lsp/javascript-inlay-hint-kind-type-hint))) " " "")
                                         (propertize (lsp-javascript-format-inlay text kind)
                                                     'font-lock-face (lsp-javascript-face-for-inlay kind))
-                                        (if whitespace-after? " " "")))))))))
-    :mode 'tick))
+                                        (if whitespace-after? " " ""))))))))
+       :mode 'tick)))
 
 (defun lsp-javascript-column-at-pos (pos)
   (save-excursion

--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -682,6 +682,11 @@ name (e.g. `data' variable passed as `data' parameter)."
   :type 'boolean
   :package-version '(lsp-mode . "8.0.1"))
 
+(defcustom lsp-javascript-update-inlay-hints-on-scroll t
+  "Update inlay hints immediately when scrolling or modifying window sizes."
+  :type 'boolean
+  :package-version '(lsp-mode . "8.0.1"))
+
 (lsp-register-custom-settings
  '(("javascript.autoClosingTags" lsp-javascript-auto-closing-tags t)
    ("javascript.implicitProjectConfig.checkJs" lsp-javascript-implicit-project-config-check-js t)
@@ -817,6 +822,9 @@ name (e.g. `data' variable passed as `data' parameter)."
       (lsp)
       (lsp--info "Renamed '%s' to '%s'." name (file-name-nondirectory new)))))
 
+(defun lsp-javascript-update-inlay-hints-scroll-function (window start)
+  (lsp-javascript--update-inlay-hints start (window-end window t)))
+
 (defun lsp-javascript-update-inlay-hints ()
   (lsp-javascript--update-inlay-hints (window-start) (window-end nil t)))
 
@@ -826,10 +834,10 @@ name (e.g. `data' variable passed as `data' parameter)."
        "typescript/inlayHints"
        (lsp-make-javascript-inlay-hints-params
         :text-document (lsp--text-document-identifier)
-        :range (lsp-make-javascript-range :start
-                                          (lsp-point-to-position start)
-                                          :end
-                                          (lsp-point-to-position end)))
+        :range (lsp-make-range :start
+                               (lsp-point-to-position start)
+                               :end
+                               (lsp-point-to-position end)))
        (lambda (res)
          (lsp--remove-overlays 'lsp-javascript-inlay-hint)
          (let ((hints (lsp-get res :inlayHints)))
@@ -880,10 +888,14 @@ name (e.g. `data' variable passed as `data' parameter)."
   (cond
    (lsp-javascript-inlay-hints-mode
     (lsp-javascript-update-inlay-hints)
-    (add-hook 'lsp-on-idle-hook #'lsp-javascript-update-inlay-hints nil t))
+    (add-hook 'lsp-on-idle-hook #'lsp-javascript-update-inlay-hints nil t)
+    (when lsp-javascript-update-inlay-hints-on-scroll
+      (add-to-list (make-local-variable 'window-scroll-functions) #'lsp-javascript-update-inlay-hints-scroll-function)))
    (t
     (lsp--remove-overlays 'lsp-javascript-inlay-hint)
-    (remove-hook 'lsp-on-idle-hook #'lsp-javascript-update-inlay-hints t))))
+    (remove-hook 'lsp-on-idle-hook #'lsp-javascript-update-inlay-hints t)
+    (when lsp-javascript-update-inlay-hints-on-scroll
+      (setf window-scroll-functions (delete #'lsp-javascript-update-inlay-hints-scroll-function window-scroll-functions))))))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -425,7 +425,8 @@ See `-let' for a description of the destructuring mechanism."
 (defconst lsp/javascript-inlay-hint-kind-parameter-hint "Parameter")
 (defconst lsp/javascript-inlay-hint-kind-enum-hint "Enum")
 (lsp-interface (javascript:InlayHint (:text :position :kind) (:whitespaceBefore :whitespaceAfter))
-               (javascript:InlayHintsParams (:textDocument) (:range)))
+               (javascript:InlayHintsParams (:textDocument) (:range))
+               (javascript:Range (:start :end)))
 
 (lsp-interface (clojure-lsp:TestTreeParams (:uri :tree) nil)
                (clojure-lsp:TestTreeNode (:name :range :nameRange :kind) (:children)))

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -425,8 +425,7 @@ See `-let' for a description of the destructuring mechanism."
 (defconst lsp/javascript-inlay-hint-kind-parameter-hint "Parameter")
 (defconst lsp/javascript-inlay-hint-kind-enum-hint "Enum")
 (lsp-interface (javascript:InlayHint (:text :position :kind) (:whitespaceBefore :whitespaceAfter))
-               (javascript:InlayHintsParams (:textDocument) (:range))
-               (javascript:Range (:start :end)))
+               (javascript:InlayHintsParams (:textDocument) (:range)))
 
 (lsp-interface (clojure-lsp:TestTreeParams (:uri :tree) nil)
                (clojure-lsp:TestTreeNode (:name :range :nameRange :kind) (:children)))


### PR DESCRIPTION
This drastically speeds up working with large files. A work project has a 90,000-line JavaScript file. Before, I couldn’t edit it with inlay hints enabled since it would just keep locking up (even after the initial delay while it was being parsed and everything). In contrast, with this change, inlay hints have virtually no impact on performance regardless of the size of the file. In fact, I tried making the hints more aggressive by updating them when scrolling or changing the size of the window and noticed no impact on responsiveness. (I added a custom variable to allow disabling this in case it does impact performance on other machines.)

Bonus:
Fixes #3459