### PR TITLE
Allow to not cut the signature received on hover

### DIFF
--- a/clients/lsp-ocaml.el
+++ b/clients/lsp-ocaml.el
@@ -78,7 +78,7 @@
   :server-id 'ocaml-lsp-server))
 
 (defcustom lsp-cut-signature 'space
-  "If non-nil, signatures returned on hover will not be split on newline"
+  "If non-nil, signatures returned on hover will not be split on newline."
   :group 'lsp-ocaml
   :type '(choice (symbol :tag "Default behaviour" 'cut)
                  (symbol :tag "Display all the lines with spaces" 'space)))
@@ -86,18 +86,48 @@
 (cl-defmethod lsp-clients-extract-signature-on-hover (contents (_server-id (eql ocamllsp)) &optional storable)
   "Extract a representative line from OCaml's CONTENTS, to show in the echo area.
 This function splits the content between the signature
-and the documentation to display the signature"
-  (let ((type (lsp-make-marked-string
-               :language "ocaml"
-               :value (car (s-split "---" (lsp--render-element contents))))))
-      (if (eq lsp-cut-signature 'cut)
-          (car (s-lines (s-trim (lsp--render-element type))))
-        (if (and (eq lsp-cut-signature 'space) (equal nil storable))
-            (let* ((ntype (s-replace "\n" " " (s-trim (lsp--render-element type)))))
-              (if (>= (length ntype) (frame-width))
-                  (concat (substring ntype 0 (- (frame-width) 4)) "...")
-                ntype))
-        (s-trim (lsp--render-element type))))))
+and the documentation to display the signature
+and truncate it if it's too wide.
+The STORABLE argument is used if you want to use this
+function to get the type and, for example, kill and yank it.
+
+An example of function using STORABLE is:
+
+  (defun mdrp/lsp-get-type-and-kill ()
+    (interactive)
+    (let ((contents (-some->> (lsp--text-document-position-params)
+                    (lsp--make-request \"textDocument/hover\")
+                    (lsp--send-request)
+                    (lsp:hover-contents))))
+      (let ((contents (and contents
+                    (lsp--render-on-hover-content
+                     contents
+                     t))))
+        (let ((contents
+               (pcase (lsp-workspaces)
+                 (`(,workspace)
+                  (lsp-clients-extract-signature-on-hover
+                   contents
+                   (lsp--workspace-server-id workspace)
+                   t))
+                 (lsp-clients-extract-signature-on-hover
+                   contents
+                   nil)
+                 )))
+          (message \"Copied %s to kill-ring\" contents)
+          (kill-new contents)))))"
+  (let ((type (s-trim (lsp--render-element (lsp-make-marked-string
+                                            :language "ocaml"
+                                            :value (car (s-split "---" (lsp--render-element contents))))))))
+    (if (equal nil storable)
+        (if (eq lsp-cut-signature 'cut)
+            (car (s-lines type))
+          ;; else lsp-cut-signature is 'space
+          (let ((ntype (s-replace "\n" " " type)))
+            (if (>= (length ntype) (frame-width))
+                (concat (substring ntype 0 (- (frame-width) 4)) "...")
+              ntype)))
+      type)))
 
 (lsp-consistency-check lsp-ocaml)
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5246,7 +5246,6 @@ When language is nil render as markup if `markdown-mode' is loaded."
   "Extract a representative line from CONTENTS, to show in the echo area."
   (car (s-lines (s-trim (lsp--render-element contents)))))
 
-
 (defun lsp--render-on-hover-content (contents render-all)
   "Render the content received from 'document/onHover' request.
 CONTENTS  - MarkedString | MarkedString[] | MarkupContent

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -112,11 +112,6 @@
   :group 'lsp-mode
   :type 'boolean)
 
-(defcustom lsp-cut-signature t
-  "If non-nil, signatures returned on hover will not be split on newline"
-  :group 'lsp-mode
-  :type 'boolean)
-
 (defcustom lsp-log-io-allowlist-methods '()
   "The methods to filter before print to lsp-log-io."
   :group 'lsp-mode
@@ -5249,9 +5244,8 @@ When language is nil render as markup if `markdown-mode' is loaded."
 
 (cl-defgeneric lsp-clients-extract-signature-on-hover (contents _server-id)
   "Extract a representative line from CONTENTS, to show in the echo area."
-  (if lsp-cut-signature
-      (car (s-lines (s-trim (lsp--render-element contents))))
-    (s-replace "\n" " " (s-trim (lsp--render-element contents)))))
+  (car (s-lines (s-trim (lsp--render-element contents)))))
+
 
 (defun lsp--render-on-hover-content (contents render-all)
   "Render the content received from 'document/onHover' request.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -112,6 +112,11 @@
   :group 'lsp-mode
   :type 'boolean)
 
+(defcustom lsp-cut-signature t
+  "If non-nil, signatures returned on hover will not be split on newline"
+  :group 'lsp-mode
+  :type 'boolean)
+
 (defcustom lsp-log-io-allowlist-methods '()
   "The methods to filter before print to lsp-log-io."
   :group 'lsp-mode
@@ -5244,7 +5249,9 @@ When language is nil render as markup if `markdown-mode' is loaded."
 
 (cl-defgeneric lsp-clients-extract-signature-on-hover (contents _server-id)
   "Extract a representative line from CONTENTS, to show in the echo area."
-  (car (s-lines (s-trim (lsp--render-element contents)))))
+  (if lsp-cut-signature
+      (car (s-lines (s-trim (lsp--render-element contents))))
+    (s-replace "\n" " " (s-trim (lsp--render-element contents)))))
 
 (defun lsp--render-on-hover-content (contents render-all)
   "Render the content received from 'document/onHover' request.


### PR DESCRIPTION
Some servers (i.e. the ocamllsp one) return only the signature on hover (without the documentation) but tend to put newlines between the different items. With the current implementation of `lsp-clients-extract-signature-on-hover`, the displayed signature will only contain the first item

```ocaml
config1:string list ->
config2:string list -> config3:string list -> int -> int -> int
```

will then be rendered as

```ocaml
config1:string list ->
```

With the new implementation, a custom variable allows to take control over this behaviour and the function has been reimplemented to either return the previous result or return the signature with newlines replaced by spaces