### PR TITLE
docs: update Fortran LSP to fortls

### DIFF
--- a/clients/lsp-fortran.el
+++ b/clients/lsp-fortran.el
@@ -29,7 +29,7 @@
 (defgroup lsp-fortran nil
   "LSP support for Fortran, using the Fortran Language Server."
   :group 'lsp-mode
-  :link '(url-link "https://github.com/hansec/fortran-language-server"))
+  :link '(url-link "https://gnikit.github.io/fortls"))
 
 (defcustom lsp-clients-fortls-executable "fortls"
   "The fortls executable to use.

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -212,9 +212,9 @@
   {
     "name": "fortran",
     "full-name": "Fortran",
-    "server-name": "fortran-language-server",
-    "server-url": "https://github.com/hansec/fortran-language-server",
-    "installation": "pip install fortran-language-server",
+    "server-name": "fortls",
+    "server-url": "https://gnikit.github.io/fortls",
+    "installation": "pip install fortls",
     "debugger": "Yes"
   },
   {


### PR DESCRIPTION
The project fortran-language-server has been abandoned, we have created
a new Language Server called fortls, with backwards compatibility,
a lot of bug fixes and a plethora of new features.

See the docs for more info: https://gnikit.github.io/fortls/

- [] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)

- [] I updated documentation if applicable (`docs` folder)
