### PR TITLE
Gopls use deamon mode by default

### DIFF
--- a/clients/lsp-go.el
+++ b/clients/lsp-go.el
@@ -48,7 +48,7 @@
   'lsp-go-gopls-server-args
   "lsp-mode 7.0.1")
 
-(defcustom lsp-go-gopls-server-args nil
+(defcustom lsp-go-gopls-server-args '("-remote=auto")
   "Extra CLI arguments for gopls."
   :type '(repeat string)
   :group 'lsp-go)


### PR DESCRIPTION
Using deamon mode can save a start-up cost each time a session is created.

more: https://github.com/golang/tools/blob/master/gopls/doc/daemon.md