### PR TITLE
Remove spurious window.showMessage client capability

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3549,7 +3549,6 @@ disappearing, unset all the variables related to it."
                                              (versionSupport . t)))
                       (linkedEditingRange . ((dynamicRegistration . t)))))
      (window . ((workDoneProgress . t)
-                (showMessage . nil)
                 (showDocument . ((support . t))))))
    custom-capabilities))
 


### PR DESCRIPTION
Version 3.16 introduced additional window-specific client
capabilities, as

```ts
/**
         * Window specific client capabilities.
         */
        window?: {
                /**
                 * Whether client supports handling progress notifications. If set
                 * servers are allowed to report in `workDoneProgress` property in the
                 * request specific server capabilities.
                 *
                 * @since 3.15.0
                 */
                workDoneProgress?: boolean;

                /**
                 * Capabilities specific to the showMessage request
                 *
                 * @since 3.16.0
                 */
                showMessage?: ShowMessageRequestClientCapabilities;

                /**
                 * Client capabilities for the show document request.
                 *
                 * @since 3.16.0
                 */
                showDocument?: ShowDocumentClientCapabilities;
        };
```

In particular, `showMessage` should either not be present, or have
contents `ShowMessageRequestClientCapabilities`.

We were setting it to NIL, this removes it completely to be compliant.

See
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities