### PR TITLE
lsp-rust: set UPDATE_EXPECT=1 when expect-test on runnable

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -35,6 +35,7 @@
   * Add Gleam support
   * Drop deprecated rust-analyzer variable lsp-rust-analyzer-import-merge-behaviour
   * Added run and debug code lenses to ~lsp-kotlin~
+  * Add setting UPDATE_EXPECT=1 when running `expect!` tests ~lsp-rust~
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1126,12 +1126,15 @@ meaning."
 Extract the arguments, prepare the minor mode (cargo-process-mode if possible)
 and run a compilation"
   (-let* (((&rust-analyzer:Runnable :kind :label :args) runnable)
-          ((&rust-analyzer:RunnableArgs :cargo-args :executable-args :workspace-root?) args)
+          ((&rust-analyzer:RunnableArgs :cargo-args :executable-args :workspace-root? :expect-test?) args)
           (default-directory (or workspace-root? default-directory)))
     (if (not (string-equal kind "cargo"))
         (lsp--error "'%s' runnable is not supported" kind)
       (compilation-start
-       (string-join (append (list "cargo") cargo-args (when executable-args '("--")) executable-args '()) " ")
+       (string-join (append (when expect-test? '("env" "UPDATE_EXPECT=1"))
+                            (list "cargo") cargo-args
+                            (when executable-args '("--")) executable-args '()) " ")
+
        ;; cargo-process-mode is nice, but try to work without it...
        (if (functionp 'cargo-process-mode) 'cargo-process-mode nil)
        (lambda (_) (concat "*" label "*"))))))

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -414,7 +414,7 @@ See `-let' for a description of the destructuring mechanism."
                (rust-analyzer:MoveItemParams (:textDocument :range :direction) nil)
                (rust-analyzer:RunnablesParams (:textDocument) (:position))
                (rust-analyzer:Runnable (:label :kind :args) (:location))
-               (rust-analyzer:RunnableArgs (:cargoArgs :executableArgs) (:workspaceRoot))
+               (rust-analyzer:RunnableArgs (:cargoArgs :executableArgs) (:workspaceRoot :expectTest))
                (rust-analyzer:RelatedTestsParams (:textDocument :position) nil)
                (rust-analyzer:RelatedTests (:runnable) nil)
                (rust-analyzer:InlayHint (:position :label :kind :paddingLeft :paddingRight) nil)


### PR DESCRIPTION
The rust-analyzer `experimental/runnables` LSP extension includes an optional flag `expectTest`

https://github.com/rust-lang/vscode-rust/blob/b1ae67b06640ffab6e1ebb72e07364b4477dfbf1/rust-analyzer/editors/code/src/lsp_ext.ts#L59-L68

This is set when the cursor is on an `expect!` or `expect_file!` macro when the `lsp-rust-analyzer-run` command is invoked.

Update the `lsp-rust` client to include `env UPDATE_EXPECT=1` before the corgo command when this is set, so `expect` automatically updates the expected result to match actual.

![image](https://user-images.githubusercontent.com/409607/176537126-c2763b03-c350-4edd-98b2-f96f6eff14c0.png)
