### PR TITLE
Don't prompt for an action within `lsp-organize-imports`, even if `lsp-auto-execute-action` is disabled.

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -40,6 +40,7 @@
   * Add [[https://github.com/artempyanykh/marksman][marksman]] support.
   * ~lsp-find-references~ to include declaration by default (configurable with ~lsp-references-exclude-definition~)
   * Add [[https://github.com/ruby-syntax-tree/syntax_tree][syntax_tree]] support for Ruby code.
+  * ~lsp-organize-imports~ no longer prompts for an action, even if ~lsp-auto-execute-action~ is nil.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5759,11 +5759,14 @@ execute a CODE-ACTION-KIND action."
   `(defun ,(intern (concat "lsp-" (symbol-name func-name))) ()
      ,(format "Perform the %s code action, if available." code-action-kind)
      (interactive)
-     (condition-case nil
-         (lsp-execute-code-action-by-kind ,code-action-kind)
-       (lsp-no-code-actions
-        (when (called-interactively-p 'any)
-          (lsp--info ,(format "%s action not available" code-action-kind)))))))
+     ;; Even when `lsp-auto-execute-action' is nil, it still makes sense to
+     ;; auto-execute here: the user has specified exactly what they want.
+     (let ((lsp-auto-execute-action t))
+       (condition-case nil
+           (lsp-execute-code-action-by-kind ,code-action-kind)
+         (lsp-no-code-actions
+          (when (called-interactively-p 'any)
+            (lsp--info ,(format "%s action not available" code-action-kind))))))))
 
 (lsp-make-interactive-code-action organize-imports "source.organizeImports")
 


### PR DESCRIPTION
Prior to this change invoking `lsp-organize-imports` would prompt for a choice of action, if the variable `lsp-auto-execute-action` were set to nil. This seems unintentional.

`lsp-auto-execute-action` is useful when `lsp-execute-code-action` is invoked directly and the user doesn't necessarily know what action would be executed automatically. But for a function like `lsp-organize-imports` created via `lsp-make-interactive-code-action`, we know the user asked for a specific action to be performed, so it doesn't make sense to prompt them again.

I encountered this behavior because I've set up the before-save hooks [officially recommended here](https://github.com/golang/tools/blob/master/gopls/doc/emacs.md#loading-lsp-mode-in-emacs) for the Go language; with the `lsp-organize-imports` hook and `(setq
lsp-auto-execute-action nil)`, saving prompts every time.