### PR TITLE
terraform: Reference counts using Code Lens

### DIFF
--- a/clients/lsp-terraform.el
+++ b/clients/lsp-terraform.el
@@ -109,9 +109,8 @@ language server."
 
 (defun lsp-terraform-ls--custom-capabilities ()
   "Construct custom capabilities for the language server."
-  (if lsp-terraform-ls-enable-show-reference
-      '((experimental . ((showReferencesCommandId . "client.showReferences"))))
-    nil))
+  (when lsp-terraform-ls-enable-show-reference
+      '((experimental . ((showReferencesCommandId . "client.showReferences"))))))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection #'lsp-terraform-ls--make-launch-cmd)

--- a/clients/lsp-terraform.el
+++ b/clients/lsp-terraform.el
@@ -84,14 +84,42 @@
           (repeat string))
   :package-version `(lsp-mode . "8.0.1"))
 
+(defcustom lsp-terraform-ls-enable-show-reference nil
+  "Enable reference counts.
+
+Display reference counts above top level blocks and
+attributes.  This is an experimental feature provided by the
+language server."
+  :group 'lsp-terraform-ls
+  :type 'boolean
+  :package-version '(lsp-mode . "8.0.1"))
+
 (defun lsp-terraform-ls--make-launch-cmd ()
   `(,lsp-terraform-ls-server "serve"))
+
+(lsp-defun lsp-terraform-ls--show-references ((&Command :arguments? :command :title))
+  "Show references for command with ARGS."
+  (lsp-show-xrefs
+     (lsp--locations-to-xref-items
+      (lsp-request "textDocument/references"
+                   (lsp--make-reference-params
+                    (lsp--text-document-position-params nil (elt arguments? 0)))))
+     t
+     t))
+
+(defun lsp-terraform-ls--custom-capabilities ()
+  "Construct custom capabilities for the language server."
+  (if lsp-terraform-ls-enable-show-reference
+      '((experimental . ((showReferencesCommandId . "client.showReferences"))))
+    nil))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection #'lsp-terraform-ls--make-launch-cmd)
                   :major-modes '(terraform-mode)
                   :priority 1
-                  :server-id 'tfmls))
+                  :server-id 'tfmls
+                  :action-handlers (ht ("client.showReferences" #'lsp-terraform-ls--show-references))
+                  :custom-capabilities (lsp-terraform-ls--custom-capabilities)))
 
 (defun lsp-terraform-ls-validate ()
   "Execute terraform validate on project root."

--- a/clients/lsp-terraform.el
+++ b/clients/lsp-terraform.el
@@ -97,7 +97,7 @@ language server."
 (defun lsp-terraform-ls--make-launch-cmd ()
   `(,lsp-terraform-ls-server "serve"))
 
-(lsp-defun lsp-terraform-ls--show-references ((&Command :arguments? :command :title))
+(lsp-defun lsp-terraform-ls--show-references ((&Command :arguments?))
   "Show references for command with ARGS."
   (lsp-show-xrefs
      (lsp--locations-to-xref-items


### PR DESCRIPTION
Hashicorp's language server implements an experimental opt-in code
lens to display the number of references to any root level block or
attribute.

This PR implements that feature.