### PR TITLE
[completion] Fix completion always sorting on client

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -475,8 +475,7 @@ The MARKERS and PREFIX value will be attached to each candidate."
                                              ((lsp-completion-list? resp)
                                               (lsp:completion-list-items resp))
                                              (t resp))
-                                         (if (or completed
-                                                 (seq-some #'lsp:completion-item-sort-text? it))
+                                         (if (seq-some #'lsp:completion-item-sort-text? it)
                                              (lsp-completion--sort-completions it)
                                            it)
                                          (-map (lambda (item)


### PR DESCRIPTION
After some debugging, I noticed lsp-completion always sorts on client side, even if server (testing with clojure-lsp) didn't provide `sort-text?` on completion items.
It seems that `completion` was the cause, not sure why that is there, but removing it fixes the issue, I'd like to understand why that was added and if we should indeed remove.