### PR TITLE
`lsp-update-servers` updates all installed servers

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7634,6 +7634,19 @@ When prefix UPDATE? is t force installation even if the server is present."
     (lsp--install-server-internal chosen-client t)))
 
 ;;;###autoload
+(defun lsp-update-servers ()
+  "Update all installed servers."
+  (interactive)
+  (lsp--require-packages)
+  (cl-loop for client in
+           (-filter (-andfn
+                     (-not #'lsp--client-download-in-progress?)
+                     #'lsp--client-download-server-fn
+                     #'lsp--server-binary-present?) (hash-table-values lsp-clients))
+           do (lsp--install-server-internal client t))
+  )
+
+;;;###autoload
 (defun lsp-ensure-server (server-id)
   "Ensure server SERVER-ID"
   (lsp--require-packages)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7614,7 +7614,7 @@ When prefix UPDATE? is t force installation even if the server is present."
 
 ;;;###autoload
 (defun lsp-update-server (&optional server-id)
-  "Interactively update a server."
+  "Interactively update (reinstall) a server."
   (interactive)
   (lsp--require-packages)
   (let ((chosen-client (or (gethash server-id lsp-clients)
@@ -7635,16 +7635,14 @@ When prefix UPDATE? is t force installation even if the server is present."
 
 ;;;###autoload
 (defun lsp-update-servers ()
-  "Update all installed servers."
+  "Update (reinstall) all installed servers."
   (interactive)
   (lsp--require-packages)
-  (cl-loop for client in
-           (-filter (-andfn
-                     (-not #'lsp--client-download-in-progress?)
-                     #'lsp--client-download-server-fn
-                     #'lsp--server-binary-present?) (hash-table-values lsp-clients))
-           do (lsp--install-server-internal client t))
-  )
+  (mapc (lambda (client) (lsp--install-server-internal client t))
+        (-filter (-andfn
+                  (-not #'lsp--client-download-in-progress?)
+                  #'lsp--client-download-server-fn
+                  #'lsp--server-binary-present?) (hash-table-values lsp-clients))))
 
 ;;;###autoload
 (defun lsp-ensure-server (server-id)


### PR DESCRIPTION
I have tested this and believe it works correctly.

The filter logic is copied from `lsp-update-server` above.

Closes https://github.com/emacs-lsp/lsp-mode/issues/3190

One downside is that many `*lsp-install:....` buffers are created.

Thanks