### PR TITLE
clients/lsp-fsharp.el: respect `lsp-fsharp-server-install-dir` value

### DIFF
--- a/clients/lsp-fsharp.el
+++ b/clients/lsp-fsharp.el
@@ -179,7 +179,10 @@ available, else the globally installed tool."
 
 (defun lsp-fsharp--fsac-cmd ()
   "The location of fsautocomplete executable."
-  (expand-file-name "fsautocomplete.dll" lsp-fsharp-server-install-dir))
+  (or (expand-file-name "fsautocomplete" lsp-fsharp-server-install-dir)
+      (executable-find "fsautocomplete")
+      (f-join (or (getenv "USERPROFILE") (getenv "HOME"))
+              ".dotnet" "tools" "fsautocomplete")))
 
 (defun lsp-fsharp--make-launch-cmd ()
   "Build the command required to launch fsautocomplete."
@@ -203,10 +206,7 @@ available, else the globally installed tool."
                                 (list "/bin/ksh" "-c"))
 
                                (t nil)))
-
-        (fsautocomplete-exec (or (executable-find "fsautocomplete")
-                                 (f-join (or (getenv "USERPROFILE") (getenv "HOME"))
-                                         ".dotnet" "tools" "fsautocomplete"))))
+        (fsautocomplete-exec (lsp-fsharp--fsac-cmd)))
     (append startup-wrapper
             (list fsautocomplete-exec "--background-service-enabled")
             lsp-fsharp-server-args)))


### PR DESCRIPTION
Recent changes to lsp-fsharp.el broke local server setup configuration where server binary can be overriden by setting
`lsp-fsharp-server-install-dir`.

This makes sure `lsp-fsharp--fsac-cmd` and `lsp-fsharp--make-launch-cmd` agree on the order for fsautocomplete executable resolution.

Also latest fsautocomplete builds now build native binary so .dll should not be used when resolving fsautocomplete with `expand-file-name`.