### PR TITLE
Make more capabilities become dynamically registrable

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -428,9 +428,7 @@ The MARKERS and PREFIX value will be attached to each candidate."
   (when (or (--some (lsp--client-completion-in-comments? (lsp--workspace-client it))
                     (lsp-workspaces))
             (not (nth 4 (syntax-ppss))))
-    (let* ((trigger-chars (-> (or (lsp--capability :completionProvider)
-                                  (-some-> (lsp--registered-capability "textDocument/completion")
-                                    (lsp--registered-capability-options)))
+    (let* ((trigger-chars (-> (lsp--capability-for-method "textDocument/completion")
                               (lsp:completion-options-trigger-characters?)))
            (bounds-start (or (-some--> (cl-first (bounds-of-thing-at-point 'symbol))
                                (save-excursion


### PR DESCRIPTION
Makes the following capabilities become dynamically registrable since some language servers (e.x `pwsh-ls` is sending them as dynamic capabilities)
- `onTypeFormatting`
- `signatureHelp`
- `hover`
- `selectionRange`
- `typeHierarchy`

Also add `lsp--capability-for-method` as a shortcut to return `RegistrationOptions` and switch a few `lsp--capability` check to `lsp-feature?` instead.
