### PR TITLE
add references capability

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3554,6 +3554,7 @@ disappearing, unset all the variables related to it."
                                       (linkSupport . t)))
                       (definition . ((dynamicRegistration . t)
                                      (linkSupport . t)))
+                      (references . ((dynamicRegistration . t)))
                       (implementation . ((dynamicRegistration . t)
                                          (linkSupport . t)))
                       (typeDefinition . ((dynamicRegistration . t)


### PR DESCRIPTION
The `volar` server depends on the `references` capability, see this line 

https://github.com/johnsoncodehk/volar/blob/019417a8e999e68d93ec6ac59d2b7684ca3a6da5/packages/language-server/src/registerFeatures.ts#L87-L89

And fix https://github.com/emacs-lsp/lsp-mode/issues/3785#issuecomment-1300608112

Can we directly add this?