### PR TITLE
Update lsp-mode.el

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -355,6 +355,8 @@ the server has requested that."
     "[/\\\\]build-aux\\'"
     "[/\\\\]autom4te.cache\\'"
     "[/\\\\]\\.reference\\'"
+    ;; Bazel
+    "bazel-[^/\\\\]+\\'",
     ;; Clojure
     "[/\\\\]\\.lsp\\'"
     "[/\\\\]\\.clj-kondo\\'"

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -356,7 +356,7 @@ the server has requested that."
     "[/\\\\]autom4te.cache\\'"
     "[/\\\\]\\.reference\\'"
     ;; Bazel
-    "bazel-[^/\\\\]+\\'",
+    "bazel-[^/\\\\]+\\'"
     ;; Clojure
     "[/\\\\]\\.lsp\\'"
     "[/\\\\]\\.clj-kondo\\'"


### PR DESCRIPTION
Ignore the `bazel-*` symbolic links pointing to object cache that Bazel creates at the root of a project