### PR TITLE
Fix F# executable finding

### DIFF
--- a/clients/lsp-fsharp.el
+++ b/clients/lsp-fsharp.el
@@ -179,7 +179,9 @@ available, else the globally installed tool."
 
 (defun lsp-fsharp--fsac-cmd ()
   "The location of fsautocomplete executable."
-  (or (expand-file-name "fsautocomplete" lsp-fsharp-server-install-dir)
+  (or (-let [maybe-local-executable (expand-file-name "fsautocomplete" lsp-fsharp-server-install-dir)]
+        (when (f-exists-p maybe-local-executable)
+          maybe-local-executable))
       (executable-find "fsautocomplete")
       (f-join (or (getenv "USERPROFILE") (getenv "HOME"))
               ".dotnet" "tools" "fsautocomplete")))


### PR DESCRIPTION
Previously, this function used a bare `expand-file-name` to try and locate the `fsharpautocomplete` binary, preferring versions installed in the LSP cache directory over global installations. However, `expand-file-name` does not verify that a file exists. `expand-file-name` will, therefore, always succeed, even if it's incorrect. This causes LSP to crash loop, trying to start a (likely) non-existent binary.

This commit updates this behavior to include an existence check, ensuring that it will correctly "fail" the LSP cache version and check more paths.