### PR TITLE
add Emacs 28.1 to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
                     - 26.3
                     - 27.1
                     - 27.2
+                    - 28.1
                     # TODO: activate when cask works with emacs snapshot
                     # - snapshot
 
@@ -76,6 +77,7 @@ jobs:
                     - 26.3
                     - 27.1
                     - 27.2
+                    - 28.1
                     # TODO: activate when cask works with emacs snapshot
                     # - snapshot
 


### PR DESCRIPTION
28.1 included here: https://github.com/cask/cask#typical-ci-usage