### PR TITLE
Fix #3554 and add a space when lsp-lens-place-position is end-of-line

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -45,6 +45,8 @@
   * Add ~lsp-sorbet-as-add-on~ variable to allow running the Sorbet server as an add-on alongside Solargraph or others
   * Add [[https://github.com/nikeee/dot-language-server][dot-language-server]] (/a.k.a./ Graphviz) support.
   * Add [[https://github.com/FractalBoy/perl-language-server][PLS]] support (additional sever for Perl).
+  * Fix ~lsp-avy-lens~ when ~avy-style~ is ~'de-bruijn~ or ~'words~ #3554
+  * Fix ~lsp-avy-lens~ when ~lsp-lens-place-position~ position is ~end-of-line~
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -398,6 +398,7 @@ CALLBACK - callback for the lenses."
 (declare-function avy-process "ext:avy" (candidates &optional overlay-fn cleanup-fn))
 (declare-function avy--key-to-char "ext:avy" (c))
 (defvar avy-action)
+(defvar avy-style)
 
 ;;;###autoload
 (defun lsp-avy-lens ()
@@ -406,6 +407,7 @@ CALLBACK - callback for the lenses."
   (unless lsp-lens--overlays
     (user-error "No lenses in current buffer"))
   (let* ((avy-action 'identity)
+         (avy-style 'lsp-avy-lens)
          (position (if (eq lsp-lens-place-position 'end-of-line)
                        'after-string
                      'before-string))
@@ -439,9 +441,13 @@ CALLBACK - callback for the lenses."
                                        (concat new-str "\n"))))
                        (overlay-put ov position new-str)))
                    (lambda ()
-                     (--map (overlay-put it position
-                                         (overlay-get it 'lsp-original))
-                            lsp-lens--overlays))))))
+                     (--map
+                      (let ((original (overlay-get it 'lsp-original)))
+                        (overlay-put it position
+                                     (if (eq lsp-lens-place-position 'end-of-line)
+                                         (concat " " original)
+                                       original)))
+                      lsp-lens--overlays))))))
     (when action (funcall-interactively action))))
 
 (lsp-consistency-check lsp-lens)


### PR DESCRIPTION
Fix #3554
It's because [here](https://github.com/abo-abo/avy/blob/ba5f035be33693d1a136a5cbeedb24327f551a92/avy.el#L816), neither avy style `'de-bruijn` nor `'words` trigger overlay-fn.
But lsp-avy-lens need overlay-fn (the second argument of avy-process) to work.

And according to [this line](https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-lens.el#L98), there should be a whitespace if position is `'end-of-line`.
