### PR TITLE
Support for Astro language server

### DIFF
--- a/clients/lsp-astro.el
+++ b/clients/lsp-astro.el
@@ -1,0 +1,42 @@
+;;; lsp-astro.el --- lsp-mode astro integration -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022 Paweł Kobojek
+
+;; Author: Paweł Kobojek
+;; Keywords: languages,astro
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;  client for astro-ls
+
+;;; Code:
+(require 'lsp-mode)
+
+(defgroup lsp-astro nil
+  "LSP support for Astro.build, using astro-ls."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/withastro/language-tools"))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection '("astro-ls" "--stdio"))
+                  :activation-fn (lsp-activate-on "astro")
+                  :server-id 'astro-ls))
+
+
+
+(lsp-consistency-check lsp-astro)
+(provide 'lsp-astro)
+;;; lsp-astro.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -34,6 +34,15 @@
     "debugger": "Not available"
   },
   {
+    "name": "astro",
+    "full-name": "Astro",
+    "server-name": "astro-ls",
+    "server-url": "https://github.com/withastro/language-tools",
+    "installation": "npm i -g @astrojs/language-server",
+    "lsp-install-server": "astro-ls",
+    "debugger": "Not available"
+  },
+  {
     "name": "bash",
     "full-name": "Bash",
     "server-name": "bash-language-server",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -174,7 +174,7 @@ As defined by the Language Server Protocol 3.16."
   :package-version '(lsp-mode . "6.1"))
 
 (defcustom lsp-client-packages
-  '(ccls lsp-actionscript lsp-ada lsp-angular lsp-ansible lsp-bash lsp-beancount lsp-clangd lsp-clojure
+  '(ccls lsp-actionscript lsp-ada lsp-angular lsp-ansible lsp-astro lsp-bash lsp-beancount lsp-clangd lsp-clojure
          lsp-cmake lsp-crystal lsp-csharp lsp-css lsp-d lsp-dart lsp-dhall lsp-docker lsp-dockerfile
          lsp-elm lsp-elixir lsp-emmet lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript lsp-go
          lsp-gleam lsp-graphql lsp-hack lsp-grammarly lsp-groovy lsp-haskell lsp-haxe lsp-idris lsp-java lsp-javascript
@@ -749,6 +749,7 @@ Changes take effect only when a new session is started."
                                         (".*/PKGBUILD$" . "shellscript")
                                         (".*\\.ttcn3$" . "ttcn3")
                                         (".*\\ya?ml$" . "yaml")
+                                        (".*\\.astro$" . "astro")
                                         (ada-mode . "ada")
                                         (nxml-mode . "xml")
                                         (sql-mode . "sql")
@@ -1942,7 +1943,7 @@ regex in IGNORED-FILES."
     lsp-python-ms lsp-rescript lsp-sonarlint lsp-sourcekit lsp-tailwindcss lsp-treemacs
     lsp-ui swift-helpful
     ;; clients
-    lsp-actionscript lsp-ada lsp-angular lsp-bash lsp-beancount lsp-clangd
+    lsp-actionscript lsp-ada lsp-angular lsp-astro lsp-bash lsp-beancount lsp-clangd
     lsp-clojure lsp-cmake lsp-crystal lsp-csharp lsp-css lsp-d lsp-dhall
     lsp-dockerfile lsp-elixir lsp-elm lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript
     lsp-go lsp-gleam lsp-graphql lsp-groovy lsp-hack lsp-haxe lsp-html lsp-idris lsp-javascript lsp-json lsp-kotlin lsp-lua

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - Ada: page/lsp-ada.md
     - Angular: page/lsp-angular.md
     - Ansible: page/lsp-ansible.md
+    - Astro: page/lsp-astro.md
     - Bash: page/lsp-bash.md
     - Beancount: page/lsp-beancount.md
     - Camel: page/lsp-camel.md


### PR DESCRIPTION
Support for [Astro](https://astro.build/) [language server](https://github.com/withastro/language-tools). Related issue: #3584 