### PR TITLE
Fix: Don’t hardcode architecture in lsp-clojure on Linux

### DIFF
--- a/clients/lsp-clojure.el
+++ b/clients/lsp-clojure.el
@@ -53,8 +53,9 @@
                                    ((string= "x86_64" arch) "amd64")
                                    (t arch))))
               ('darwin (concat "macos-"
-                               (cond ((string= "aarch64" arch) arch)
-                                     (t "amd64"))))
+                               (cond
+                                ((string= "x86_64" arch) "amd64")
+                                (t arch))))
               ('windows-nt "windows-amd64"))))
   "Automatic download url for lsp-clojure."
   :type 'string

--- a/clients/lsp-clojure.el
+++ b/clients/lsp-clojure.el
@@ -46,12 +46,16 @@
 
 (defcustom lsp-clojure-server-download-url
   (format "https://github.com/clojure-lsp/clojure-lsp/releases/latest/download/clojure-lsp-native-%s.zip"
-          (pcase system-type
-            ('gnu/linux "linux-amd64")
-            ('darwin (if (string-match "^aarch64-.*" system-configuration)
-                         "macos-aarch64"
-                       "macos-amd64"))
-            ('windows-nt "windows-amd64")))
+          (let ((arch (substring system-configuration 0 (string-search "-" system-configuration))))
+            (pcase system-type
+              ('gnu/linux (concat "linux-"
+                                  (cond
+                                   ((string= "x86_64" arch) "amd64")
+                                   (t arch))))
+              ('darwin (concat "macos-"
+                               (cond ((string= "aarch64" arch) arch)
+                                     (t "amd64"))))
+              ('windows-nt "windows-amd64"))))
   "Automatic download url for lsp-clojure."
   :type 'string
   :group 'lsp-clojure

--- a/clients/lsp-clojure.el
+++ b/clients/lsp-clojure.el
@@ -46,7 +46,7 @@
 
 (defcustom lsp-clojure-server-download-url
   (format "https://github.com/clojure-lsp/clojure-lsp/releases/latest/download/clojure-lsp-native-%s.zip"
-          (let ((arch (substring system-configuration 0 (string-search "-" system-configuration))))
+          (let ((arch (car (split-string system-configuration "-"))))
             (pcase system-type
               ('gnu/linux (concat "linux-"
                                   (cond


### PR DESCRIPTION
Prior to this commit, all Linuxen were assumed to be running on amd64, which is wrong.  This change attempts to more precisely determine the OS/arch combo.

I suspect that a more general mechanism which can be used across clients is needed here, but this solves the immediate problem.