### PR TITLE
feat(clients): add support for the syntax_tree Ruby gem

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -39,6 +39,7 @@
   * Add ~lsp-use-workspace-root-for-server-default-directory~.
   * Add [[https://github.com/artempyanykh/marksman][marksman]] support.
   * ~lsp-find-references~ to include declaration by default
+  * Add [[https://github.com/ruby-syntax-tree/syntax_tree][syntax_tree]] support for Ruby code.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-ruby-syntax-tree.el
+++ b/clients/lsp-ruby-syntax-tree.el
@@ -1,0 +1,59 @@
+;;; lsp-ruby-syntax-tree.el --- lsp-mode for the Ruby syntax_tree gem -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022 Geoffrey Lessel
+
+;; Author: Geoffrey Lessel
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP client for the Ruby syntax_tree gem.
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-ruby-syntax-tree nil
+  "LSP support for the Ruby syntax_tree gem."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/ruby-syntax-tree/syntax_tree"))
+
+(defcustom lsp-ruby-syntax-tree-use-bundler nil
+  "Run stree (the syntax_tree executable) using bundler."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'lsp-ruby-syntax-tree)
+
+(defcustom lsp-ruby-syntax-tree-format-options nil
+  "Options to pass to the stree lsp server."
+  :type '(repeat string)
+  :group 'lsp-ruby-syntax-tree)
+
+(defun lsp-ruby-syntax-tree--build-command ()
+  (append
+   (if lsp-ruby-syntax-tree-use-bundler '("bundle" "exec"))
+   '("stree" "lsp")
+   lsp-ruby-syntax-tree-format-options))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection #'lsp-ruby-syntax-tree--build-command)
+  :major-modes '(ruby-mode enh-ruby-mode)
+  :priority -4
+  :server-id 'ruby-syntax-tree-ls))
+
+(provide 'lsp-ruby-syntax-tree)
+;;; lsp-ruby-syntax-tree.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -734,6 +734,15 @@
     "debugger": "Not available"
   },
   {
+    "name": "syntax_tree",
+    "common-group-name": "Ruby (syntax_tree)",
+    "full-name": "ruby-syntax-tree",
+    "server-name": "stree",
+    "server-url": "https://github.com/ruby-syntax-tree/syntax_tree",
+    "installation-url": "https://github.com/ruby-syntax-tree/syntax_tree#installation",
+    "debugger": "Not available"
+  },
+  {
     "name": "terraform",
     "full-name": "Terraform",
     "server-name": "terraform-lsp",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -182,7 +182,7 @@ As defined by the Language Server Protocol 3.16."
          lsp-pyright lsp-python-ms lsp-purescript lsp-r lsp-racket lsp-remark lsp-rf lsp-rust lsp-solargraph
          lsp-sorbet lsp-sourcekit lsp-sonarlint lsp-tailwindcss lsp-tex lsp-terraform lsp-toml
          lsp-ttcn3 lsp-typeprof lsp-v lsp-vala lsp-verilog lsp-vetur lsp-volar lsp-vhdl lsp-vimscript
-         lsp-xml lsp-yaml lsp-sqls lsp-svelte lsp-steep lsp-zig)
+         lsp-xml lsp-yaml lsp-ruby-syntax-tree lsp-sqls lsp-svelte lsp-steep lsp-zig)
   "List of the clients to be automatically required."
   :group 'lsp-mode
   :type '(repeat symbol))


### PR DESCRIPTION
This adds the client for the `syntax_tree` Ruby gem. The naming on
this one was a bit odd as the github org name is "ruby-syntax-tree",
the gem name is "syntax_tree", and the executable is "stree". I
attempted to standardize on "ruby-syntax-tree".

[syntax_tree](https://github.com/ruby-syntax-tree/syntax_tree) is a
Ruby gem that at the moment doesn't provide a lot of functionality
in its lsp server, but _does_ provide auto formatting which is something
I would really like.