### PR TITLE
fix(lsp-mode): Fix all compile warnings and errors

### DIFF
--- a/clients/lsp-bash.el
+++ b/clients/lsp-bash.el
@@ -34,7 +34,7 @@
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-bash-explainshell-endpoint nil
-  "The endpoint to use explainshell.com to answer 'onHover' queries.
+  "The endpoint to use explainshell.com to answer `onHover' queries.
 See instructions at https://marketplace.visualstudio.com/items?itemName=mads-hartmann.bash-ide-vscode"
   :type 'string
   :risky t
@@ -42,7 +42,7 @@ See instructions at https://marketplace.visualstudio.com/items?itemName=mads-har
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-bash-highlight-parsing-errors nil
-  "Consider parsing errors in scripts as 'problems'."
+  "Consider parsing errors in scripts as `problems'."
   :type 'boolean
   :group 'lsp-bash
   :package-version '(lsp-mode . "6.2"))

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -111,9 +111,9 @@ be available here: https://github.com/clangd/clangd/releases/"
   "Extract the parts of the LLVM clang-tidy documentation that are relevant.
 
 This function assumes that the current buffer contains the result
-of browsing 'clang.llvm.org', as returned by `url-retrieve'.
+of browsing `clang.llvm.org', as returned by `url-retrieve'.
 More concretely, this function returns the main <div> element
-with class 'section', and also removes 'headerlinks'."
+with class `section', and also removes `headerlinks'."
   (goto-char (point-min))
   (lsp-cpp-flycheck-clang-tidy--narrow-to-http-body)
   (lsp-cpp-flycheck-clang-tidy--decode-region-as-utf8 (point-min) (point-max))

--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -280,11 +280,11 @@ PRESENT-BUFFER will make the buffer be presented to the user."
     (message "lsp-csharp: No test method(s) found to be ran previously on this workspace")))
 
 (lsp-defun lsp-csharp--handle-os-error (_workspace (&omnisharp:ErrorMessage :file-name :text))
-  "Handle the 'o#/error' (interop) notification displaying a message."
+  "Handle the `o#/error' (interop) notification displaying a message."
   (lsp-warn "%s: %s" file-name text))
 
 (lsp-defun lsp-csharp--handle-os-testmessage (_workspace (&omnisharp:TestMessageEvent :message))
-  "Handle the 'o#/testmessage and display test message on test output buffer."
+  "Handle the `o#/testmessage and display test message on test output buffer."
   (lsp-csharp--test-message message))
 
 (lsp-defun lsp-csharp--handle-os-testcompleted (_workspace (&omnisharp:DotNetTestResult
@@ -294,7 +294,7 @@ PRESENT-BUFFER will make the buffer be presented to the user."
                                                             :error-stack-trace
                                                             :standard-output
                                                             :standard-error))
-  "Handle the 'o#/testcompleted' message from the server.
+  "Handle the `o#/testcompleted' message from the server.
 
 Will display the results of the test on the lsp-csharp test output buffer."
   (let ((passed (string-equal "passed" outcome)))
@@ -366,7 +366,7 @@ using the `textDocument/references' request."
 (lsp-defun lsp-csharp--cls-metadata-uri-handler (uri)
   "Handle `csharp:/(metadata)' uri from csharp-ls server.
 
-'csharp/metadata' request is issued to retrieve metadata from the server.
+`csharp/metadata' request is issued to retrieve metadata from the server.
 A cache file is created on project root dir that stores this metadata and
 filename is returned so lsp-mode can display this file."
 

--- a/clients/lsp-go.el
+++ b/clients/lsp-go.el
@@ -149,14 +149,14 @@ The returned type provides a tri-state that either:
   - sets element to false (actually, :json-false)
   - sets element to true \(actually, t)"
   (let ((list '()))
-	(dolist (v alist)
-	  (push `(cons
-			  :tag ,(cdr v)
-			  (const :format "" ,(car v))
-			  (choice (const :tag "Enable" t) (const :tag "Disable" :json-false)))
-			list))
-	(push 'set list)
-	list))
+    (dolist (v alist)
+      (push `(cons
+              :tag ,(cdr v)
+              (const :format "" ,(car v))
+              (choice (const :tag "Enable" t) (const :tag "Disable" :json-false)))
+            list))
+    (push 'set list)
+    list))
 
 (define-obsolete-variable-alias
   'lsp-gopls-codelens
@@ -169,12 +169,12 @@ The returned type provides a tri-state that either:
   "lsp-mode 7.0.1")
 
 (defcustom lsp-go-codelenses '((gc_details . :json-false)
-			       (generate . t)
-			       (regenerate_cgo . t)
-			       (tidy . t)
-			       (upgrade_dependency . t)
-			       (test . t)
-			       (vendor . t))
+                   (generate . t)
+                   (regenerate_cgo . t)
+                   (tidy . t)
+                   (upgrade_dependency . t)
+                   (test . t)
+                   (vendor . t))
   "Select what codelenses should be enabled or not.
 
 The codelenses can be found at https://github.com/golang/tools/blob/3fa0e8f87c1aae0a9adc2a63af1a1945d16d9359/internal/lsp/source/options.go#L106-L112."
@@ -231,7 +231,7 @@ $GOPATH/pkg/mod along with the value of
 (defcustom lsp-go-link-target "pkg.go.dev"
   "Which website to use for displaying Go documentation."
   :type '(choice (const "pkg.go.dev")
-		 (string :tag "A custom website"))
+         (string :tag "A custom website"))
   :group 'lsp-go
   :package-version '(lsp-mode "7.0.1"))
 
@@ -266,7 +266,7 @@ $GOPATH/pkg/mod along with the value of
   :package-version '(lsp-mode "8.0.0"))
 
 (defcustom lsp-go-import-shortcut "Both"
-  "Specifies whether import statements should link to documentation or go to 
+  "Specifies whether import statements should link to documentation or go to
   definitions."
   :type '(choice (const "Both")
                  (const "Link")
@@ -287,13 +287,13 @@ $GOPATH/pkg/mod along with the value of
 (defcustom lsp-go-symbol-style "Dynamic"
   "Controls how symbols are qualified in symbol responses.
 
-  'Dynamic' uses whichever qualifier results in the highest scoring match for
-  the given symbol query. Here a 'qualifier' is any '/' or '.' delimited suffix
-  of the fully qualified symbol. i.e. 'to/pkg.Foo.Field' or just 'Foo.Field'.
+`Dynamic' uses whichever qualifier results in the highest scoring match for
+the given symbol query. Here a `qualifier' is any '/' or '.' delimited suffix
+of the fully qualified symbol. i.e. `to/pkg.Foo.Field' or just `Foo.Field'.
 
-  'Full' is fully qualified symbols, i.e. 'path/to/pkg.Foo.Field'.
+`Full' is fully qualified symbols, i.e. `path/to/pkg.Foo.Field'.
 
-  'Package' is package qualified symbols i.e. 'pkg.Foo.Field'."
+`Package' is package qualified symbols i.e. `pkg.Foo.Field'."
   :type '(choice (const "Dynamic")
                  (const "Full")
                  (const "Package"))

--- a/clients/lsp-go.el
+++ b/clients/lsp-go.el
@@ -169,12 +169,12 @@ The returned type provides a tri-state that either:
   "lsp-mode 7.0.1")
 
 (defcustom lsp-go-codelenses '((gc_details . :json-false)
-                   (generate . t)
-                   (regenerate_cgo . t)
-                   (tidy . t)
-                   (upgrade_dependency . t)
-                   (test . t)
-                   (vendor . t))
+                               (generate . t)
+                               (regenerate_cgo . t)
+                               (tidy . t)
+                               (upgrade_dependency . t)
+                               (test . t)
+                               (vendor . t))
   "Select what codelenses should be enabled or not.
 
 The codelenses can be found at https://github.com/golang/tools/blob/3fa0e8f87c1aae0a9adc2a63af1a1945d16d9359/internal/lsp/source/options.go#L106-L112."
@@ -231,7 +231,7 @@ $GOPATH/pkg/mod along with the value of
 (defcustom lsp-go-link-target "pkg.go.dev"
   "Which website to use for displaying Go documentation."
   :type '(choice (const "pkg.go.dev")
-         (string :tag "A custom website"))
+                 (string :tag "A custom website"))
   :group 'lsp-go
   :package-version '(lsp-mode "7.0.1"))
 

--- a/clients/lsp-kotlin.el
+++ b/clients/lsp-kotlin.el
@@ -87,7 +87,7 @@ When enabled a debugger for Kotlin will be available."
 
 (defcustom lsp-kotlin-external-sources-use-kls-scheme t
   "[Recommended] Specifies whether URIs inside JARs should be represented
-using the 'kls'-scheme."
+using the `kls'-scheme."
   :type 'boolean
   :group 'lsp-kotlin
   :package-version '(lsp-mode . "6.1"))

--- a/clients/lsp-lua.el
+++ b/clients/lsp-lua.el
@@ -337,7 +337,7 @@ tolerance for this setting. Please adjust it to the appropriate value."
   :group 'lsp-lua-language-server)
 
 (defcustom lsp-lua-runtime-file-encoding "utf8"
-  "File encoding. The 'ansi' option is only available under the 'Windows'
+  "File encoding. The `ansi' option is only available under the `Windows'
 platform."
   :type '(choice (:tag "utf8" "ansi"))
   :package-version '(lsp-mode . "8.0.0")

--- a/clients/lsp-pyls.el
+++ b/clients/lsp-pyls.el
@@ -250,7 +250,7 @@ convention."
 (defcustom lsp-pyls-plugins-pydocstyle-match "(?!test_).*\\.py"
   "Check only files that exactly match the given regular
 expression; default is to match files that don't start with
-'test_' but end with '.py'."
+`test_' but end with `.py'."
   :type 'string
   :group 'lsp-pyls
   :package-version '(lsp-mode . "6.1"))

--- a/clients/lsp-pylsp.el
+++ b/clients/lsp-pylsp.el
@@ -206,7 +206,7 @@ convention."
 (defcustom lsp-pylsp-plugins-pydocstyle-match "(?!test_).*\\.py"
   "Check only files that exactly match the given regular
 expression; default is to match files that don't start with
-'test_' but end with '.py'."
+`test_' but end with `.py'."
   :type 'string
   :group 'lsp-pylsp)
 

--- a/clients/lsp-svelte.el
+++ b/clients/lsp-svelte.el
@@ -188,7 +188,7 @@ file paths or globs relative to workspace root."
 
 (defcustom lsp-svelte-plugin-svelte-compiler-warnings nil
   "Svelte compiler warning codes to ignore or to treat as errors.
-Example: '((css-unused-selector . ignore) (unused-export-let . error))"
+Example: `((css-unused-selector . ignore) (unused-export-let . error))"
   :type '(alist :key-type (symbol :tag "Warning code")
                 :value-type (choice
                              (const :tag "Ignore" ignore)

--- a/clients/lsp-terraform.el
+++ b/clients/lsp-terraform.el
@@ -266,25 +266,25 @@ This is a synchronous action."
                    :installed-version installed-version
                    :version-constraint (lsp-get provider :version_constraint)))
 
-(lsp-defun construct-tf-module ((&terraform-ls:Module :name :docs-link :version :source-type :dependent-modules))
+(lsp-defun construct-tf-module ((&terraform-ls:Module :name :docs_link :version :source_type :dependent_modules))
   "Construct `TF-MODULE' using MODULE."
   (make-tf-module :name name
-                  :doc-link docs-link
+                  :doc-link docs_link
                   :version version
-                  :source-type source-type
-                  :dependent-modules dependent-modules))
+                  :source-type source_type
+                  :dependent-modules dependent_modules))
 
-(lsp-defun lsp-terraform-ls--providers-to-tf-package ((&terraform-ls:Providers :provider-requirements :installed-providers))
+(lsp-defun lsp-terraform-ls--providers-to-tf-package ((&terraform-ls:Providers :provider_requirements :installed_providers))
   "Convert PROVIDERS-TREE-DATA to list of `tf-package'."
-  (let* ((provider-requirements-keys (hash-table-keys provider-requirements))
-         (installed-versions (mapcar (lambda (x) (lsp-get installed-providers (make-symbol (format ":%s" x)))) provider-requirements-keys))
-         (providers (mapcar (lambda (x) (lsp-get provider-requirements (make-symbol (format ":%s" x)))) provider-requirements-keys))
+  (let* ((provider-requirements-keys (hash-table-keys provider_requirements))
+         (installed-versions (mapcar (lambda (x) (lsp-get installed_providers (make-symbol (format ":%s" x)))) provider-requirements-keys))
+         (providers (mapcar (lambda (x) (lsp-get provider_requirements (make-symbol (format ":%s" x)))) provider-requirements-keys))
          (tf-packages (-zip-with (lambda (x y) (construct-tf-package x y)) providers installed-versions)))
     tf-packages))
 
-(lsp-defun lsp-terraform-ls--modules-to-tf-module ((&terraform-ls:ModuleCalls :module-calls))
+(lsp-defun lsp-terraform-ls--modules-to-tf-module ((&terraform-ls:ModuleCalls :module_calls))
   "Convert MODULES-TREE-DATA to list of `TF-MODULE'."
-  (let* ((modules (-map (lambda (x) (construct-tf-module x)) module-calls)))
+  (let* ((modules (-map (lambda (x) (construct-tf-module x)) module_calls)))
     modules))
 
 (defun lsp-terraform-ls--fetch-modules-data (project-root)

--- a/clients/lsp-volar.el
+++ b/clients/lsp-volar.el
@@ -106,7 +106,7 @@
    ("documentFeatures.documentFormatting.getDocumentPrintWidthRequest" nil t)))
 
 (defun lsp-volar--vue-project-p (workspace-root)
-  "Check if the 'vue' package is present in the package.json file
+  "Check if the `vue' package is present in the package.json file
 in the WORKSPACE-ROOT."
   (if-let ((package-json (f-join workspace-root "package.json"))
            (exist (f-file-p package-json))

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -184,7 +184,7 @@ This will help minimize popup flickering issue in `company-mode'."
 
 (defun lsp-completion--looking-back-trigger-characterp (trigger-characters)
   "Return character if text before point match any of the TRIGGER-CHARACTERS."
-  (unless (= (point) (point-at-bol))
+  (unless (= (point) (line-beginning-position))
     (seq-some
      (lambda (trigger-char)
        (and (equal (buffer-substring-no-properties (- (point) (length trigger-char)) (point))

--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -300,8 +300,8 @@ See https://github.com/emacs-lsp/lsp-mode."
                                   end (cdr region))
                           (lsp-save-restriction-and-excursion
                             (goto-char (point-min))
-                            (setq start (point-at-bol (1+ start-line))
-                                  end (point-at-eol (1+ end-line))))))
+                            (setq start (line-beginning-position (1+ start-line))
+                                  end (line-end-position (1+ end-line))))))
                       (flymake-make-diagnostic (current-buffer)
                                                start
                                                end

--- a/lsp-dired.el
+++ b/lsp-dired.el
@@ -72,12 +72,12 @@
                    (if (dired-move-to-filename nil)
                        (let* ((file (dired-get-filename nil t))
                               (bol (progn
-                                     (point-at-bol)
+                                     (beginning-of-line)
                                      (search-forward-regexp "^[[:space:]]*" (line-end-position) t)
                                      (point)))
                               (face (lsp-dired--face-for-path file)))
                          (when face
-                           (-doto (make-overlay bol (point-at-eol))
+                           (-doto (make-overlay bol (line-end-position))
                              (overlay-put 'evaporate t)
                              (overlay-put 'face face))))
                      (cl-return-from :file nil))
@@ -89,22 +89,26 @@
 
 (defface lsp-dired-path-error-face
   '((t :underline (:style wave :color "Red1")))
-  "Face used for breadcrumb paths on headerline when there is an error under that path"
+  "Face used for breadcrumb paths on headerline when there is an error under
+that path."
   :group 'lsp-dired)
 
 (defface lsp-dired-path-warning-face
   '((t :underline (:style wave :color "Yellow")))
-  "Face used for breadcrumb paths on headerline when there is an warning under that path"
+  "Face used for breadcrumb paths on headerline when there is an warning under
+that path."
   :group 'lsp-dired)
 
 (defface lsp-dired-path-info-face
   '((t :underline (:style wave :color "Green")))
-  "Face used for breadcrumb paths on headerline when there is an info under that path"
+  "Face used for breadcrumb paths on headerline when there is an info under
+that path."
   :group 'lsp-dired)
 
 (defface lsp-dired-path-hint-face
   '((t :underline (:style wave :color "Green")))
-  "Face used for breadcrumb paths on headerline when there is an hint under that path"
+  "Face used for breadcrumb paths on headerline when there is an hint under
+that path."
   :group 'lsp-dired)
 
 (defun lsp-dired--face-for-path (dir)

--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -61,25 +61,29 @@
 (defface lsp-headerline-breadcrumb-path-error-face
   '((t :underline (:style wave :color "Red1")
        :inherit lsp-headerline-breadcrumb-path-face))
-  "Face used for breadcrumb paths on headerline when there is an error under that path"
+  "Face used for breadcrumb paths on headerline when there is an error under
+that path."
   :group 'lsp-headerline)
 
 (defface lsp-headerline-breadcrumb-path-warning-face
   '((t :underline (:style wave :color "Yellow")
        :inherit lsp-headerline-breadcrumb-path-face))
-  "Face used for breadcrumb paths on headerline when there is an warning under that path"
+  "Face used for breadcrumb paths on headerline when there is an warning under
+that path."
   :group 'lsp-headerline)
 
 (defface lsp-headerline-breadcrumb-path-info-face
   '((t :underline (:style wave :color "Green")
        :inherit lsp-headerline-breadcrumb-path-face))
-  "Face used for breadcrumb paths on headerline when there is an info under that path"
+  "Face used for breadcrumb paths on headerline when there is an info under
+that path."
   :group 'lsp-headerline)
 
 (defface lsp-headerline-breadcrumb-path-hint-face
   '((t :underline (:style wave :color "Green")
        :inherit lsp-headerline-breadcrumb-path-face))
-  "Face used for breadcrumb paths on headerline when there is an hint under that path"
+  "Face used for breadcrumb paths on headerline when there is an hint under
+that path."
   :group 'lsp-headerline)
 
 (defface lsp-headerline-breadcrumb-project-prefix-face

--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -104,8 +104,8 @@ Results are meaningful only if FROM and TO are on the same line."
   (-doto (save-excursion
            (goto-char pos)
            (if (eq 'end-of-line lsp-lens-place-position)
-               (make-overlay (point-at-eol) -1 nil t t)
-             (make-overlay (point-at-bol) (1+ (point-at-eol)) nil t t)))
+               (make-overlay (line-end-position) -1 nil t t)
+             (make-overlay (line-beginning-position) (1+ (line-end-position)) nil t t)))
     (overlay-put 'lsp-lens t)
     (overlay-put 'evaporate t)
     (overlay-put 'lsp-lens-position pos)))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1585,10 +1585,10 @@ actual language server executable. ARGS is a list of arguments to
 give to FIND-COMMAND to find the language server.  Returns the
 output of FIND-COMMAND if it exits successfully, nil otherwise.
 
-Typical uses include finding an executable by invoking 'find' in
-a project, finding LLVM commands on macOS with 'xcrun', or
+Typical uses include finding an executable by invoking `find' in
+a project, finding LLVM commands on macOS with `xcrun', or
 looking up project-specific language servers for projects written
-in the various dynamic languages, e.g. 'nvm', 'pyenv' and 'rbenv'
+in the various dynamic languages, e.g. `nvm', `pyenv' and `rbenv'
 etc."
   (when-let* ((find-command-path (executable-find find-command))
               (executable-path
@@ -3055,7 +3055,7 @@ If WORKSPACE is not provided current workspace will be used."
 (defun lsp--make-log-entry (method id body type &optional process-time)
   "Create an outgoing log object from BODY with method METHOD and id ID.
 If ID is non-nil, then the body is assumed to be a notification.
-TYPE can either be 'incoming or 'outgoing"
+TYPE can either be `incoming or `outgoing"
   (cl-assert (memq type '(incoming-req outgoing-req incoming-notif
                                        outgoing-notif incoming-resp
                                        outgoing-resp)))
@@ -4069,7 +4069,7 @@ yet."
                                         (point-max)))))
 
 (defun lsp--text-document-did-open ()
-  "'document/didOpen' event."
+  "`document/didOpen' event."
   (run-hooks 'lsp-before-open-hook)
   (when (and lsp-auto-touch-files
              (not (f-exists? (lsp--uri-to-path (lsp--buffer-uri)))))
@@ -4134,7 +4134,7 @@ yet."
   "The active region or the current line."
   (if (use-region-p)
       (lsp--region-to-range (region-beginning) (region-end))
-    (lsp--region-to-range (point-at-bol) (point-at-eol))))
+    (lsp--region-to-range (line-beginning-position) (line-end-position))))
 
 (defun lsp--check-document-changes-version (document-changes)
   "Verify that DOCUMENT-CHANGES have the proper version."
@@ -4412,7 +4412,7 @@ OPERATION is symbol representing the source of this text edit."
 
 (defun lsp--create-apply-text-edits-handlers ()
   "Create (handler cleanup-fn) for applying text edits in async request.
-Only works when mode is 'tick or 'alive."
+Only works when mode is `tick or `alive."
   (let* (first-edited
          (func (lambda (start &rest _)
                  (setq first-edited (if first-edited
@@ -5298,7 +5298,7 @@ When language is nil render as markup if `markdown-mode' is loaded."
   (car (s-lines (s-trim (lsp--render-element contents)))))
 
 (defun lsp--render-on-hover-content (contents render-all)
-  "Render the content received from 'document/onHover' request.
+  "Render the content received from `document/onHover' request.
 CONTENTS  - MarkedString | MarkedString[] | MarkupContent
 RENDER-ALL - nil if only the signature should be rendered."
   (cond
@@ -5843,7 +5843,7 @@ execute a CODE-ACTION-KIND action."
 
 (defun lsp--document-highlight-callback (highlights)
   "Create a callback to process the reply of a
-'textDocument/documentHighlight' message for the buffer BUF.
+`textDocument/documentHighlight' message for the buffer BUF.
 A reference is highlighted only if it is visible in a window."
   (lsp--remove-overlays 'lsp-highlight)
 
@@ -6274,7 +6274,7 @@ The command is executed via `workspace/executeCommand'"
             command err))))
 
 (defun lsp-send-execute-command (command &optional args)
-  "Create and send a 'workspace/executeCommand' message having command COMMAND
+  "Create and send a `workspace/executeCommand' message having command COMMAND
 and optional ARGS."
   (lsp-workspace-command-execute command args))
 
@@ -7529,11 +7529,11 @@ typescript-language-server requires both the server and the
 typescript compiler. If you've installed them in a team shared
 read-only location, you can instruct lsp-mode to use them via
 
- (eval-after-load 'lsp-mode
-   '(progn
-      (require 'lsp-javascript)
-      (lsp-dependency 'typescript-language-server `(:system ,tls-exe))
-      (lsp-dependency 'typescript `(:system ,ts-js))))
+ (eval-after-load `lsp-mode
+   (progn
+      (require `lsp-javascript)
+      (lsp-dependency `typescript-language-server `(:system ,tls-exe))
+      (lsp-dependency `typescript `(:system ,ts-js))))
 
 where tls-exe is the absolute path to the typescript-language-server
 executable and ts-js is the absolute path to the typescript compiler
@@ -8151,7 +8151,7 @@ function or lambda function to be called without arguments; BOOLEAN? is an
 optional flag that should be non-nil for boolean settings, when it is nil the
 property will be ignored if the VALUE is nil.
 
-Example: `(lsp-register-custom-settings '((\"foo.bar.buzz.enabled\" t t)))'
+Example: `(lsp-register-custom-settings `((\"foo.bar.buzz.enabled\" t t)))'
 \(note the double parentheses)"
   (let ((-compare-fn #'lsp--compare-setting-path))
     (setq lsp-client-settings (-uniq (append props lsp-client-settings)))))
@@ -8954,8 +8954,8 @@ This avoids overloading the server with many files when starting Emacs."
 (defun lsp--move-point-in-indentation (point indentation)
   (save-excursion
     (goto-char point)
-    (if (<= point (+ (point-at-bol) indentation))
-        (point-at-bol)
+    (if (<= point (+ (line-beginning-position) indentation))
+        (line-beginning-position)
       point)))
 
 (declare-function flycheck-checker-supports-major-mode-p "ext:flycheck")
@@ -8972,7 +8972,7 @@ This avoids overloading the server with many files when starting Emacs."
 
 (defun lsp-progress-spinner-type ()
   "Retrive the spinner type value, if value is not a symbol of `spinner-types
-defaults to 'progress-bar."
+defaults to `progress-bar."
   (or (car (assoc lsp-progress-spinner-type spinner-types)) 'progress-bar))
 
 (defun lsp-org ()
@@ -9045,8 +9045,8 @@ defaults to 'progress-bar."
 
                      (goto-char (point-min))
                      (while (not (eobp))
-                       (delete-region (point) (if (> (+ (point) indentation) (point-at-eol))
-                                                  (point-at-eol)
+                       (delete-region (point) (if (> (+ (point) indentation) (line-end-position))
+                                                  (line-end-position)
                                                 (+ (point) indentation)))
                        (forward-line))
                      (buffer-substring-no-properties (point-min)


### PR DESCRIPTION
Fix whole bunch of compile warnings and errors.

<details>

```
Leaving directory ‘c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846’

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-actionscript.el at Sat Oct  1 21:18:33 2022
Entering directory ‘c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/’

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-ada.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-angular.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-ansible.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-bash.el at Sat Oct  1 21:18:38 2022
lsp-bash.el:36:2: Warning: custom-declare-variable
    `lsp-bash-explainshell-endpoint' docstring has wrong usage of unescaped
    single quotes (use \= or different quoting)
lsp-bash.el:44:2: Warning: custom-declare-variable
    `lsp-bash-highlight-parsing-errors' docstring has wrong usage of unescaped
    single quotes (use \= or different quoting)

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-beancount.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-camel.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-clangd.el at Sat Oct  1 21:18:38 2022

In lsp-cpp-flycheck-clang-tidy--extract-relevant-doc-section:
lsp-clangd.el:110:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-clojure.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-cmake.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-completion.el at Sat Oct  1 21:18:38 2022

In lsp-completion--looking-back-trigger-characterp:
lsp-completion.el:187:23: Warning: ‘point-at-bol’ is an obsolete function (as
    of 29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-crystal.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-csharp.el at Sat Oct  1 21:18:38 2022

In lsp-csharp--handle-os-error:
lsp-csharp.el:282:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

In lsp-csharp--handle-os-testmessage:
lsp-csharp.el:286:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

In lsp-csharp--handle-os-testcompleted:
lsp-csharp.el:290:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

In lsp-csharp--cls-metadata-uri-handler:
lsp-csharp.el:366:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-css.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-d.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-dhall.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-diagnostics.el at Sat Oct  1 21:18:38 2022

In lsp-diagnostics--flymake-update-diagnostics:
lsp-diagnostics.el:303:42: Warning: ‘point-at-bol’ is an obsolete function (as
    of 29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
lsp-diagnostics.el:304:40: Warning: ‘point-at-eol’ is an obsolete function (as
    of 29.1); use ‘line-end-position’ or ‘pos-eol’ instead.
lsp-diagnostics.el:303:42: Warning: ‘point-at-bol’ is an obsolete function (as
    of 29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
lsp-diagnostics.el:304:40: Warning: ‘point-at-eol’ is an obsolete function (as
    of 29.1); use ‘line-end-position’ or ‘pos-eol’ instead.

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-dired.el at Sat Oct  1 21:18:38 2022

In lsp-dired--insert-for-subdir:
lsp-dired.el:75:39: Warning: ‘point-at-bol’ is an obsolete function (as of
    29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
lsp-dired.el:80:54: Warning: ‘point-at-eol’ is an obsolete function (as of
    29.1); use ‘line-end-position’ or ‘pos-eol’ instead.
lsp-dired.el:90:2: Warning: custom-declare-face `lsp-dired-path-error-face'
    docstring wider than 80 characters
lsp-dired.el:95:2: Warning: custom-declare-face `lsp-dired-path-warning-face'
    docstring wider than 80 characters
lsp-dired.el:100:2: Warning: custom-declare-face `lsp-dired-path-info-face'
    docstring wider than 80 characters
lsp-dired.el:105:2: Warning: custom-declare-face `lsp-dired-path-hint-face'
    docstring wider than 80 characters

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-dockerfile.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-dot.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-elixir.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-elm.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-emmet.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-erlang.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-eslint.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-fortran.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-fsharp.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-gdscript.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-gleam.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-go.el at Sat Oct  1 21:18:38 2022
lsp-go.el:287:2: Warning: custom-declare-variable `lsp-go-symbol-style'
    docstring has wrong usage of unescaped single quotes (use \= or different
    quoting)

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-graphql.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-groovy.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-hack.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-haxe.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-headerline.el at Sat Oct  1 21:18:38 2022
lsp-headerline.el:61:2: Warning: custom-declare-face
    `lsp-headerline-breadcrumb-path-error-face' docstring wider than 80
    characters
lsp-headerline.el:67:2: Warning: custom-declare-face
    `lsp-headerline-breadcrumb-path-warning-face' docstring wider than 80
    characters
lsp-headerline.el:73:2: Warning: custom-declare-face
    `lsp-headerline-breadcrumb-path-info-face' docstring wider than 80
    characters
lsp-headerline.el:79:2: Warning: custom-declare-face
    `lsp-headerline-breadcrumb-path-hint-face' docstring wider than 80
    characters

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-html.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-icons.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-ido.el at Sat Oct  1 21:18:38 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-idris.el at Sat Oct  1 21:18:39 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-iedit.el at Sat Oct  1 21:18:39 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-javascript.el at Sat Oct  1 21:18:39 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-json.el at Sat Oct  1 21:18:39 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-kotlin.el at Sat Oct  1 21:18:39 2022
lsp-kotlin.el:88:2: Warning: custom-declare-variable
    `lsp-kotlin-external-sources-use-kls-scheme' docstring has wrong usage of
    unescaped single quotes (use \= or different quoting)

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-lens.el at Sat Oct  1 21:18:39 2022

In lsp-lens--overlay-ensure-at:
lsp-lens.el:107:31: Warning: ‘point-at-eol’ is an obsolete function (as of
    29.1); use ‘line-end-position’ or ‘pos-eol’ instead.
lsp-lens.el:108:29: Warning: ‘point-at-bol’ is an obsolete function (as of
    29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
lsp-lens.el:108:48: Warning: ‘point-at-eol’ is an obsolete function (as of
    29.1); use ‘line-end-position’ or ‘pos-eol’ instead.

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-lua.el at Sat Oct  1 21:18:39 2022
lsp-lua.el:339:2: Warning: custom-declare-variable
    `lsp-lua-runtime-file-encoding' docstring has wrong usage of unescaped
    single quotes (use \= or different quoting)

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-magik.el at Sat Oct  1 21:18:39 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-markdown.el at Sat Oct  1 21:18:39 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-marksman.el at Sat Oct  1 21:18:39 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-mint.el at Sat Oct  1 21:18:39 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-mode.el at Sat Oct  1 21:18:39 2022

In lsp-clients-executable-find:
lsp-mode.el:1580:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

In lsp--make-log-entry:
lsp-mode.el:3055:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

In lsp--text-document-did-open:
lsp-mode.el:4071:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

In lsp--region-or-line:
lsp-mode.el:4137:28: Warning: ‘point-at-bol’ is an obsolete function (as of
    29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
lsp-mode.el:4137:43: Warning: ‘point-at-eol’ is an obsolete function (as of
    29.1); use ‘line-end-position’ or ‘pos-eol’ instead.

In lsp--create-apply-text-edits-handlers:
lsp-mode.el:4413:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

In lsp--render-on-hover-content:
lsp-mode.el:5300:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

In lsp--document-highlight-callback:
lsp-mode.el:5844:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

In lsp-send-execute-command:
lsp-mode.el:6276:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

In lsp-dependency:
lsp-mode.el:7520:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

In lsp-register-custom-settings:
lsp-mode.el:8146:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

In lsp--move-point-in-indentation:
lsp-mode.el:8957:23: Warning: ‘point-at-bol’ is an obsolete function (as of
    29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
lsp-mode.el:8958:10: Warning: ‘point-at-bol’ is an obsolete function (as of
    29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.

In lsp-progress-spinner-type:
lsp-mode.el:8973:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

In lsp-org:
lsp-mode.el:9048:79: Warning: ‘point-at-eol’ is an obsolete function (as of
    29.1); use ‘line-end-position’ or ‘pos-eol’ instead.
lsp-mode.el:9049:52: Warning: ‘point-at-eol’ is an obsolete function (as of
    29.1); use ‘line-end-position’ or ‘pos-eol’ instead.
lsp-mode.el:9048:79: Warning: ‘point-at-eol’ is an obsolete function (as of
    29.1); use ‘line-end-position’ or ‘pos-eol’ instead.
lsp-mode.el:9049:52: Warning: ‘point-at-eol’ is an obsolete function (as of
    29.1); use ‘line-end-position’ or ‘pos-eol’ instead.

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-modeline.el at Sat Oct  1 21:18:40 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-nginx.el at Sat Oct  1 21:18:40 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-nim.el at Sat Oct  1 21:18:40 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-nix.el at Sat Oct  1 21:18:40 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-ocaml.el at Sat Oct  1 21:18:40 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-openscad.el at Sat Oct  1 21:18:40 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-perl.el at Sat Oct  1 21:18:40 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-perlnavigator.el at Sat Oct  1 21:18:40 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-php.el at Sat Oct  1 21:18:40 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-pls.el at Sat Oct  1 21:18:40 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-prolog.el at Sat Oct  1 21:18:40 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-protocol.el at Sat Oct  1 21:18:40 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-purescript.el at Sat Oct  1 21:18:42 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-pwsh.el at Sat Oct  1 21:18:42 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-pyls.el at Sat Oct  1 21:18:42 2022
lsp-pyls.el:250:2: Warning: custom-declare-variable
    `lsp-pyls-plugins-pydocstyle-match' docstring has wrong usage of unescaped
    single quotes (use \= or different quoting)

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-pylsp.el at Sat Oct  1 21:18:42 2022
lsp-pylsp.el:206:2: Warning: custom-declare-variable
    `lsp-pylsp-plugins-pydocstyle-match' docstring has wrong usage of
    unescaped single quotes (use \= or different quoting)

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-r.el at Sat Oct  1 21:18:42 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-racket.el at Sat Oct  1 21:18:42 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-remark.el at Sat Oct  1 21:18:42 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-rf.el at Sat Oct  1 21:18:42 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-ruby-syntax-tree.el at Sat Oct  1 21:18:42 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-rust.el at Sat Oct  1 21:18:42 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-semantic-tokens.el at Sat Oct  1 21:18:42 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-solargraph.el at Sat Oct  1 21:18:42 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-sorbet.el at Sat Oct  1 21:18:42 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-sqls.el at Sat Oct  1 21:18:42 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-steep.el at Sat Oct  1 21:18:43 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-svelte.el at Sat Oct  1 21:18:43 2022
lsp-svelte.el:189:2: Warning: custom-declare-variable
    `lsp-svelte-plugin-svelte-compiler-warnings' docstring has wrong usage of
    unescaped single quotes (use \= or different quoting)

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-terraform.el at Sat Oct  1 21:18:43 2022
lsp-terraform.el:269:34: Error: Unknown key: :docs-link.  Available keys: (:name :docs_link :version :source_type :dependent_modules)

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-tex.el at Sat Oct  1 21:18:43 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-toml.el at Sat Oct  1 21:18:43 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-ttcn3.el at Sat Oct  1 21:18:43 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-typeprof.el at Sat Oct  1 21:18:43 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-v.el at Sat Oct  1 21:18:43 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-vala.el at Sat Oct  1 21:18:43 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-verilog.el at Sat Oct  1 21:18:43 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-vetur.el at Sat Oct  1 21:18:43 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-vhdl.el at Sat Oct  1 21:18:43 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-vimscript.el at Sat Oct  1 21:18:43 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-volar.el at Sat Oct  1 21:18:43 2022

In lsp-volar--vue-project-p:
lsp-volar.el:108:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-xml.el at Sat Oct  1 21:18:43 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-yaml.el at Sat Oct  1 21:18:43 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp-zig.el at Sat Oct  1 21:18:43 2022

Compiling file c:/Users/JenChieh/AppData/Roaming/.emacs.d/elpa/lsp-mode-20221001.846/lsp.el at Sat Oct  1 21:18:43 2022
```

</details>
