### PR TITLE
Pull npm peerDependencies as required

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7730,7 +7730,16 @@ nil."
         ;; https://github.com/emacs-lsp/lsp-mode/issues/2364 for
         ;; discussion.
         (make-directory (f-join lsp-server-install-dir "npm" package "lib") 'parents)
-        (lsp-async-start-process callback
+        (lsp-async-start-process (lambda ()
+                                   (if (string-empty-p
+                                        (string-trim (shell-command-to-string
+                                                      (mapconcat #'shell-quote-argument `(,npm-binary "view" ,package "peerDependencies") " "))))
+                                       callback
+                                     (let ((default-directory (f-join lsp-server-install-dir "npm" package "lib" "node_modules" package)))
+                                       (lsp-async-start-process callback
+                                                                error-callback
+                                                                (executable-find "npx")
+                                                                "npm-install-peers"))))
                                  error-callback
                                  npm-binary
                                  "-g"


### PR DESCRIPTION
npm is _**needlessly**_ complex and has 3 types of dependencies.

Normal: which are intended to be installed everywhere
Dev: which are only needed for development (eg linters, compilers, etc)
Peer: which are "needed" but have to be installed manually (better explanation here https://nodejs.org/en/blog/npm/peer-dependencies/)

The latter type isn't installed unless you install them yourself, which
doesn't help for situations like ours where we install specific tools in
isolated prefixes. `npm-install-peers` was the simplest way I found to
just "install" those dependencies.

Whether or not peer dependencies are installed seems to change between
versions of npm, so across ancient versions the behaviour still "should"
be the same.

Affects: graphql (for now)