### PR TITLE
Allow with-lsp-workspace for non-existed one

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,13 +50,13 @@ jobs:
             - name: Install depedencies on Linux
               if: runner.os == 'Linux'
               run: |
-                   pip3 install python-language-server
+                   pip3 install python-lsp-server
                    sudo apt-get install clangd-9
 
             - name: Install deps on macOS
               if: runner.os == 'macOS'
               run: |
-                   pip3 install python-language-server
+                   pip3 install python-lsp-server
 
             - name: Check clangd
               if: runner.os == 'Linux'
@@ -94,7 +94,7 @@ jobs:
                 version: ${{ matrix.emacs-version }}
 
             - name: Install depedencies
-              run: "pip install python-language-server"
+              run: "pip install python-lsp-server"
 
             - name: Run tests
               run:

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1920,7 +1920,7 @@ regex in IGNORED-FILES."
   "Helper macro for invoking BODY in WORKSPACE context."
   (declare (debug (form body))
            (indent 1))
-  `(when ,workspace (let ((lsp--cur-workspace ,workspace)) ,@body)))
+  `(let ((lsp--cur-workspace ,workspace)) ,@body))
 
 (defmacro with-lsp-workspaces (workspaces &rest body)
   "Helper macro for invoking BODY against multiple WORKSPACES."
@@ -6660,7 +6660,8 @@ server. WORKSPACE is the active workspace."
   "Dispatch the messages in `lsp--parsed-messages'."
   (run-at-time 0 nil (lambda ()
                        (when (cl-rest lsp--parsed-messages) (lsp--dispatch-messages))
-                       (apply #'lsp--parser-on-message (pop lsp--parsed-messages)))))
+                       (when lsp--parsed-messages
+                         (apply #'lsp--parser-on-message (pop lsp--parsed-messages))))))
 
 (defun lsp--create-filter-function (workspace)
   "Make filter for the workspace."

--- a/test/lsp-clangd-test.el
+++ b/test/lsp-clangd-test.el
@@ -81,6 +81,7 @@ and starts lsp. After the test BODY runs - tidy up."
      ;; or we might keep it forever
      (setq lsp-clients-clangd-args '("--compile-commands-dir=build/" "--log=verbose"))
 
+     (setq lsp--parsed-messages nil)
      ;; snippet complains in logs
      (setq lsp-enable-snippet nil)
      (lsp-workspace-folders-add (f-join lsp-test-location "fixtures/SampleCppProject/"))


### PR DESCRIPTION
Fix issue in https://github.com/emacs-lsp/lsp-treemacs/issues/144#issuecomment-1279392725
In this change:
- Reallow passing null for workspace in `with-lsp-workspace`
- Check `workspace` available in `lsp--parse-on-message` instead of relying on `with-lsp-workspace`.
- Fix CI to use the maintained `pylsp` instead of `pyls`