### PR TITLE
Prefer plain unzip for extracting archives instead of PowerShell when available

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8041,8 +8041,8 @@ archieve(e. g. when the archieve has multiple files)"
   "Unzip script to unzip file.")
 
 (defcustom lsp-unzip-script (lambda ()
-                              (cond ((executable-find "powershell") lsp-ext-pwsh-script)
-                                    ((executable-find "unzip") lsp-ext-unzip-script)
+                              (cond ((executable-find "unzip") lsp-ext-unzip-script)
+                                    ((executable-find "powershell") lsp-ext-pwsh-script)
                                     (t nil)))
   "The script to unzip."
   :group 'lsp-mode


### PR DESCRIPTION
Currently on Linux, Powershell is used to unzip ZIP-archives even when plain unzip is available.

However using PowerShell has more dependencies (versions, needs correct parameters, escaping etc) than plain `unzip`. On Ubuntu powershell is also provided as a snap which may or may not cause issues wrt to environment-variables, permissions, etc.

This PR changes the probing order in `lsp-mode.el` to prefer unzip over PowerShell when unzip is available.

This PR partially adresses: https://github.com/emacs-lsp/lsp-mode/issues/3802