### PR TITLE
Fix unzipping failure when PowerShell is available

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8002,7 +8002,7 @@ archieve(e. g. when the archieve has multiple files)"
 ;; unzip
 
 (defconst lsp-ext-pwsh-script "powershell -noprofile -noninteractive \
--nologo -ex bypass Expand-Archive -path '%s' -dest '%s'"
+-nologo -ex bypass -command Expand-Archive -path '%s' -dest '%s'"
   "Powershell script to unzip file.")
 
 (defconst lsp-ext-unzip-script "bash -c 'mkdir -p %2$s && unzip -qq -o %1$s -d %2$s'"


### PR DESCRIPTION
This PR fixes an unzipping failure when PowerShell is available on `PATH`.

Root cause is the PowerShell script is missing an argument `-command` to specify commands passed in. So when it's executed it returns the following error.

```
The argument 'Expand-Archive' is not recognized as the name of a script file. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.

Usage: pwsh[.exe] [-Login] [[-File] <filePath> [args]]
                  [-Command { - | <script-block> [-args <arg-array>]
                                | <string> [<CommandParameters>] } ]
                  [-ConfigurationName <string>] [-CustomPipeName <string>]
                  [-EncodedCommand <Base64EncodedCommand>]
                  [-ExecutionPolicy <ExecutionPolicy>] [-InputFormat {Text | XML}]
                  [-Interactive] [-MTA] [-NoExit] [-NoLogo] [-NonInteractive] [-NoProfile]
                  [-OutputFormat {Text | XML}] [-SettingsFile <filePath>] [-SSHServerMode] [-STA]
                  [-Version] [-WindowStyle <style>] [-WorkingDirectory <directoryPath>]

       pwsh[.exe] -h | -Help | -? | /?

PowerShell Online Help https://aka.ms/powershell-docs

All parameters are case-insensitive.
```

Unfortunately the unzipping operation that uses PowerShell takes precedence over the regular `unzip` method: https://github.com/emacs-lsp/lsp-mode/blob/54cdc61be837e9ab3e4673bbb73fb6627089a973/lsp-mode.el#L8011-L8014

When users have PowerShell installed they will constantly fail with file extraction. Thus they can't install servers unless PowerShell is uninstalled or removed from `PATH`.

Test performed: Tested by installing `clangd`. `lsp-mode` was able to extract the files successfully.