### PR TITLE
Download aarch64 version of rust-analyzer for ARM based Macs

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -886,7 +886,9 @@ or JSON objects in `rust-project.json` format."
   (format "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/%s"
           (pcase system-type
             ('gnu/linux "rust-analyzer-x86_64-unknown-linux-gnu.gz")
-            ('darwin "rust-analyzer-x86_64-apple-darwin.gz")
+            ('darwin (if (string-match "^aarch64-.*" system-configuration)
+                         "rust-analyzer-aarch64-apple-darwin.gz"
+                       "rust-analyzer-x86_64-apple-darwin.gz"))
             ('windows-nt "rust-analyzer-x86_64-pc-windows-msvc.gz")))
   "Automatic download url for Rust Analyzer"
   :type 'string


### PR DESCRIPTION
I was getting a lot of errors using the `x86_64` version of the `rust-analyzer` binary on a Mac using an M1 chip. Changing the download to the `aarch64` version fixed this. 