### PR TITLE
Do not use 'nil for the nix nil server id

### DIFF
--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -57,7 +57,7 @@
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-nix-nil-server-path))
                   :major-modes '(nix-mode)
-                  :server-id 'nil))
+                  :server-id 'nix-nil))
 
 (lsp-consistency-check lsp-nix)
 


### PR DESCRIPTION
Some functions, notably `lsp-install-server`, rely on there not being an entry with key `nil` in the `lsp-clients` hash table. Quoting `nil` doesn't make it not the same as `nil` so we need to use a different value for the server-id.

Resolves #3794