### PR TITLE
Kotlin override/implement member functionality

### DIFF
--- a/clients/lsp-kotlin.el
+++ b/clients/lsp-kotlin.el
@@ -27,7 +27,6 @@
 (require 'lsp-mode)
 (require 'cl-lib)
 (require 'dash)
-(require 'ht)
 
 (defgroup lsp-kotlin nil
   "LSP support for Kotlin, using KotlinLanguageServer."
@@ -230,9 +229,9 @@ to Kotlin."
    (lambda (member-options)
      (-if-let* ((option-items (-map (lambda (x)
                                       (list (lsp-get x :title)
-                                            (ht-get (lsp-get (lsp-get x :edit)
+                                            (lsp-get (lsp-get (lsp-get x :edit)
                                                              :changes)
-                                                    (lsp--buffer-uri))))
+                                                     (intern (concat ":" (lsp--buffer-uri))))))
                                     member-options))
                 (selected-members (lsp-kotlin--completing-read-multiple "Select overrides" option-items nil)))
          (dolist (edit (-flatten selected-members))

--- a/clients/lsp-kotlin.el
+++ b/clients/lsp-kotlin.el
@@ -26,7 +26,8 @@
 
 (require 'lsp-mode)
 (require 'cl-lib)
-(require 'cl)
+(require 'dash)
+(require 'ht)
 
 (defgroup lsp-kotlin nil
   "LSP support for Kotlin, using KotlinLanguageServer."
@@ -221,14 +222,21 @@ to Kotlin."
         deps))))
 
 (defun lsp-kotlin-implement-member ()
+  (interactive)
   (lsp-request-async
    "kotlin/overrideMember"
    (list :textDocument (list :uri (lsp--buffer-uri))
          :position (lsp--cur-position))
    (lambda (member-options)
-     (let* ((option-items (map 'list (lambda (x) (list (lsp-get x :title) (lsp-get (lsp-get x :edit) :changes))) member-options))
-            (selected-members (lsp-kotlin--completing-read-multiple "Select overrides" option-items nil)))
-       (lsp--apply-text-edits selected-members)))))
+     (-if-let* ((option-items (-map (lambda (x)
+                                      (list (lsp-get x :title)
+                                            (ht-get (lsp-get (lsp-get x :edit)
+                                                             :changes)
+                                                    (lsp--buffer-uri))))
+                                    member-options))
+                (selected-members (lsp-kotlin--completing-read-multiple "Select overrides" option-items nil)))
+         (dolist (edit (-flatten selected-members))
+           (lsp--apply-text-edits edit))))))
 
 (lsp-dependency
  'kotlin-language-server

--- a/clients/lsp-kotlin.el
+++ b/clients/lsp-kotlin.el
@@ -26,6 +26,7 @@
 
 (require 'lsp-mode)
 (require 'cl-lib)
+(require 'cl)
 
 (defgroup lsp-kotlin nil
   "LSP support for Kotlin, using KotlinLanguageServer."
@@ -180,6 +181,54 @@ to Kotlin."
     (lsp-lens-refresh t))
    (t (setq-local lsp-lens-backends (delete #'lsp-kotlin-lens-backend lsp-lens-backends)))))
 
+
+;; Stolen from lsp-java:
+;; https://github.com/emacs-lsp/lsp-java/blob/a1aff851bcf4f397f2a968557d213db1fede0c8a/lsp-java.el#L1065
+(declare-function helm-make-source "ext:helm-source")
+(defvar lsp-kotlin--helm-result nil)
+(defun lsp-kotlin--completing-read-multiple (message items initial-selection)
+  (if (functionp 'helm)
+      (progn
+        (require 'helm-source)
+        (helm :sources (helm-make-source
+                           message 'helm-source-sync :candidates items
+                           :action '(("Identity" lambda (_)
+                                      (setq lsp-kotlin--helm-result (helm-marked-candidates)))))
+              :buffer "*lsp-kotlin select*"
+              :prompt message)
+        lsp-kotlin--helm-result)
+    (if (functionp 'ivy-read)
+        (let (result)
+          (ivy-read message (mapcar #'car items)
+                    :action (lambda (c) (setq result (list (cdr (assoc c items)))))
+                    :multi-action
+                    (lambda (canditates)
+                      (setq result (mapcar (lambda (c) (cdr (assoc c items))) canditates))))
+          result)
+      (let ((deps initial-selection) dep)
+        (while (setq dep (cl-rest (lsp--completing-read
+                                   (if deps
+                                       (format "%s (selected %s): " message (length deps))
+                                     (concat message ": "))
+                                   items
+                                   (-lambda ((name . id))
+                                     (if (-contains? deps id)
+                                         (concat name " ✓")
+                                       name)))))
+          (if (-contains? deps dep)
+              (setq deps (remove dep deps))
+            (cl-pushnew dep deps)))
+        deps))))
+
+(defun lsp-kotlin-implement-member ()
+  (lsp-request-async
+   "kotlin/overrideMember"
+   (list :textDocument (list :uri (lsp--buffer-uri))
+         :position (lsp--cur-position))
+   (lambda (member-options)
+     (let* ((option-items (map 'list (lambda (x) (list (lsp-get x :title) (lsp-get (lsp-get x :edit) :changes))) member-options))
+            (selected-members (lsp-kotlin--completing-read-multiple "Select overrides" option-items nil)))
+       (lsp--apply-text-edits selected-members)))))
 
 (lsp-dependency
  'kotlin-language-server


### PR DESCRIPTION
Functionality to support override/implement member was recently merged in the language server (screenshot in that PR):
https://github.com/fwcd/kotlin-language-server/pull/379

Think I described the functionality quite well in the PR above:
> Override any member that is currently not implemented in the current class. This includes open functions, functions with default implementations, open members, abstract stuff etc. The main difference here is that this is general override member functionality, NOT JUST abstract members like the quick fix does. This is super useful for cases where you need to override a default implementation (e.g toString, Thread run, lsp4j interface methods like in TextDocumentService etc.), NOT just the unimplemented abstract ones. For me it would be super useful for my day job using Kotlin 😄 Having to google api docs to find signatures are a pain in the ass just for doing simple stuff like this.

(the quick fix I'm referring to is a code action that the language server provides)


I think an interactive function makes sense here. The users can then create a key binding for it if they want to. If you feel like we should have one out of the box, let me know 🙂 


This functionality is very similar to the Java-version of implement/override methods, but has a few minor differences in how it works. Both need a multiple select field where we can select the methods/members we want. Due to this reason I stole that function from lsp-java:
https://github.com/emacs-lsp/lsp-java/blob/a1aff851bcf4f397f2a968557d213db1fede0c8a/lsp-java.el#L1065

Maybe it should be in a common place? At this point I don't know where it should really be.