### PR TITLE
Improve support for emacs29 tree-sitter based major-modes

### DIFF
--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -343,7 +343,7 @@ using the `textDocument/references' request."
                    #'(lambda ()
                        (when-let ((binary (lsp-csharp--language-server-path)))
                          (f-exists? binary))))
-                  :major-modes '(csharp-mode csharp-tree-sitter-mode)
+                  :major-modes '(csharp-mode csharp-tree-sitter-mode csharp-ts-mode)
                   :server-id 'omnisharp
                   :priority -1
                   :action-handlers (ht ("omnisharp/client/findReferences" 'lsp-csharp--action-client-find-references))
@@ -459,7 +459,7 @@ Will update if UPDATE? is t"
                                                         #'lsp-csharp--cls-test-csharp-ls-present)
                   :priority -2
                   :server-id 'csharp-ls
-                  :major-modes '(csharp-mode csharp-tree-sitter-mode)
+                  :major-modes '(csharp-mode csharp-tree-sitter-mode csharp-ts-mode)
                   :before-file-open-fn #'lsp-csharp--cls-before-file-open
                   :uri-handlers (ht ("csharp" #'lsp-csharp--cls-metadata-uri-handler))
                   :download-server-fn #'lsp-csharp--cls-download-server))

--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -392,7 +392,7 @@ to allow or deny it.")
                      (or (string-match-p (rx (one-or-more anything) "."
                                              (or "ts" "js" "jsx" "tsx" "html" "vue" "svelte")eos)
                                          filename)
-                         (and (derived-mode-p 'js-mode 'js2-mode 'typescript-mode 'html-mode 'svelte-mode)
+                         (and (derived-mode-p 'js-mode 'js2-mode 'typescript-mode 'typescript-ts-mode 'html-mode 'svelte-mode)
                            (not (string-match-p "\\.json\\'" filename))))))
   :priority -1
   :completion-in-comments? t

--- a/clients/lsp-graphql.el
+++ b/clients/lsp-graphql.el
@@ -48,7 +48,7 @@
   (or (string-match-p (rx (one-or-more anything) "."
                         (or "ts" "js" "jsx" "tsx" "vue" "graphql" "gql")eos)
         filename)
-    (and (derived-mode-p 'js-mode 'js2-mode 'typescript-mode)
+    (and (derived-mode-p 'js-mode 'js2-mode 'typescript-mode 'typescript-ts-mode)
       (not (derived-mode-p 'json-mode)))))
 
 (lsp-register-client

--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -51,7 +51,7 @@
 (defun lsp-typescript-javascript-tsx-jsx-activate-p (filename &optional _)
   "Check if the js-ts lsp server should be enabled based on FILENAME."
   (or (string-match-p "\\.mjs\\|\\.[jt]sx?\\'" filename)
-      (and (derived-mode-p 'js-mode 'typescript-mode)
+      (and (derived-mode-p 'js-mode 'typescript-mode 'typescript-ts-mode)
            (not (derived-mode-p 'json-mode)))))
 
 ;; Unmaintained sourcegraph server

--- a/clients/lsp-volar.el
+++ b/clients/lsp-volar.el
@@ -103,7 +103,7 @@ in the WORKSPACE-ROOT."
             (and (lsp-workspace-root) (lsp-volar--vue-project-p (lsp-workspace-root)))
             (and (lsp-workspace-root) lsp-volar-activate-file (f-file-p (f-join (lsp-workspace-root) lsp-volar-activate-file))))
            (or (or (string-match-p "\\.mjs\\|\\.[jt]sx?\\'" filename)
-                   (and (derived-mode-p 'js-mode 'typescript-mode)
+                   (and (derived-mode-p 'js-mode 'typescript-mode 'typescript-ts-mode)
                         (not (derived-mode-p 'json-mode))))
                (string= (file-name-extension filename) "vue")))
    (string= (file-name-extension filename) "vue")))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -824,6 +824,7 @@ Changes take effect only when a new session is started."
                                         (dockerfile-mode . "dockerfile")
                                         (csharp-mode . "csharp")
                                         (csharp-tree-sitter-mode . "csharp")
+                                        (csharp-ts-mode . "csharp")
                                         (plain-tex-mode . "plaintex")
                                         (latex-mode . "latex")
                                         (v-mode . "v")
@@ -5803,6 +5804,7 @@ Request codeAction/resolve for more info if server supports."
     (c++-mode                   . c-basic-offset)                   ; C++
     (csharp-mode                . c-basic-offset)                   ; C#
     (csharp-tree-sitter-mode    . csharp-tree-sitter-indent-offset) ; C#
+    (csharp-ts-mode             . csharp-ts-mode-indent-offset)     ; C# (tree-sitter, Emacs29)
     (d-mode                     . c-basic-offset)                   ; D
     (java-mode                  . c-basic-offset)                   ; Java
     (jde-mode                   . c-basic-offset)                   ; Java (JDE)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -806,6 +806,7 @@ Changes take effect only when a new session is started."
                                         (js-mode . "javascript")
                                         (js-ts-mode . "javascript")
                                         (typescript-mode . "typescript")
+                                        (typescript-ts-mode . "typescript")
                                         (fsharp-mode . "fsharp")
                                         (reason-mode . "reason")
                                         (caml-mode . "ocaml")
@@ -5824,6 +5825,7 @@ Request codeAction/resolve for more info if server supports."
     (nxml-mode                  . nxml-child-indent)                ; XML
     (pascal-mode                . pascal-indent-level)              ; Pascal
     (typescript-mode            . typescript-indent-level)          ; Typescript
+    (typescript-ts-mode         . typescript-ts-mode-indent-offset) ; Typescript (tree-sitter, Emacs29)
     (sh-mode                    . sh-basic-offset)                  ; Shell Script
     (ruby-mode                  . ruby-indent-level)                ; Ruby
     (enh-ruby-mode              . enh-ruby-indent-level)            ; Ruby


### PR DESCRIPTION
Add support for new Emacs 29 tree-sitter based modes:

* csharp-ts-mode
* typescript-ts-mode