### PR TITLE
fix broken separator line of lsp-headerline

### DIFF
--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -143,6 +143,10 @@ is an hints in symbols range."
   "Holds the current breadcrumb path-up-to-project segments for
 caching purposes.")
 
+;; Redefine local vars of `all-the-icons' to avoid bytecode compilation errors.
+(defvar all-the-icons-default-adjust)
+(defvar all-the-icons-scale-factor)
+
 (defun lsp-headerline--arrow-icon ()
   "Build the arrow icon for headerline breadcrumb."
   (or

--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -147,11 +147,13 @@ caching purposes.")
   "Build the arrow icon for headerline breadcrumb."
   (or
    lsp-headerline-arrow
-   (setq lsp-headerline-arrow (lsp-icons-all-the-icons-material-icon
-                               "chevron_right"
-                               'lsp-headerline-breadcrumb-separator-face
-                               ">"
-                               'headerline-breadcrumb))))
+   (setq lsp-headerline-arrow (let ((all-the-icons-scale-factor 1.0)
+                                    (all-the-icons-default-adjust 0))
+                                (lsp-icons-all-the-icons-material-icon
+                                 "chevron_right"
+                                 'lsp-headerline-breadcrumb-separator-face
+                                 ">"
+                                 'headerline-breadcrumb)))))
 
 (lsp-defun lsp-headerline--symbol-icon ((&DocumentSymbol :kind))
   "Build the SYMBOL icon for headerline breadcrumb."


### PR DESCRIPTION
Hi,

In this PR, I fixed the broken separating line of lsp-headerline, which was caused by the default setting of the `all-the-icons` package:

This is the current headerline separator (before being patched, the line with `>` is broken)

![lsp-header-line](https://user-images.githubusercontent.com/193967/171534768-37ac08d6-083d-4cae-8563-263f0c7dc511.png)

And here is the headerline after being applied the patch:

![lsp-header-line-fixed](https://user-images.githubusercontent.com/193967/171535103-93ee644d-dbbe-4ef2-ad1a-38da32fb7590.png)

Could you review and consider merging it?

Thank you!

