### PR TITLE
fix(lsp-mode.el): Make sure modules will be loaded

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7720,7 +7720,7 @@ Check `*lsp-install*' and `*lsp-log*' buffer."
     (seq-do (lambda (package)
               ;; loading client is slow and `lsp' can be called repeatedly
               (unless (featurep package)
-                (require package nil t)))
+                (ignore-errors (require package nil t))))
             lsp-client-packages)
     (setq lsp--client-packages-required t)))
 


### PR DESCRIPTION
By looking at the macro `require`'s description:

```
If the optional third argument NOERROR is non-nil, then, if
the file is not found, the function returns nil instead of signaling
an error.  Normally the return value is FEATURE.
```

It seems like it only check file not found condition; I think it's better if we ignore all conditions so one lsp packages break won't break all of them.