### PR TITLE
tests: Setup node is no longer required

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,6 @@ jobs:
         with:
           version: 27.1
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-
       - uses: emacs-eask/setup-eask@master
         with:
           version: 'snapshot'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,6 @@ jobs:
       with:
         version: ${{ matrix.emacs-version }}
 
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '16'
-
     - uses: emacs-eask/setup-eask@master
       with:
         version: 'snapshot'


### PR DESCRIPTION
This is no longer needed for [setup-eask](https://github.com/emacs-eask/setup-eask).