### PR TITLE
don't put evaporate to  lens overlay

### DIFF
--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -107,7 +107,6 @@ Results are meaningful only if FROM and TO are on the same line."
                (make-overlay (point-at-eol) -1 nil t t)
              (make-overlay (point-at-bol) (1+ (point-at-eol)) nil t t)))
     (overlay-put 'lsp-lens t)
-    (overlay-put 'evaporate t)
     (overlay-put 'lsp-lens-position pos)))
 
 (defun lsp-lens--show (str pos metadata)


### PR DESCRIPTION
close #3761

@akoptelov does it work ?

> An overlay whose start and end specify the same buffer position is known as empty. A non-empty overlay can become empty if the text between its start and end is deleted. When that happens, the overlay is by default not deleted, but you can cause it to be deleted by giving it the ‘evaporate’ property

The overlays seem to be deleted even when not using ‘evaporate’.