### PR TITLE
fix(lsp-volar): diagnosticMode -> diagnosticModel

### DIFF
--- a/clients/lsp-volar.el
+++ b/clients/lsp-volar.el
@@ -119,7 +119,7 @@ in the WORKSPACE-ROOT."
   :server-id 'vue-semantic-server
   :initialization-options (lambda () (ht-merge (lsp-configuration-section "typescript")
                                                (ht ("serverMode" 0)
-                                                   ("diagnosticMode" 1)
+                                                   ("diagnosticModel" 1)
                                                    ("textDocumentSync" 2))))
   :initialized-fn (lambda (workspace)
                     (with-lsp-workspace workspace


### PR DESCRIPTION
This typo will not affect the actual function, because the volar server has a default value, and the value is also 2.