### PR TITLE
refactor lsp-elixir to be activated on "elixir"

### DIFF
--- a/clients/lsp-elixir.el
+++ b/clients/lsp-elixir.el
@@ -191,7 +191,7 @@ be available here: https://github.com/elixir-lsp/elixir-ls/releases/"
                                                 (lsp-package-path 'elixir-ls))
                                             "language_server.bat")
                                        ,@(cl-rest lsp-elixir-server-command))))
-                  :major-modes '(elixir-mode)
+                  :activation-fn (lsp-activate-on "elixir")
                   :priority -1
                   :server-id 'elixir-ls
                   :action-handlers (ht ("elixir.lens.test.run" 'lsp-elixir--run-test))


### PR DESCRIPTION
If you create a derived-mode, even if you add the new major-mode to `lsp-language-id-configuration`, `lsp` is not started.

It works if you activate on "elixir"