### PR TITLE
Remove deprecated `--background-services-enabled` flag to FSAC

### DIFF
--- a/clients/lsp-fsharp.el
+++ b/clients/lsp-fsharp.el
@@ -138,8 +138,7 @@ opened module/namespace."
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-fsharp-enable-reference-code-lens t
-  "Enables reference count code lenses.
-It is recommended to disable if `--background-service-enabled' is not used."
+  "Enables reference count code lenses."
   :group 'lsp-fsharp
   :type 'boolean
   :package-version '(lsp-mode . "6.2"))
@@ -210,7 +209,7 @@ available, else the globally installed tool."
                                (t nil)))
         (fsautocomplete-exec (lsp-fsharp--fsac-cmd)))
     (append startup-wrapper
-            (list fsautocomplete-exec "--background-service-enabled")
+            (list fsautocomplete-exec)
             lsp-fsharp-server-args)))
 
 (defun lsp-fsharp--test-fsautocomplete-present ()


### PR DESCRIPTION
The latest version of FsAutoComplete drops the `--background-services-enabled` flag; see the
[CHANGELOG](https://github.com/fsharp/FsAutoComplete/blob/main/CHANGELOG.md). Accordingly, FSAC will no longer start. This flag is hard-coded, so can't be overridden. Alas. 

My thought is: best to just drop the hard-coding of this argument and instead allow users of older FSAC versions to specify `--background-service-enabled` in their `lsp-fsharp-server-args` custom. 