### PR TITLE
lsp-completion-at-point: simplify bound calculation

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -430,15 +430,7 @@ The MARKERS and PREFIX value will be attached to each candidate."
             (not (nth 4 (syntax-ppss))))
     (let* ((trigger-chars (-> (lsp--capability-for-method "textDocument/completion")
                               (lsp:completion-options-trigger-characters?)))
-           (bounds-start (or (-some--> (cl-first (bounds-of-thing-at-point 'symbol))
-                               (save-excursion
-                                 (ignore-errors
-                                   (goto-char (+ it 1))
-                                   (while (lsp-completion--looking-back-trigger-characterp
-                                           trigger-chars)
-                                     (cl-incf it)
-                                     (forward-char))
-                                   it)))
+           (bounds-start (or (cl-first (bounds-of-thing-at-point 'symbol))
                              (point)))
            result done?
            (candidates


### PR DESCRIPTION
Since we have the logic to calculate the prefix by looking at the candidate items already, the bound calculation by using trigger characters shouldn't be needed anymore.
We should simplify the logic so this will not cause unexpected behavior even if the server define every thing as trigger chars