### PR TITLE
lsp-eslint: support glob patterns for workingDirectories parameter

### DIFF
--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -120,7 +120,14 @@ source.fixAll code action."
   :package-version '(lsp-mode . "6.3"))
 
 (defcustom lsp-eslint-working-directories []
-  ""
+  "A vector of working directory names to use. Can be a pattern, an absolute path
+or a path relative to the workspace. Examples:
+ - \"/home/user/abc/\"
+ - \"abc/\"
+ - (directory \"abc\") which is equivalent to \"abc\" above
+ - (pattern \"abc/*\")
+Note that the home directory reference ~/ is not currently supported, use
+/home/[user]/ instead."
   :type 'lsp-string-vector
   :package-version '(lsp-mode . "6.3"))
 
@@ -288,11 +295,7 @@ stored."
 
 (defun lsp-eslint--working-directory (workspace current-file)
   "Find the first directory in the parameter config.workingDirectories which
-contains the current file. This parameter supports:
-
- - \".abc\"
- - (directory \"./abc\") equivalent to \"./abc\", see above
- - (pattern \"./abc/*\")"
+contains the current file"
   (let ((directories (-map (lambda (dir)
                              (when (and (listp dir) (plist-member dir 'directory))
                                (setq dir (plist-get dir 'directory)))

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -297,9 +297,14 @@ contains the current file. This parameter supports:
                              (when (and (listp dir) (plist-member dir 'directory))
                                (setq dir (plist-get dir 'directory)))
                              (if (and (listp dir) (plist-member dir 'pattern))
-                               (setq dir (f-glob (f-join workspace (plist-get dir 'pattern))))
-                               (if (and (stringp dir) (not (f-absolute? dir)))
-                                 (setq dir (f-join workspace dir)))))
+                               (progn
+                                 (setq dir (plist-get dir 'pattern))
+                                 (when (not (f-absolute? dir))
+                                   (setq dir (f-join workspace dir)))
+                                 (f-glob dir))
+                               (if (f-absolute? dir)
+                                 dir
+                                 (f-join workspace dir))))
                            (append lsp-eslint-working-directories nil))))
     (-first (lambda (dir) (f-ancestor-of-p dir current-file)) (-flatten directories))))
 


### PR DESCRIPTION
This PR adds glob support to the `workingDirectories` parameter for the `lsp-eslint` client. This mimics the behaviour of VSCode with ESLint: https://github.com/microsoft/vscode-eslint/blob/main/client/src/client.ts#L642.

Closes #3438
Closes #3688 (fix was ported to this pr)