### PR TITLE
lsp-ansible: add command to resync inventory

### DIFF
--- a/clients/lsp-ansible.el
+++ b/clients/lsp-ansible.el
@@ -25,7 +25,6 @@
 ;;; Code:
 
 (require 'lsp-mode)
-(require 'lsp-completion)
 
 ;;; Ansible
 (defgroup lsp-ansible nil
@@ -200,6 +199,7 @@ This prevents the Ansible server from being turned on in all yaml files."
   "Resync the inventory cache used by Ansible Language Server for hosts completion."
   (interactive)
   (lsp-notify "resync/ansible-inventory" nil)
+  (require 'lsp-completion)
   (lsp-completion--clear-cache))
 
 (lsp-register-client

--- a/clients/lsp-ansible.el
+++ b/clients/lsp-ansible.el
@@ -195,6 +195,8 @@ This prevents the Ansible server from being turned on in all yaml files."
        ;; emacs-ansible provides ansible, not ansible-mode
        (with-no-warnings (bound-and-true-p ansible))))
 
+(declare-function lsp-completion--clear-cache "lsp-completion" (&optional keep-last-result))
+
 (defun lsp-ansible-resync-inventory ()
   "Resync the inventory cache used by Ansible Language Server for hosts completion."
   (interactive)

--- a/clients/lsp-ansible.el
+++ b/clients/lsp-ansible.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'lsp-mode)
+(require 'lsp-completion)
 
 ;;; Ansible
 (defgroup lsp-ansible nil
@@ -194,6 +195,12 @@ This prevents the Ansible server from being turned on in all yaml files."
   (and (eq major-mode 'yaml-mode)
        ;; emacs-ansible provides ansible, not ansible-mode
        (with-no-warnings (bound-and-true-p ansible))))
+
+(defun lsp-ansible-resync-inventory ()
+  "Resync the inventory cache used by Ansible Language Server for hosts completion."
+  (interactive)
+  (lsp-notify "resync/ansible-inventory" nil)
+  (lsp-completion--clear-cache))
 
 (lsp-register-client
  (make-lsp-client


### PR DESCRIPTION
The last version of Ansible Language Server add a notification event to resync the inventory cache (see https://github.com/ansible/ansible-language-server/releases/tag/v0.9.0-next.0 and https://github.com/ansible/ansible-language-server/pull/350).

This PR makes it easy for the user to send this notification with `lsp-mode`.