### PR TITLE
Allow dynamicRegistration for declaration/definition/completion

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -428,9 +428,10 @@ The MARKERS and PREFIX value will be attached to each candidate."
   (when (or (--some (lsp--client-completion-in-comments? (lsp--workspace-client it))
                     (lsp-workspaces))
             (not (nth 4 (syntax-ppss))))
-    (let* ((trigger-chars (->> (lsp--server-capabilities)
-                               (lsp:server-capabilities-completion-provider?)
-                               (lsp:completion-options-trigger-characters?)))
+    (let* ((trigger-chars (-> (or (lsp--capability :completionProvider)
+                                  (-some-> (lsp--registered-capability "textDocument/completion")
+                                    (lsp--registered-capability-options)))
+                              (lsp:completion-options-trigger-characters?)))
            (bounds-start (or (-some--> (cl-first (bounds-of-thing-at-point 'symbol))
                                (save-excursion
                                  (ignore-errors

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -854,7 +854,7 @@ Changes take effect only when a new session is started."
 We want to try the last workspace first when jumping into a library
 directory")
 
-(defvar lsp-method-requirements
+(defconst lsp-method-requirements
   '(("textDocument/callHierarchy" :capability :callHierarchyProvider)
     ("textDocument/codeAction" :capability :codeActionProvider)
     ("codeAction/resolve"
@@ -862,16 +862,17 @@ directory")
                       (with-lsp-workspace workspace
                         (lsp:code-action-options-resolve-provider?
                          (or (lsp--capability :codeActionProvider)
-                             (when-let ((maybe-capability (lsp--registered-capability "textDocument/codeAction"))
-                                        (capability-options (lsp--registered-capability-options maybe-capability)))
-                               capability-options))))))
+                             (-some-> (lsp--registered-capability "textDocument/codeAction")
+                               (lsp--registered-capability-options)))))))
     ("textDocument/codeLens" :capability :codeLensProvider)
     ("textDocument/completion" :capability :completionProvider)
     ("completionItem/resolve"
      :check-command (lambda (wk)
                       (with-lsp-workspace wk
                         (lsp:completion-options-resolve-provider?
-                         (lsp--capability :completionProvider)))))
+                         (or (lsp--capability :completionProvider)
+                             (-some-> (lsp--registered-capability "textDocument/completion")
+                               (lsp--registered-capability-options)))))))
     ("textDocument/declaration" :capability :declarationProvider)
     ("textDocument/definition" :capability :definitionProvider)
     ("textDocument/documentColor" :capability :colorProvider)
@@ -889,8 +890,8 @@ directory")
                       (with-lsp-workspace workspace
                         (lsp:rename-options-prepare-provider?
                          (or (lsp--capability :renameProvider)
-                             (when-let ((maybe-capability (lsp--registered-capability "textDocument/rename")))
-                               (lsp--registered-capability-options maybe-capability)))))))
+                             (-some-> (lsp--registered-capability "textDocument/rename")
+                               (lsp--registered-capability-options)))))))
     ("textDocument/rangeFormatting" :capability :documentRangeFormattingProvider)
     ("textDocument/references" :capability :referencesProvider)
     ("textDocument/rename" :capability :renameProvider)
@@ -3493,10 +3494,14 @@ disappearing, unset all the variables related to it."
                                       (willRename . t)
                                       (didDelete . :json-false)
                                       (willDelete . :json-false)))))
-     (textDocument . ((declaration . ((linkSupport . t)))
-                      (definition . ((linkSupport . t)))
-                      (implementation . ((linkSupport . t)))
-                      (typeDefinition . ((linkSupport . t)))
+     (textDocument . ((declaration . ((dynamicRegistration . t)
+                                      (linkSupport . t)))
+                      (definition . ((dynamicRegistration . t)
+                                     (linkSupport . t)))
+                      (implementation . ((dynamicRegistration . t)
+                                         (linkSupport . t)))
+                      (typeDefinition . ((dynamicRegistration . t)
+                                         (linkSupport . t)))
                       (synchronization . ((willSave . t) (didSave . t) (willSaveWaitUntil . t)))
                       (documentSymbol . ((symbolKind . ((valueSet . ,(apply 'vector (number-sequence 1 26)))))
                                          (hierarchicalDocumentSymbolSupport . t)))
@@ -3537,7 +3542,8 @@ disappearing, unset all the variables related to it."
                                                                            "additionalTextEdits"
                                                                            "command"])))
                                                         (insertTextModeSupport . ((valueSet . [1 2])))))
-                                     (contextSupport . t)))
+                                     (contextSupport . t)
+                                     (dynamicRegistration . t)))
                       (signatureHelp . ((signatureInformation . ((parameterInformation . ((labelOffsetSupport . t)))))))
                       (documentLink . ((dynamicRegistration . t)
                                        (tooltipSupport . t)))


### PR DESCRIPTION
Currently `pwsh-ls` is not working for finding definition since the capabilities are pushed down via `client/registerCapability`.
The same thing happens for completion as well, we need to support them with dynamic registration.