### PR TITLE
Allow running the Sorbet server as an add-on alongside Solargraph

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -42,6 +42,7 @@
   * Add [[https://github.com/ruby-syntax-tree/syntax_tree][syntax_tree]] support for Ruby code.
   * ~lsp-organize-imports~ no longer prompts for an action, even if ~lsp-auto-execute-action~ is nil.
   * Add [[https://github.com/mint-lang/mint][mint-lang]] support.
+  * Add ~lsp-sorbet-as-add-on~ variable to allow running the Sorbet server as an add-on alongside Solargraph or others
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing
 
-`emacs-lsp` is a very active organization so before you start working on 
-a feature/issue make sure that there is a corresponding issue and drop a 
-note that you start working on that to avoid collisions. 
-Feel free to ping the maintainers in [Discord](https://discord.gg/Wrqrf42f2h) 
+`emacs-lsp` is a very active organization so before you start working on
+a feature/issue make sure that there is a corresponding issue and drop a
+note that you start working on that to avoid collisions.
+Feel free to ping the maintainers in [Discord](https://discord.gg/Wrqrf42f2h)
 chat or in the issue report if you need help/clarification on how things work.
 
 If you discover issues, have ideas for improvements or new features,
@@ -26,7 +26,7 @@ do so.
 ### Reporting bugs
 
 When reporting bugs it's a good idea to go through the [Troubleshooting section
-of the documentation][7].  Adding information like the backtrace and the *lsp-log* buffer to
+of the documentation][5].  Adding information like the backtrace and the *lsp-log* buffer to
 the bug report makes it easier to track down bugs. Some steps to reproduce a bug
 reliably would also make a huge difference.
 
@@ -36,11 +36,11 @@ reliably would also make a huge difference.
 * Use the same coding conventions as the rest of the project.
 * Make sure that the unit tests are passing locally via `make test` or via the CI.
 * Write [good commit messages][3].
-* Update the [changelog][6].
+* Update the [changelog][4].
 * Code-style/formatting changes and typo-fixes should go into their own commits and put into the `.git-blame-ignore-revs` file to avoid thrashing the `git blame` data.
 
 [1]: https://github.com/emacs-lsp/lsp-mode/issues
 [2]: http://gun.io/blog/how-to-github-fork-branch-and-pull-request
 [3]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
-[4]: https://github.com/emacs-lsp/lsp-mode/blob/master/CHANGELOG.md
-[5]: https://emacs-lsp.github.io/lsp-mode/page/troubleshooting/
+[4]: CHANGELOG.org
+[5]: docs/page/troubleshooting.md

--- a/clients/lsp-sorbet.el
+++ b/clients/lsp-sorbet.el
@@ -38,6 +38,12 @@
   :group 'lsp-sorbet
   :package-version '(lsp-mode . "8.0.0"))
 
+(defcustom lsp-sorbet-as-add-on nil
+  "Run sorbet LSP server alongside other LSP server(s)"
+  :type 'boolean
+  :group 'lsp-sorbet
+  :package-version '(lsp-mode . "8.0.0"))
+
 (defun lsp-sorbet--build-command ()
   "Build sorbet command"
   (let ((lsp-command '("srb" "typecheck" "--lsp" "--disable-watchman")))
@@ -47,6 +53,7 @@
 
 (lsp-register-client
  (make-lsp-client
+  :add-on? lsp-sorbet-as-add-on
   :new-connection (lsp-stdio-connection
                    #'lsp-sorbet--build-command)
   :priority -2


### PR DESCRIPTION
A common Ruby setup is to run the Sorbet typechecker alongside a main server like Solargraph, this new variable will allow this setup by enabling it in your Emacs init file:

```elisp
(setq-default
 ;; lsp-mode run sorbet LSP as add-on alongside solargraph
 lsp-sorbet-as-add-on t)
```

I've considered making the Sorbet client default to being an add-on, however if you have Sorbet installed but not Solargraph it will try to start the TypeProf server which I found doesn't work with older versions of Ruby out of the box. So in the end I think this is the cleanest solution, but let me know your thoughts.