### PR TITLE
Fix activation of lsp-help-mode

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5176,9 +5176,9 @@ If EXCLUDE-DECLARATION is non-nil, request the server to include declarations."
     (if (and contents (not (equal contents "")))
         (let ((lsp-help-buf-name "*lsp-help*"))
           (with-current-buffer (get-buffer-create lsp-help-buf-name)
-            (lsp-help-mode)
             (with-help-window lsp-help-buf-name
-              (insert (string-trim-right (lsp--render-on-hover-content contents t))))))
+              (insert (string-trim-right (lsp--render-on-hover-content contents t))))
+            (lsp-help-mode)))
       (lsp--info "No content at point."))))
 
 (defun lsp--point-in-bounds-p (bounds)


### PR DESCRIPTION
For some reason, enabling `(lsp-help-mode)` before use of `(with-help-window)` will revert the buffer back to `(help-mode)`. Therefore, move the activation of lsp-help-mode after that.