### PR TITLE
feat: Add LSP support for the DOT/Graphviz lang

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -43,6 +43,7 @@
   * ~lsp-organize-imports~ no longer prompts for an action, even if ~lsp-auto-execute-action~ is nil.
   * Add [[https://github.com/mint-lang/mint][mint-lang]] support.
   * Add ~lsp-sorbet-as-add-on~ variable to allow running the Sorbet server as an add-on alongside Solargraph or others
+  * Add [[https://github.com/nikeee/dot-language-server][dot-language-server]] (/a.k.a./ Graphviz) support.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-dot.el
+++ b/clients/lsp-dot.el
@@ -1,0 +1,62 @@
+;;; lsp-dot.el --- LSP client for the DOT/Graphviz language -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022 Abdelhak Bougouffa
+
+;; Author: Abdelhak Bougouffa <abougouffa@fedoraproject.org>
+;; Keywords: languages, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP client for the DOT/Graphviz language
+
+;;; Code:
+
+(require 'lsp-mode)
+
+;;; DOT Language (Graphviz)
+(defgroup lsp-dot nil
+  "Settings for the DOT Language Server."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/nikeee/dot-language-server")
+  :package-version '(lsp-mode . "8.0.0"))
+
+(defun lsp-dot--dot-ls-server-command ()
+  "Startup command for the DOT language server."
+  (list (lsp-package-path 'dot-language-server) "--stdio"))
+
+(lsp-dependency 'dot-language-server
+                '(:system "dot-language-server")
+                '(:npm :package "dot-language-server"
+                       :path "dot-language-server"))
+
+(defun lsp-dot--dot-ls-activate-p (filename &optional _)
+  "Check if the dot-ls lsp server should be enabled based on FILENAME."
+  (or (string-match-p "\\.dot\\|\\.gv\\'" filename)
+      (derived-mode-p 'graphviz-dot-mode)))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection #'lsp-dot--dot-ls-server-command)
+  :priority -1
+  :activation-fn #'lsp-dot--dot-ls-activate-p
+  :server-id 'dot-ls
+  :download-server-fn (lambda (_client callback error-callback _update?)
+                        (lsp-package-ensure 'dot-language-server callback error-callback))))
+
+(lsp-consistency-check lsp-dot)
+
+(provide 'lsp-dot)
+;;; lsp-dot.el ends here

--- a/clients/lsp-dot.el
+++ b/clients/lsp-dot.el
@@ -42,16 +42,11 @@
                 '(:npm :package "dot-language-server"
                        :path "dot-language-server"))
 
-(defun lsp-dot--dot-ls-activate-p (filename &optional _)
-  "Check if the dot-ls lsp server should be enabled based on FILENAME."
-  (or (string-match-p "\\.dot\\|\\.gv\\'" filename)
-      (derived-mode-p 'graphviz-dot-mode)))
-
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection #'lsp-dot--dot-ls-server-command)
   :priority -1
-  :activation-fn #'lsp-dot--dot-ls-activate-p
+  :activation-fn (lsp-activate-on "dot")
   :server-id 'dot-ls
   :download-server-fn (lambda (_client callback error-callback _update?)
                         (lsp-package-ensure 'dot-language-server callback error-callback))))

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -159,6 +159,15 @@
     "debugger": "Not available"
   },
   {
+    "name": "dot",
+    "full-name": "DOT",
+    "server-name": "dot-language-server",
+    "server-url": "https://github.com/nikeee/dot-language-server",
+    "installation": "npm install -g dot-language-server",
+    "lsp-install-server": "dot-ls",
+    "debugger": "Not available"
+  },
+  {
     "name": "elixir",
     "full-name": "Elixir",
     "server-name": "elixir-lsp/elixir-ls",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -847,7 +847,8 @@ Changes take effect only when a new session is started."
                                         (magik-mode . "magik")
                                         (idris-mode . "idris")
                                         (idris2-mode . "idris2")
-                                        (gleam-mode . "gleam"))
+                                        (gleam-mode . "gleam")
+                                        (graphviz-dot-mode . "dot"))
   "Language id configuration.")
 
 (defvar lsp--last-active-workspaces nil


### PR DESCRIPTION
This PR adds a new LSP client for the DOT language used in [Graphviz](https://graphviz.org/) via the [dot-language-server](https://github.com/nikeee/dot-language-server)