### PR TITLE
Add vendor folder to lsp-file-watch-ignored-directories

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -338,6 +338,7 @@ the server has requested that."
     "[/\\\\]\\.vscode\\'"
     "[/\\\\]\\.venv\\'"
     "[/\\\\]\\.mypy_cache\\'"
+    "[/\\\\]\\vendor\\'"
     ;; Autotools output
     "[/\\\\]\\.deps\\'"
     "[/\\\\]build-aux\\'"


### PR DESCRIPTION
For programming languages like PHP and Ruby, the libraries are located in the `vendor/` directory.