### PR TITLE
[ansible] replace mode equality check with `derived-mode-p`

### DIFF
--- a/clients/lsp-ansible.el
+++ b/clients/lsp-ansible.el
@@ -191,7 +191,7 @@ Python virtual environment."
 (defun lsp-ansible-check-ansible-minor-mode (&rest _)
   "Check whether ansible minor mode is active.
 This prevents the Ansible server from being turned on in all yaml files."
-  (and (eq major-mode 'yaml-mode)
+  (and (derived-mode-p 'yaml-mode)
        ;; emacs-ansible provides ansible, not ansible-mode
        (with-no-warnings (bound-and-true-p ansible))))
 


### PR DESCRIPTION
Fixes #3687

Omitted the changelog entry because the change is pretty insignificant.