### PR TITLE
Fix how client returns folding range capabilities

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3534,12 +3534,12 @@ disappearing, unset all the variables related to it."
                       (documentLink . ((dynamicRegistration . t)
                                        (tooltipSupport . t)))
                       (hover . ((contentFormat . ["markdown" "plaintext"])))
-                      (foldingRange . ,(when lsp-enable-folding
-                                         `((dynamicRegistration . t)
-                                           ,@(when lsp-folding-range-limit
-                                               `((rangeLimit . ,lsp-folding-range-limit)))
-                                           ,@(when lsp-folding-line-folding-only
-                                               `((lineFoldingOnly . t))))))
+                      ,@(when lsp-enable-folding
+                          `((foldingRange . ((dynamicRegistration . t)
+                                             ,@(when lsp-folding-range-limit
+                                                 `((rangeLimit . ,lsp-folding-range-limit)))
+                                             ,@(when lsp-folding-line-folding-only
+                                                 `((lineFoldingOnly . t)))))))
                       (callHierarchy . ((dynamicRegistration . :json-false)))
                       (publishDiagnostics . ((relatedInformation . t)
                                              (tagSupport . ((valueSet . [1 2])))


### PR DESCRIPTION
This PR changes how the client returns folding range capabilities. In particular, if folding range is not enabled, it is omitted completely from the list of capabilities.

This seems to fix https://github.com/emacs-lsp/lsp-mode/issues/2722 for me (which is still an issue, see, e.g., https://github.com/gdkrmr/lsp-julia/issues/35#issuecomment-1102504324 and https://github.com/gdkrmr/lsp-julia/issues/35#issuecomment-1168101143).

As far as I understand, the [current behaviour of lsp-mode might be a violation of the specs](https://github.com/julia-vscode/LanguageServer.jl/issues/844#issuecomment-810563376) and the main reason for crashes observed with lsp-julia + LanguageServer.jl.

I'm not familiar with the code in lsp-mode and a beginner when it comes to lisp programming, so I'm not completely sure if this is the correct fix and how to add tests for it (if that is desired).