### PR TITLE
lsp-rust: fix bad cond case in inlay-hints

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1044,13 +1044,13 @@ meaning."
       label
     (cond
      ((eql kind lsp/rust-analyzer-inlay-hint-kind-type-hint) (format lsp-rust-analyzer-inlay-type-format label))
-     ((eql kind lsp/rust-analyzer-inlay-hint-kind-type-hint) (format lsp-rust-analyzer-inlay-param-format label))
+     ((eql kind lsp/rust-analyzer-inlay-hint-kind-param-hint) (format lsp-rust-analyzer-inlay-param-format label))
      (t label))))
 
 (defun lsp-rust-analyzer-face-for-inlay (kind)
   (cond
    ((eql kind lsp/rust-analyzer-inlay-hint-kind-type-hint) 'lsp-rust-analyzer-inlay-type-face)
-   ((eql kind lsp/rust-analyzer-inlay-hint-kind-type-hint) 'lsp-rust-analyzer-inlay-param-face)
+   ((eql kind lsp/rust-analyzer-inlay-hint-kind-param-hint) 'lsp-rust-analyzer-inlay-param-face)
    (t 'lsp-rust-analyzer-inlay-face)))
 
 (defun lsp-rust-analyzer-initialized? ()


### PR DESCRIPTION
I think this is a small copy-paste that got through the net, found this out while trying to understand my other issue around plists