### PR TITLE
lsp-rust: files/watcher should be a string

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -695,9 +695,7 @@ or JSON objects in `rust-project.json` format."
                   :allTargets ,(lsp-json-bool lsp-rust-analyzer-cargo-all-targets)
                   :overrideCommand ,lsp-rust-analyzer-cargo-override-command)
     :files (:exclude ,lsp-rust-analyzer-exclude-globs
-            :watcher ,(lsp-json-bool (if lsp-rust-analyzer-use-client-watching
-                                         "client"
-                                       "notify"))
+            :watcher ,(if lsp-rust-analyzer-use-client-watching "client" "notify")
             :excludeDirs ,lsp-rust-analyzer-exclude-dirs)
     :cargo (:allFeatures ,(lsp-json-bool lsp-rust-all-features)
             :noDefaultFeatures ,(lsp-json-bool lsp-rust-no-default-features)


### PR DESCRIPTION
This was causing rust-analyzer to generate a warning for me.