### PR TITLE
hide parent details in imenu nodes

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6715,6 +6715,11 @@ information, for example if it doesn't support DocumentSymbols."
   :group 'lsp-imenu
   :type 'boolean)
 
+(defcustom lsp-imenu-hide-parent-details t
+  "Whether `lsp-imenu' should hide signatures of parent nodes."
+  :group 'lsp-imenu
+  :type 'boolean)
+
 (defface lsp-details-face '((t :height 0.8 :inherit shadow))
   "Used to display additional information troughout `lsp'.
 Things like line numbers, signatures, ... are considered
@@ -6923,7 +6928,8 @@ The result looks like this: ((\"Variables\" . (...)))."
     (-lambda ((sym &as &DocumentSymbol :kind :children?))
       (if (seq-empty-p children?)
           (list (list kind (lsp--symbol->imenu sym)))
-        (let ((parent (lsp-render-symbol sym lsp-imenu-detailed-outline)))
+        (let ((parent (lsp-render-symbol sym (and lsp-imenu-detailed-outline
+                                                  (not lsp-imenu-hide-parent-details)))))
           (cons
            (list kind (lsp--symbol->imenu sym))
            (mapcar (-lambda ((type .  imenu-items))


### PR DESCRIPTION
Hi,

This is a simple PR for lsp-imenu to hide details of parent nodes, while still showing the documentation of the child node. It helps to make the imenu details more concise.

For example, here is a screenshot of the original lsp-imenu in CC mode, were the parent details (in gray tex) are redundant and not necessary:

![imenu](https://user-images.githubusercontent.com/193967/194068890-958582ff-4c16-472e-a6ef-15039b2db10c.png)

And here is the result after applying my PR:

![imenu-2](https://user-images.githubusercontent.com/193967/194068948-18e38f0f-4927-4e2d-b259-e01e385702d2.png)

Hope that the PR is useful and can be merged back.

Thanks!


