### PR TITLE
Add configuration for excluding declarations from xrefs/references

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -38,7 +38,7 @@
   * Add setting UPDATE_EXPECT=1 when running `expect!` tests ~lsp-rust~
   * Add ~lsp-use-workspace-root-for-server-default-directory~.
   * Add [[https://github.com/artempyanykh/marksman][marksman]] support.
-  * ~lsp-find-references~ to include declaration by default
+  * ~lsp-find-references~ to include declaration by default (configurable with ~lsp-references-exclude-definition~)
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -504,6 +504,11 @@ If this is set to nil, `eldoc' will show only the symbol information."
   :type 'boolean
   :group 'lsp-mode)
 
+(defcustom lsp-references-exclude-definition nil
+  "If non-nil, exclude declarations when finding references."
+  :type 'boolean
+  :group 'lsp-mode)
+
 (defcustom lsp-enable-indentation t
   "Indent regions using the file formatting functionality provided by the
 language server."
@@ -5984,7 +5989,7 @@ perform the request synchronously."
       (goto-char (cl-rest (or (assoc identifier lsp--symbols-cache)
                               (user-error "Unable to find symbol %s" identifier)))))
     (lsp--locations-to-xref-items (lsp-request "textDocument/references"
-                                               (lsp--make-reference-params)))))
+                                               (lsp--make-reference-params nil lsp-references-exclude-definition)))))
 
 (cl-defmethod xref-backend-apropos ((_backend (eql xref-lsp)) pattern)
   (seq-map #'lsp--symbol-information-to-xref
@@ -6155,7 +6160,7 @@ REFERENCES? t when METHOD returns references."
   "Find references of the symbol under point."
   (interactive "P")
   (lsp-find-locations "textDocument/references"
-                      (list :context `(:includeDeclaration ,(lsp-json-bool (not exclude-declaration))))
+                      (list :context `(:includeDeclaration ,(lsp-json-bool (not (or exclude-declaration lsp-references-exclude-definition)))))
                       :display-action display-action
                       :references? t))
 


### PR DESCRIPTION
Add variable `lsp-references-exclude-definition`, to allow `lsp-find-references` and `xref-find-references` to exclude declarations (keeping the current default behaviour of including them).