### PR TITLE
Fix usage of ...trigger-for-incomplete-completions

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -56,6 +56,7 @@
     obsolete ~lsp-xml-format-quotes~.
   * Add [[https://github.com/oxalica/nil][nil]] support (additional server for Nix)
   * Add [[https://github.com/johnsoncodehk/volar/pull/1916][Volar 1.0]] support, refactor vue-language-server ~initializationOptions~, and remove multi server that is no longer needed.
+  * Ensure that incomplete completions only trigger when retriggering from the same completion session #3028
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -394,8 +394,8 @@ The MARKERS and PREFIX value will be attached to each candidate."
     (lsp:completion-item-documentation?)
     (lsp--render-element)))
 
-(defun lsp-completion--get-context (trigger-characters)
-  "Get completion context with provided TRIGGER-CHARACTERS."
+(defun lsp-completion--get-context (trigger-characters same-session?)
+  "Get completion context with provided TRIGGER-CHARACTERS and SAME-SESSION?."
   (let* ((triggered-by-char non-essential)
          (trigger-char (when triggered-by-char
                          (lsp-completion--looking-back-trigger-characterp
@@ -403,7 +403,8 @@ The MARKERS and PREFIX value will be attached to each candidate."
          (trigger-kind (cond
                         (trigger-char
                          lsp/completion-trigger-kind-trigger-character)
-                        ((equal (cl-second lsp-completion--cache) :incomplete)
+                        ((and same-session?
+                              (equal (cl-second lsp-completion--cache) :incomplete))
                          lsp/completion-trigger-kind-trigger-for-incomplete-completions)
                         (t lsp/completion-trigger-kind-invoked))))
     (apply #'lsp-make-completion-context
@@ -457,7 +458,7 @@ The MARKERS and PREFIX value will be attached to each candidate."
                       (-let* ((resp (lsp-request-while-no-input
                                      "textDocument/completion"
                                      (plist-put (lsp--text-document-position-params)
-                                                :context (lsp-completion--get-context trigger-chars))))
+                                                :context (lsp-completion--get-context trigger-chars same-session?))))
                               (completed (and resp
                                               (not (and (lsp-completion-list? resp)
                                                         (lsp:completion-list-is-incomplete resp)))))


### PR DESCRIPTION
Ensure that the completion session is the same as the previous incomplete completion before using trigger style
`lsp/completion-trigger-kind-trigger-for-incomplete-completions`.

Previously the internal function `lsp-completion--get-context` had no notion of whether the current completion request was the using the same context as the previous completion request. This internal function is only called by `lsp-completion-at-point`. `lsp-completion-at-point` does calculate whether this completion request is using the same context as the last result. We therefore now pass the information from `lsp-completion-at-point` down to `lsp-completion--get-context` and use it therein when making a determination about which trigger type of completion to use.

This addresses issue #3028 where completions would stop working with the sourcekit-lsp language server for Swift. This language server in particular sends back incomplete completions frequently and also checks on its side to make sure any requested completion continuation context is the same as it was when originally requested. If not it cancels the request.