### PR TITLE
fix(lsp-protocol.el): Fix unknown keys in lsp-terraform

### DIFF
--- a/clients/lsp-terraform.el
+++ b/clients/lsp-terraform.el
@@ -205,8 +205,7 @@ Defaults to side following treemacs default."
   (lsp-request
    "workspace/executeCommand"
    (list :command "terraform-ls.terraform.validate"
-         :arguments (vector (format "uri=%s" (lsp--path-to-uri (lsp-workspace-root))))
-         )
+         :arguments (vector (format "uri=%s" (lsp--path-to-uri (lsp-workspace-root)))))
    :no-wait t
    :no-merge t))
 
@@ -266,25 +265,25 @@ This is a synchronous action."
                    :installed-version installed-version
                    :version-constraint (lsp-get provider :version_constraint)))
 
-(lsp-defun construct-tf-module ((&terraform-ls:Module :name :docs-link :version :source-type :dependent-modules))
+(lsp-defun construct-tf-module ((&terraform-ls:Module :name :docs_link :version :source_type :dependent_modules))
   "Construct `TF-MODULE' using MODULE."
   (make-tf-module :name name
-                  :doc-link docs-link
+                  :doc-link docs_link
                   :version version
-                  :source-type source-type
-                  :dependent-modules dependent-modules))
+                  :source-type source_type
+                  :dependent-modules dependent_modules))
 
-(lsp-defun lsp-terraform-ls--providers-to-tf-package ((&terraform-ls:Providers :provider-requirements :installed-providers))
+(lsp-defun lsp-terraform-ls--providers-to-tf-package ((&terraform-ls:Providers :provider_requirements :installed_providers))
   "Convert PROVIDERS-TREE-DATA to list of `tf-package'."
-  (let* ((provider-requirements-keys (hash-table-keys provider-requirements))
-         (installed-versions (mapcar (lambda (x) (lsp-get installed-providers (make-symbol (format ":%s" x)))) provider-requirements-keys))
-         (providers (mapcar (lambda (x) (lsp-get provider-requirements (make-symbol (format ":%s" x)))) provider-requirements-keys))
+  (let* ((provider-requirements-keys (hash-table-keys provider_requirements))
+         (installed-versions (mapcar (lambda (x) (lsp-get installed_providers (make-symbol (format ":%s" x)))) provider-requirements-keys))
+         (providers (mapcar (lambda (x) (lsp-get provider_requirements (make-symbol (format ":%s" x)))) provider-requirements-keys))
          (tf-packages (-zip-with (lambda (x y) (construct-tf-package x y)) providers installed-versions)))
     tf-packages))
 
-(lsp-defun lsp-terraform-ls--modules-to-tf-module ((&terraform-ls:ModuleCalls :module-calls))
+(lsp-defun lsp-terraform-ls--modules-to-tf-module ((&terraform-ls:ModuleCalls :module_calls))
   "Convert MODULES-TREE-DATA to list of `TF-MODULE'."
-  (let* ((modules (-map (lambda (x) (construct-tf-module x)) module-calls)))
+  (let* ((modules (-map (lambda (x) (construct-tf-module x)) module_calls)))
     modules))
 
 (defun lsp-terraform-ls--fetch-modules-data (project-root)


### PR DESCRIPTION
When `(require 'lsp-terraform)` we get the error,

```
lsp-terraform.el:269:34: Error: Unknown key: :docs-link.  Available keys: (:name :docs_link :version :source_type :dependent_modules)
```

@psibi Not sure if this is the correct fix. Can you confirm this? 😕 