### PR TITLE
lsp-rust: add semantic token modifiers

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -48,6 +48,7 @@
   * Fix ~lsp-avy-lens~ when ~avy-style~ is ~'de-bruijn~ or ~'words~ #3554
   * Fix ~lsp-avy-lens~ when ~lsp-lens-place-position~ position is ~end-of-line~
   * Add ~lsp-clojure-trace-enable~ variable.
+  * Add some support for rust-analyzer semantic token modifiers.  Highlights mutable and reference variables.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.


### PR DESCRIPTION
This is more of a proof-of-concept than anything else.

It works for the "mutable" modifier, adding an underline. This matches
what the VsCode client does, but clashes with the lsp-mode default for
read vs write highlighted variables. The rest have a no-operation face
assigned, but need to be there to get the numbers right.

It is based on the approach in `lsp-terraform.el`.  I tried setting it
in the client registration as per `lsp-clojure.el`, but the final
mapping of fonts to indexes does not work for some reason,
as the call to `lsp--semantic-tokens-initialize-workspace` does not get
the correct value from (`lsp-semantic-tokens--modifier-faces-for
client`), 
despite them being set elsewhere. I suspect a timing or update problem.

I set `  (setq lsp-semantic-tokens-enable t)` in `(use-package lsp-mode` in my personal init file to enable this.