### PR TITLE
use `go install` instead of `go get`

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -729,7 +729,7 @@
     "full-name": "SQL (sqls)",
     "server-name": "sqls",
     "server-url": "https://github.com/lighttiger2505/sqls",
-    "installation": "go get github.com/lighttiger2505/sqls",
+    "installation": "go install github.com/lighttiger2505/sqls@latest",
     "debugger": "Not available"
   },
   {


### PR DESCRIPTION
I don't know when this started, but it seems that go is trying to use the `install` subcommand instead of `get`.

```
$ go get github.com/lighttiger2505/sqls
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

```
$ go install github.com/lighttiger2505/sqls@latest
go: downloading github.com/lighttiger2505/sqls v0.2.22
go: downloading github.com/sourcegraph/jsonrpc2 v0.1.0
go: downloading github.com/urfave/cli/v2 v2.3.0
go: downloading github.com/olekukonko/tablewriter v0.0.5
go: downloading github.com/denisenkom/go-mssqldb v0.11.0
go: downloading github.com/go-sql-driver/mysql v1.6.0
go: downloading github.com/godror/godror v0.29.0
go: downloading github.com/jackc/pgx/v4 v4.12.0
go: downloading github.com/mattn/go-sqlite3 v1.14.8
go: downloading golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
go: downloading github.com/mattn/go-runewidth v0.0.9
go: downloading github.com/jackc/pgx v3.6.2+incompatible
go: downloading github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe
go: downloading github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d
go: downloading github.com/godror/knownpb v0.1.0
go: downloading github.com/go-logfmt/logfmt v0.5.0
go: downloading google.golang.org/protobuf v1.27.1
go: downloading github.com/jackc/pgproto3/v2 v2.1.1
go: downloading github.com/jackc/pgtype v1.8.0
go: downloading github.com/jackc/pgconn v1.9.0
go: downloading github.com/jackc/pgio v1.0.0
go: downloading github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b
go: downloading github.com/jackc/chunkreader/v2 v2.0.1
go: downloading github.com/jackc/pgpassfile v1.0.0
go: downloading github.com/jackc/pgproto3 v1.1.0
go: downloading github.com/jackc/chunkreader v1.0.0

$ which sqls
/Users/conao/go/bin/sqls
```