### PR TITLE
More clear installation

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -814,7 +814,7 @@
     "full-name": "TOML",
     "server-name": "taplo",
     "server-url": "https://github.com/tamasfe/taplo",
-    "installation": "cargo install taplo-cli",
+    "installation": "cargo install taplo-cli --features lsp",
     "debugger": "Not available"
   },
   {


### PR DESCRIPTION
`taplo-cli` installation needs to add `--features lsp` to enable lsp feature which lsp-mode needs. 