### PR TITLE
[eslint] Correct handling of absolute paths in lsp-eslint-working-directories

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -42,6 +42,7 @@
   * Add [[https://github.com/ruby-syntax-tree/syntax_tree][syntax_tree]] support for Ruby code.
   * ~lsp-organize-imports~ no longer prompts for an action, even if ~lsp-auto-execute-action~ is nil.
   * Add [[https://github.com/mint-lang/mint][mint-lang]] support.
+  * Fix handling of absolute paths in ~lsp-eslint-working-directories~
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -120,7 +120,9 @@ source.fixAll code action."
   :package-version '(lsp-mode . "6.3"))
 
 (defcustom lsp-eslint-working-directories []
-  ""
+  "A vector of working directory names to use. Can be relative to
+the workspace root or absolute. The home directory reference ~/
+is not currently supported - use /home/[user]/ instead."
   :type 'lsp-string-vector
   :package-version '(lsp-mode . "6.3"))
 
@@ -291,8 +293,9 @@ stored."
 contains the current file"
   (let ((directories (-map (lambda (dir)
                              (let ((dir (lsp-resolve-value dir)))
-                               (when (not (f-absolute? dir))
-                                 (setq dir (f-join workspace dir)))))
+                               (if (f-absolute? dir)
+                                   dir
+                                 (f-join workspace dir))))
                            (append lsp-eslint-working-directories nil))))
     (-first (lambda (dir) (f-ancestor-of-p dir current-file)) directories)))
 


### PR DESCRIPTION
As the current logic turns all absolute paths into nil.

Local tests not run as, unfortunately, `cask` doesn't seem to work with NixOS wrapped emacs.