### PR TITLE
Permit semantic token overrides to extend base set

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1503,7 +1503,34 @@ return value of `body' or nil if interrupted."
   multi-root
   ;; Initialization options or a function that returns initialization options.
   initialization-options
-  ;; Overrides semantic tokens faces for specific clients
+  ;; `semantic-tokens-faces-overrides’ is a plist that can be used to extend, or
+  ;; completely replace, the faces used for semantic highlighting on a
+  ;; client-by-client basis.
+  ;;
+  ;; It recognizes four members, all of which are optional: `:types’ and
+  ;; `:modifiers’, respectively, should be face definition lists akin to
+  ;; `:lsp-semantic-token-faces’. If specified, each of these face lists will be
+  ;; merged with the default face definition list.
+  ;;
+  ;; Alternatively, if the plist members `:discard-default-types’ or
+  ;; `:discard-default-modifiers' are non-nil, the default `:type' or `:modifiers'
+  ;; face definitions will be replaced entirely by their respective overrides.
+  ;;
+  ;; For example, setting `:semantic-tokens-faces-overrides' to
+  ;; `(:types (("macro" . font-lock-keyword-face)))' will remap "macro" tokens from
+  ;; their default face `lsp-face-semhl-macro' to `font-lock-keyword-face'.
+  ;;
+  ;; `(:types (("macro" . font-lock-keyword-face) ("not-quite-a-macro" . some-face)))'
+  ;; will also remap "macro", but on top of that associate the fictional token type
+  ;; "not-quite-a-macro" with the face named `some-face'.
+  ;;
+  ;; `(:types (("macro" . font-lock-keyword-face))
+  ;;   :modifiers (("declaration" . lsp-face-semhl-interface))
+  ;;   :discard-default-types t
+  ;;   :discard-default-modifiers t)'
+  ;; will discard all default face definitions, hence leaving the client with
+  ;; only one token type "macro", mapped to `font-lock-keyword-face', and one
+  ;; modifier type "declaration", mapped to `lsp-face-semhl-interface'.
   semantic-tokens-faces-overrides
   ;; Provides support for registering LSP Server specific capabilities.
   custom-capabilities

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -674,8 +674,9 @@ IS-RANGE-PROVIDER is non-nil when server supports range requests."
   "Merge alist BASE with OVERRIDES.
 For keys present in both alists, the assignments made by
 OVERRIDES will take precedence."
-  (let ((all-keys (-union (mapcar #'car base) (mapcar #'car overrides))))
-    (--map (cons it (alist-get it overrides (alist-get it base) nil #'string=)) all-keys)))
+  (let* ((copy-base (copy-alist base)))
+    (mapc (-lambda ((key . value)) (setf (alist-get key copy-base nil nil #'string=) value)) overrides)
+    copy-base))
 
 (defun lsp-semantic-tokens--type-faces-for (client)
   "Return the semantic token type faces for CLIENT."

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -670,25 +670,29 @@ IS-RANGE-PROVIDER is non-nil when server supports range requests."
                        (lsp-warn "No face has been associated to the %s '%s': consider adding a corresponding definition to %s"
                                  category id varname)) maybe-face)) identifiers)))
 
-(defun lsp-semantic-tokens--apply-alist-overrides (base overrides)
-  "Merge alist BASE with OVERRIDES.
+(defun lsp-semantic-tokens--apply-alist-overrides (base overrides discard-defaults)
+  "Merge or replace BASE with OVERRIDES, depending on DISCARD-DEFAULTS.
 For keys present in both alists, the assignments made by
 OVERRIDES will take precedence."
-  (let* ((copy-base (copy-alist base)))
-    (mapc (-lambda ((key . value)) (setf (alist-get key copy-base nil nil #'string=) value)) overrides)
-    copy-base))
+  (if discard-defaults
+      overrides
+    (let* ((copy-base (copy-alist base)))
+      (mapc (-lambda ((key . value)) (setf (alist-get key copy-base nil nil #'string=) value)) overrides)
+      copy-base)))
 
 (defun lsp-semantic-tokens--type-faces-for (client)
   "Return the semantic token type faces for CLIENT."
   (lsp-semantic-tokens--apply-alist-overrides
    lsp-semantic-token-faces
-   (plist-get (lsp--client-semantic-tokens-faces-overrides client) :types)))
+   (plist-get (lsp--client-semantic-tokens-faces-overrides client) :types)
+   (plist-get (lsp--client-semantic-tokens-faces-overrides client) :discard-default-types)))
 
 (defun lsp-semantic-tokens--modifier-faces-for (client)
   "Return the semantic token type faces for CLIENT."
   (lsp-semantic-tokens--apply-alist-overrides
    lsp-semantic-token-modifier-faces
-   (plist-get (lsp--client-semantic-tokens-faces-overrides client) :modifiers)))
+   (plist-get (lsp--client-semantic-tokens-faces-overrides client) :modifiers)
+   (plist-get (lsp--client-semantic-tokens-faces-overrides client) :discard-default-modifiers)))
 
 (defun lsp--semantic-tokens-on-refresh (workspace)
   "Clear semantic tokens within all buffers of WORKSPACE,

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -277,9 +277,9 @@ Faces to use for semantic token modifiers if
      . ((dynamicRegistration . t)
         (requests . ((range . t) (full . t)))
         (tokenModifiers . ,(if lsp-semantic-tokens-apply-modifiers
-                               (apply 'vector (mapcar #'car lsp-semantic-token-modifier-faces))
+                               (apply 'vector (mapcar #'car (lsp-semantic-tokens--modifier-faces-for (lsp--workspace-client lsp--cur-workspace))))
                              []))
-        (tokenTypes . ,(apply 'vector (mapcar #'car lsp-semantic-token-faces)))
+        (tokenTypes . ,(apply 'vector (mapcar #'car (lsp-semantic-tokens--type-faces-for (lsp--workspace-client lsp--cur-workspace)))))
         (formats . ["relative"])))))
 
 (defvar lsp--semantic-tokens-pending-full-token-requests '()


### PR DESCRIPTION
please don't merge -- I haven't tested this yet. As @alanz noted, the current implementation of `lsp--client-semantic-tokens-faces-overrides` doesn't allow client package authors to add new faces or modifiers to the base set; the present mini-PR should fix that (plan to try this out tomorrow, won't get to it today)