### PR TITLE
Give lsp-mode a docstring

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2764,7 +2764,7 @@ and end-of-string meta-characters."
     map)
   "Keymap for `lsp-mode'.")
 
-(define-minor-mode lsp-mode ""
+(define-minor-mode lsp-mode "Mode for LSP interaction"
   :keymap lsp-mode-map
   :lighter
   (" LSP["

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2764,7 +2764,7 @@ and end-of-string meta-characters."
     map)
   "Keymap for `lsp-mode'.")
 
-(define-minor-mode lsp-mode "Mode for LSP interaction"
+(define-minor-mode lsp-mode "Mode for LSP interaction."
   :keymap lsp-mode-map
   :lighter
   (" LSP["


### PR DESCRIPTION
Presently, on bleeding edge Emacs, `define-minor-mode` with an empty docstring makes the mode impossible to load as `""` is coerced to `nil` and subsequently `insert`ed, which is not kosher. The options as they stand are either a non-empty string (as I've done in this patch) or `nil`, which results in the fallback value of `Toggle Lsp mode on or off`. I'm not picky either way. I also sent a bug report to the Emacs list [here](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=55216) so this edge case will hopefully be covered (or explicitly disallowed) in the future.