### PR TITLE
openscad: better server; support both stdio and tcp connection types

### DIFF
--- a/clients/lsp-openscad.el
+++ b/clients/lsp-openscad.el
@@ -29,7 +29,7 @@
 (defgroup lsp-openscad nil
   "LSP support for openscad."
   :group 'lsp-mode
-  :link '(url-link "https://github.com/dzhu/openscad-language-server"))
+  :link '(url-link "https://github.com/Leathong/openscad-LSP"))
 
 (defcustom lsp-openscad-server
   "openscad-language-server"
@@ -38,9 +38,23 @@
   :risky t
   :type 'file)
 
+(defcustom lsp-openscad-server-connection-type
+  'tcp
+  "Type of connection to use with the OpenSCAD Language Server: tcp or stdio"
+  :group 'lsp-openscad
+  :risky t
+  :type 'symbol)
+
+(defun lsp-openscad-server-start-fun (port)
+  `(,lsp-openscad-server "--port" ,(number-to-string port)))
+
+(defun lsp-openscad-server-connection ()
+  (if (eq lsp-openscad-server-connection-type 'tcp)
+      (lsp-tcp-connection 'lsp-openscad-server-start-fun)
+    (lsp-stdio-connection `(,lsp-openscad-server))))
 
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection lsp-openscad-server)
+ (make-lsp-client :new-connection (lsp-openscad-server-connection)
                   :major-modes '(scad-mode)
                   :priority -1
                   :server-id 'openscad))

--- a/clients/lsp-openscad.el
+++ b/clients/lsp-openscad.el
@@ -65,15 +65,19 @@
    ("openscad.fmt_exe" lsp-openscad-format-exe)
    ("openscad.fmt_style" lsp-openscad-format-style)))
 
-(defun lsp-openscad-server-start-fun (port)
+(defun lsp-openscad-server-stdio-start-fun ()
+  "Create arguments to start openscad language server in stdio mode."
+  `(,lsp-openscad-server "--stdio" ))
+
+(defun lsp-openscad-server-tcp-start-fun (port)
   "Create arguments to start openscad language server in TCP mode on PORT."
   `(,lsp-openscad-server "--port" ,(number-to-string port)))
 
 (defun lsp-openscad-server-connection ()
   "Create command line arguments to start openscad language server."
   (if (eq lsp-openscad-server-connection-type 'tcp)
-      (lsp-tcp-connection 'lsp-openscad-server-start-fun)
-    (lsp-stdio-connection `(,lsp-openscad-server))))
+      (lsp-tcp-connection 'lsp-openscad-server-tcp-start-fun)
+    (lsp-stdio-connection 'lsp-openscad-server-stdio-start-fun)))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-openscad-server-connection)

--- a/clients/lsp-openscad.el
+++ b/clients/lsp-openscad.el
@@ -32,7 +32,7 @@
   :link '(url-link "https://github.com/Leathong/openscad-LSP"))
 
 (defcustom lsp-openscad-server
-  "openscad-language-server"
+  "openscad-lsp"
   "Path to the openscad language server."
   :group 'lsp-openscad
   :risky t

--- a/clients/lsp-openscad.el
+++ b/clients/lsp-openscad.el
@@ -45,6 +45,26 @@
   :risky t
   :type 'symbol)
 
+(defcustom lsp-openscad-search-paths ""
+  "Customized search path."
+  :type 'string
+  :group 'lsp-openscad)
+
+(defcustom lsp-openscad-format-exe "clang-format"
+  "Path to the clang-format executable."
+  :type 'string
+  :group 'lsp-openscad)
+
+(defcustom lsp-openscad-format-style "file"
+  "Style argument to use with clang-format."
+  :type 'string
+  :group 'lsp-openscad)
+
+(lsp-register-custom-settings
+ '(("openscad.search_paths" lsp-openscad-search-paths)
+   ("openscad.fmt_exe" lsp-openscad-format-exe)
+   ("openscad.fmt_style" lsp-openscad-format-style)))
+
 (defun lsp-openscad-server-start-fun (port)
   "Create arguments to start openscad language server in TCP mode on PORT."
   `(,lsp-openscad-server "--port" ,(number-to-string port)))
@@ -59,6 +79,10 @@
  (make-lsp-client :new-connection (lsp-openscad-server-connection)
                   :major-modes '(scad-mode)
                   :priority -1
+                  :initialized-fn (lambda (workspace)
+                                    (with-lsp-workspace workspace
+                                      (lsp--set-configuration
+                                       (lsp-configuration-section "openscad"))))
                   :server-id 'openscad))
 
 (provide 'lsp-openscad)

--- a/clients/lsp-openscad.el
+++ b/clients/lsp-openscad.el
@@ -40,15 +40,17 @@
 
 (defcustom lsp-openscad-server-connection-type
   'tcp
-  "Type of connection to use with the OpenSCAD Language Server: tcp or stdio"
+  "Type of connection to use with the OpenSCAD Language Server: tcp or stdio."
   :group 'lsp-openscad
   :risky t
   :type 'symbol)
 
 (defun lsp-openscad-server-start-fun (port)
+  "Create arguments to start openscad language server in TCP mode on PORT."
   `(,lsp-openscad-server "--port" ,(number-to-string port)))
 
 (defun lsp-openscad-server-connection ()
+  "Create command line arguments to start openscad language server."
   (if (eq lsp-openscad-server-connection-type 'tcp)
       (lsp-tcp-connection 'lsp-openscad-server-start-fun)
     (lsp-stdio-connection `(,lsp-openscad-server))))


### PR DESCRIPTION
A new OpenSCAD language server has entered the chat. It is available at:
https://github.com/Leathong/openscad-LSP

The Leathong server requires tcp connection type, and the dzhu server requires stdio connection type. This commit allows the use of either server implementation.

The developer of the earlier language server seems inactive, and the new server has a superset of features, so it seems reasonable to change the default.
