### PR TITLE
lsp-graphql: add locally installed command, if present, as preferred option

### DIFF
--- a/clients/lsp-graphql.el
+++ b/clients/lsp-graphql.el
@@ -27,6 +27,7 @@
 (require 'lsp-mode)
 
 (lsp-dependency 'graphql-language-service-cli
+                '(:system "graphql-lsp")
                 '(:npm :package "graphql-language-service-cli"
                        :path "graphql-lsp"))
 


### PR DESCRIPTION
lsp-graphql: add locally installed command, if present, as preferred option

I'm having some trouble with the auto-installed graphql-languageserver-cli package, and I haven't figured out whether that's an environment issue on my end, or something worth reporting as a bug, but meanwhile I'm using a working graphql-lsp that I installed manually. 

Even if the auto-installed server can be fixed, most lsp clients will prefer an already installed command if available, and I didn't see any reason for lsp-graphql to be different, so I think this would be an improvement for graphql-lsp. 

