### PR TITLE
perl: add new client for PLS server

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -44,6 +44,7 @@
   * Add [[https://github.com/mint-lang/mint][mint-lang]] support.
   * Add ~lsp-sorbet-as-add-on~ variable to allow running the Sorbet server as an add-on alongside Solargraph or others
   * Add [[https://github.com/nikeee/dot-language-server][dot-language-server]] (/a.k.a./ Graphviz) support.
+  * Add [[https://github.com/FractalBoy/perl-language-server][PLS]] support (additional sever for Perl).
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-perl.el
+++ b/clients/lsp-perl.el
@@ -108,7 +108,7 @@ Defaults to 0."
                                     (with-lsp-workspace workspace
                                       (lsp--set-configuration
                                        (lsp-configuration-section "perl"))))
-                  :priority -1
+                  :priority -2
                   :server-id 'perl-language-server))
 
 (lsp-consistency-check lsp-perl)

--- a/clients/lsp-pls.el
+++ b/clients/lsp-pls.el
@@ -1,0 +1,124 @@
+;;; lsp-pls.el --- PLS Integration for lsp-mode -*- lexical-binding: t -*-
+
+;; Copyright (C) 2022 Alexander Adolf
+
+;; Author: Alexander Adolf <alexander.adolf@condition-alpha.com>
+;; Maintainer: Alexander Adolf <alexander.adolf@condition-alpha.com>
+;; Package-Requires: (lsp-mode)
+;; Keywords: perl, lsp
+
+;; This file is not part of GNU Emacs
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; PLS client
+;; https://metacpan.org/pod/PLS
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-pls nil
+  "LSP Mode support for PLS, the Perl Language Server."
+  :group 'lsp-mode
+  :link '(url-link "https://metacpan.org/pod/PLS")
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-pls-executable "pls"
+  "Full path to the PLS executable."
+  :type '(string)
+  :group 'lsp-pls
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-pls-arguments nil
+  "Additional arguments needed to execute PLS."
+  :type '(repeat 'string)
+  :group 'lsp-pls
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-pls-working-dir nil
+  "Working directory to run PLS in.
+Defaults to the workspace root when not configured."
+  :type '(string)
+  :group 'lsp-pls
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-pls-include nil
+  "Paths to be added to your @INC."
+  :type '(repeat 'string)
+  :group 'lsp-pls
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-pls-perltidy-rc nil
+  "Path to your .perltidyrc file.
+Default is \"~/.perltidyrc\" when not configured."
+  :type '(string)
+  :group 'lsp-pls
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-pls-perlcritic-rc nil
+  "Path to your .perlcriticrc file.
+Default is \"~/.perlcriticrc\" when not configured."
+  :type '(string)
+  :group 'lsp-pls
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-pls-perlcritic-enabled t
+  "Enable perlcritic checking."
+  :type '(boolean)
+  :group 'lsp-pls
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-pls-syntax-enabled t
+  "Enable syntax checking."
+  :type '(boolean)
+  :group 'lsp-pls
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-pls-syntax-perl nil
+  "Full path to an alternate perl used for syntax checking.
+By default, the perl used to run PLS will be used."
+  :type '(string)
+  :group 'lsp-pls
+  :package-version '(lsp-mode . "8.0.1"))
+
+(lsp-register-custom-settings
+ '(("pls.cmd"                      lsp-pls-executable)
+   ("pls.args"                     lsp-pls-arguments)
+   ("pls.cwd"                      lsp-pls-working-dir)
+   ("pls.inc"                      lsp-pls-include)
+   ("pls.perltidyrc"               lsp-pls-perltidy-rc)
+   ("pls.perlcritic.perlcriticrc"  lsp-pls-perlcritic-rc)
+   ("pls.perlcritic.enabled"       lsp-pls-perlcritic-enabled)
+   ("pls.syntax.enabled"           lsp-pls-syntax-enabled)
+   ("pls.syntax.perl"              lsp-pls-syntax-perl)))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection
+                   (lambda () (cons lsp-pls-executable lsp-pls-arguments)))
+  :activation-fn (lsp-activate-on "perl")
+  :initialized-fn (lambda (workspace)
+                    (with-lsp-workspace workspace
+                      (lsp--set-configuration
+                       (lsp-configuration-section "pls"))))
+  :priority -1
+  :server-id 'pls))
+
+;; (lsp-consistency-check lsp-pls)
+
+(provide 'lsp-pls)
+;;; lsp-pls.el ends here

--- a/clients/lsp-pls.el
+++ b/clients/lsp-pls.el
@@ -95,16 +95,25 @@ By default, the perl used to run PLS will be used."
   :group 'lsp-pls
   :package-version '(lsp-mode . "8.0.1"))
 
+(defcustom lsp-pls-syntax-args nil
+  "Additional arguments to pass to Perl when syntax checking.
+This is useful if there is a BEGIN block in your code that
+changes behavior depending on the contents of @ARGV."
+  :type '(repeat 'string)
+  :group 'lsp-pls
+  :package-version '(lsp-mode . "8.0.1"))
+
 (lsp-register-custom-settings
  '(("pls.cmd"                      lsp-pls-executable)
    ("pls.args"                     lsp-pls-arguments)
    ("pls.cwd"                      lsp-pls-working-dir)
    ("pls.inc"                      lsp-pls-include)
-   ("pls.perltidyrc"               lsp-pls-perltidy-rc)
+   ("pls.perltidy.perltidyrc"      lsp-pls-perltidy-rc)
    ("pls.perlcritic.perlcriticrc"  lsp-pls-perlcritic-rc)
    ("pls.perlcritic.enabled"       lsp-pls-perlcritic-enabled)
    ("pls.syntax.enabled"           lsp-pls-syntax-enabled)
-   ("pls.syntax.perl"              lsp-pls-syntax-perl)))
+   ("pls.syntax.perl"              lsp-pls-syntax-perl)
+   ("pls.syntax.args"              lsp-pls-syntax-args)))
 
 (lsp-register-client
  (make-lsp-client

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -517,6 +517,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "pls",
+    "full-name": "PLS",
+    "server-name": "Perl Language Server",
+    "server-url": "https://metacpan.org/pod/PLS",
+    "installation": "cpan PLS",
+    "debugger": "Not available"
+  },
+  {
     "name": "perl",
     "full-name": "Perl",
     "server-name": "Perl::LanguageServer",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -178,7 +178,7 @@ As defined by the Language Server Protocol 3.16."
          lsp-elm lsp-elixir lsp-emmet lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript lsp-go
          lsp-gleam lsp-graphql lsp-hack lsp-grammarly lsp-groovy lsp-haskell lsp-haxe lsp-idris lsp-java lsp-javascript
          lsp-json lsp-kotlin lsp-latex lsp-ltex lsp-lua lsp-markdown lsp-marksman lsp-mint lsp-nginx lsp-nim lsp-nix lsp-magik
-         lsp-metals lsp-mssql lsp-ocaml lsp-openscad lsp-pascal lsp-perl lsp-perlnavigator lsp-php lsp-pwsh lsp-pyls lsp-pylsp
+         lsp-metals lsp-mssql lsp-ocaml lsp-openscad lsp-pascal lsp-perl lsp-perlnavigator lsp-pls lsp-php lsp-pwsh lsp-pyls lsp-pylsp
          lsp-pyright lsp-python-ms lsp-purescript lsp-r lsp-racket lsp-remark lsp-rf lsp-rust lsp-solargraph
          lsp-sorbet lsp-sourcekit lsp-sonarlint lsp-tailwindcss lsp-tex lsp-terraform lsp-toml
          lsp-ttcn3 lsp-typeprof lsp-v lsp-vala lsp-verilog lsp-vetur lsp-volar lsp-vhdl lsp-vimscript
@@ -1887,7 +1887,7 @@ regex in IGNORED-FILES."
     lsp-clojure lsp-cmake lsp-crystal lsp-csharp lsp-css lsp-d lsp-dhall
     lsp-dockerfile lsp-elixir lsp-elm lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript
     lsp-go lsp-gleam lsp-graphql lsp-groovy lsp-hack lsp-haxe lsp-html lsp-idris lsp-javascript lsp-json lsp-kotlin lsp-lua
-    lsp-markdown lsp-marksman lsp-nginx lsp-nim lsp-nix lsp-ocaml lsp-perl lsp-perlnavigator lsp-php lsp-prolog lsp-purescript lsp-pwsh
+    lsp-markdown lsp-marksman lsp-nginx lsp-nim lsp-nix lsp-ocaml lsp-perl lsp-perlnavigator lsp-pls lsp-php lsp-prolog lsp-purescript lsp-pwsh
     lsp-pyls lsp-pylsp lsp-racket lsp-r lsp-rf lsp-rust lsp-solargraph lsp-sorbet lsp-sqls
     lsp-steep lsp-svelte lsp-terraform lsp-tex lsp-toml lsp-ttcn3 lsp-typeprof lsp-v lsp-vala lsp-verilog
     lsp-vetur lsp-volar lsp-vhdl lsp-vimscript lsp-xml lsp-yaml lsp-zig)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ nav:
     - OCaml (ocaml-lsp): page/lsp-ocaml-lsp-server.md
     - OpenSCAD: page/lsp-openscad.md
     - Pascal/Object Pascal: page/lsp-pascal.md
+    - Perl (PLS): page/lsp-pls.md
     - Perl (Perl::LanguageServer): page/lsp-perl.md
     - Perl (Navigator): page/lsp-perlnavigator.md
     - PHP (intelephense): page/lsp-intelephense.md


### PR DESCRIPTION
Ref: https://github.com/FractalBoy/perl-language-server

Also updating the priority order, so that the new client pls is preferred over perl-languag-server, since the PLS server supports auto-completion, whereas Perl::LanguageServer does not.