### PR TITLE
terraform: Add semantic token support

### DIFF
--- a/clients/lsp-terraform.el
+++ b/clients/lsp-terraform.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'lsp-mode)
+(require 'lsp-semantic-tokens)
 
 
 ;; terraform-lsp
@@ -110,7 +111,70 @@ language server."
 (defun lsp-terraform-ls--custom-capabilities ()
   "Construct custom capabilities for the language server."
   (when lsp-terraform-ls-enable-show-reference
-      '((experimental . ((showReferencesCommandId . "client.showReferences"))))))
+    '((experimental . ((showReferencesCommandId . "client.showReferences"))))))
+
+(setq lsp-semantic-token-faces
+      '(("namespace" . lsp-face-semhl-namespace)
+        ("type" . lsp-face-semhl-type)
+        ("class" . lsp-face-semhl-class)
+        ("enum" . lsp-face-semhl-enum)
+        ("interface" . lsp-face-semhl-interface)
+        ("struct" . lsp-face-semhl-struct)
+        ("typeParameter" . lsp-face-semhl-type-parameter)
+        ("parameter" . lsp-face-semhl-parameter)
+        ("variable" . lsp-face-semhl-variable)
+        ("property" . lsp-face-semhl-property)
+        ("enumMember" . lsp-face-semhl-constant)
+        ("event" . lsp-face-semhl-event)
+        ("function" . lsp-face-semhl-function)
+        ("method" . lsp-face-semhl-method)
+        ("macro" . lsp-face-semhl-macro)
+        ("keyword" . lsp-face-semhl-keyword)
+        ("modifier" . lsp-face-semhl-member)
+        ("comment" . lsp-face-semhl-comment)
+        ("string" . lsp-face-semhl-string)
+        ("number" . lsp-face-semhl-number)
+        ("regexp" . lsp-face-semhl-regexp)
+        ("operator" . lsp-face-semhl-operator)
+        ("hcl-attrName" . lsp-face-semhl-member)
+        ("hcl-blockType" . lsp-face-semhl-struct)
+        ("hcl-blockLabel" . lsp-face-semhl-member)
+        ("hcl-bool" . lsp-face-semhl-constant)
+        ("hcl-string" . lsp-face-semhl-string)
+        ("hcl-number" . lsp-face-semhl-number)
+        ("hcl-objectKey" . lsp-face-semhl-label)
+        ("hcl-mapKey" . lsp-face-semhl-label)
+        ("hcl-keyword" . lsp-face-semhl-keyword)
+        ("hcl-traversalStep" . lsp-face-semhl-label)
+        ("hcl-typeCapsule" . lsp-face-semhl-type)
+        ("hcl-typePrimitive" . lsp-face-semhl-type)))
+
+(setq lsp-semantic-token-modifier-faces
+      '(("declaration" . lsp-face-semhl-class)
+        ("definition" . lsp-face-semhl-definition)
+        ("readonly" . lsp-face-semhl-constant)
+        ("static" . lsp-face-semhl-static)
+        ("deprecated" . lsp-face-semhl-deprecated)
+        ("abstract" . lsp-face-semhl-keyword)
+        ("async" . lsp-face-semhl-macro)
+        ("modification" . lsp-face-semhl-operator)
+        ("documentation" . lsp-face-semhl-comment)
+        ("defaultLibrary" . lsp-face-semhl-default-library)
+        ("hcl-dependent" . lsp-face-semhl-constant)
+        ("terraform-data" . lsp-face-semhl-constant)
+        ("terraform-locals" . lsp-face-semhl-variable)
+        ("terraform-module" . lsp-face-semhl-namespace)
+        ("terraform-output" . lsp-face-semhl-constant)
+        ("terraform-provider" . lsp-face-semhl-class)
+        ("terraform-resource" . lsp-face-semhl-interface)
+        ("terraform-provisioner" . lsp-face-semhl-default-library)
+        ("terraform-connection" . lsp-face-semhl-constant)
+        ("terraform-variable" . lsp-face-semhl-variable)
+        ("terraform-terraform" . lsp-face-semhl-constant)
+        ("terraform-backend" . lsp-face-semhl-definition)
+        ("terraform-name" . lsp-face-semhl-label)
+        ("terraform-type" . lsp-face-semhl-type)
+        ("terraform-requiredProviders" . lsp-face-semhl-default-library)))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection #'lsp-terraform-ls--make-launch-cmd)

--- a/clients/lsp-terraform.el
+++ b/clients/lsp-terraform.el
@@ -113,7 +113,8 @@ language server."
   (when lsp-terraform-ls-enable-show-reference
     '((experimental . ((showReferencesCommandId . "client.showReferences"))))))
 
-(setq lsp-semantic-token-faces
+(defun lsp-terraform-ls--set-tokens ()
+  (setq lsp-semantic-token-faces
       '(("namespace" . lsp-face-semhl-namespace)
         ("type" . lsp-face-semhl-type)
         ("class" . lsp-face-semhl-class)
@@ -148,8 +149,7 @@ language server."
         ("hcl-traversalStep" . lsp-face-semhl-label)
         ("hcl-typeCapsule" . lsp-face-semhl-type)
         ("hcl-typePrimitive" . lsp-face-semhl-type)))
-
-(setq lsp-semantic-token-modifier-faces
+  (setq lsp-semantic-token-modifier-faces
       '(("declaration" . lsp-face-semhl-class)
         ("definition" . lsp-face-semhl-definition)
         ("readonly" . lsp-face-semhl-constant)
@@ -174,7 +174,7 @@ language server."
         ("terraform-backend" . lsp-face-semhl-definition)
         ("terraform-name" . lsp-face-semhl-label)
         ("terraform-type" . lsp-face-semhl-type)
-        ("terraform-requiredProviders" . lsp-face-semhl-default-library)))
+        ("terraform-requiredProviders" . lsp-face-semhl-default-library))))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection #'lsp-terraform-ls--make-launch-cmd)
@@ -208,6 +208,11 @@ This is a synchronous action."
      :no-merge t))
 
 (lsp-consistency-check lsp-terraform)
+
+(with-eval-after-load 'terraform-mode
+  (when lsp-semantic-tokens-enable
+    (lsp-terraform-ls--set-tokens)
+    (add-hook 'terraform-mode-hook #'lsp-terraform-ls--set-tokens)))
 
 (provide 'lsp-terraform)
 ;;; lsp-terraform.el ends here

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3483,8 +3483,8 @@ disappearing, unset all the variables related to it."
                       (formatting . ((dynamicRegistration . t)))
                       (rangeFormatting . ((dynamicRegistration . t)))
                       ,@(when (and lsp-semantic-tokens-enable
-                                   (boundp 'lsp-semantic-tokens-capabilities))
-                          lsp-semantic-tokens-capabilities)
+                                   (functionp 'lsp--semantic-tokens-capabilities))
+                          (lsp--semantic-tokens-capabilities))
                       (rename . ((dynamicRegistration . t) (prepareSupport . t)))
                       (codeAction . ((dynamicRegistration . t)
                                      (isPreferredSupport . t)

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -227,7 +227,7 @@ Unless overridden by a more specific face association."
   "Face used for static modifier."
   :group 'lsp-semantic-tokens)
 
-(defvar lsp-semantic-token-faces
+(defvar-local lsp-semantic-token-faces
   '(("comment" . lsp-face-semhl-comment)
     ("keyword" . lsp-face-semhl-keyword)
     ("string" . lsp-face-semhl-string)
@@ -256,7 +256,7 @@ Unless overridden by a more specific face association."
     ("concept" . lsp-face-semhl-interface))
   "Faces to use for semantic tokens.")
 
-(defvar lsp-semantic-token-modifier-faces
+(defvar-local lsp-semantic-token-modifier-faces
   '(("declaration" . lsp-face-semhl-interface)
     ("definition" . lsp-face-semhl-definition)
     ("implementation" . lsp-face-semhl-implementation)
@@ -272,7 +272,7 @@ Unless overridden by a more specific face association."
 Faces to use for semantic token modifiers if
 `lsp-semantic-tokens-apply-modifiers' is non-nil.")
 
-(defvar lsp-semantic-tokens-capabilities
+(defun lsp--semantic-tokens-capabilities ()
   `((semanticTokens
      . ((dynamicRegistration . t)
         (requests . ((range . t) (full . t)))


### PR DESCRIPTION
Summary of the changes:

- Make these variables buffer local:
  - lsp-semantic-token-faces
  - lsp-semantic-token-modifier-faces

The main reason for it is that a particular client will have more semantic tokens associated with them and making them buffer local makes it work seamlessly across different languages.

- Convert the variable lsp-semantic-tokens-capabilities to lsp--semantic-tokens-capabilities function so that the initialization
message to the language server is passed correctly.

- Add complete semantic token support for terraform lanuage. This has been tested using the official Hashicorps terraform language server.