### PR TITLE
terraform-ls: Support commands for init and validate

### DIFF
--- a/clients/lsp-terraform.el
+++ b/clients/lsp-terraform.el
@@ -94,7 +94,7 @@
                   :server-id 'tfmls))
 
 (defun lsp-terraform-ls-validate ()
-  "Execute terraform validate on `default-directory'."
+  "Execute terraform validate on project root."
   (interactive)
   (lsp-request
    "workspace/executeCommand"
@@ -105,7 +105,7 @@
    :no-merge t))
 
 (defun lsp-terraform-ls-init ()
-  "Execute terraform init on `default-directory'.
+  "Execute terraform init on project root.
 
 This is a synchronous action."
   (interactive)

--- a/clients/lsp-terraform.el
+++ b/clients/lsp-terraform.el
@@ -93,6 +93,29 @@
                   :priority 1
                   :server-id 'tfmls))
 
+(defun lsp-terraform-ls-validate ()
+  "Execute terraform validate on `default-directory'."
+  (interactive)
+  (lsp-request
+   "workspace/executeCommand"
+   (list :command "terraform-ls.terraform.validate"
+         :arguments (vector (format "uri=%s" (lsp--path-to-uri (lsp-workspace-root))))
+         )
+   :no-wait t
+   :no-merge t))
+
+(defun lsp-terraform-ls-init ()
+  "Execute terraform init on `default-directory'.
+
+This is a synchronous action."
+  (interactive)
+  (lsp-request
+     "workspace/executeCommand"
+     (list :command "terraform-ls.terraform.init"
+           :arguments (vector (format "uri=%s" (lsp--path-to-uri (lsp-workspace-root)))))
+     :no-wait nil
+     :no-merge t))
+
 (lsp-consistency-check lsp-terraform)
 
 (provide 'lsp-terraform)


### PR DESCRIPTION
We implement two functions:
- lsp-terraform-ls-validate
- lsp-terraform-ls-init

The validate is most commonly used to verify the terraform files in the workspace directory.