### PR TITLE
[Fix emacs-lsp/lsp-ui#452] Fix markdown link navigation in *lsp-help* buffers

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5232,18 +5232,20 @@ MODE is the mode used in the parent frame."
   (let ((inhibit-read-only t)
         (inhibit-modification-hooks t)
         (prop))
-    (while (setq prop (markdown-find-next-prop 'face))
-      (let ((end (next-single-property-change (car prop) 'face)))
-        (when (memq (get-text-property (car prop) 'face)
-                    '(markdown-link-face
-                      markdown-url-face
-                      markdown-plain-url-face))
+    (save-restriction
+      (goto-char (point-min))
+      (while (setq prop (markdown-find-next-prop 'face))
+        (let ((end (next-single-property-change (car prop) 'face)))
+          (when (memq (get-text-property (car prop) 'face)
+                      '(markdown-link-face
+                        markdown-url-face
+                        markdown-plain-url-face))
             (add-text-properties (car prop) end
                                  (list 'button t
                                        'category 'lsp-help-link
                                        'follow-link t
                                        'keymap lsp-help-link-keymap)))
-        (goto-char end)))))
+          (goto-char end))))))
 
 (defun lsp--buffer-string-visible ()
   "Return visible buffer string.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5229,7 +5229,8 @@ MODE is the mode used in the parent frame."
   "Keymap active on links in *lsp-help* mode.")
 
 (defun lsp--fix-markdown-links ()
-  (let (prop)
+  (let ((inhibit-read-only t)
+        (prop))
     (while (setq prop (text-property-search-forward
                        'face nil
                        (lambda (_ face)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5218,6 +5218,23 @@ MODE is the mode used in the parent frame."
         (lambda (_start _end _match) t))
   (prettify-symbols-mode 1))
 
+(defvar lsp--markdown-link-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map [mouse-2] #'lsp--help-open-link)
+    (define-key map "\r" #'lsp--help-open-link)
+    map)
+  "Keymap for following links with mouse in *lsp-help* mode.")
+
+(defun lsp--fix-markdown-links ()
+  (let (prop)
+    (while (setq prop (text-property-search-forward 'face 'markdown-link-face t))
+      (add-text-properties (prop-match-beginning prop)
+                           (prop-match-end prop)
+                           (list 'button t
+                                 'category 'markdown-link
+                                 'follow-link t
+                                 'keymap lsp--markdown-link-map)))))
+
 (defun lsp--buffer-string-visible ()
   "Return visible buffer string.
 Stolen from `org-copy-visible'."
@@ -5338,7 +5355,9 @@ In addition, each can have property:
             ;;
             ;; See #2984
             (ignore-errors (font-lock-ensure))
-            (lsp--display-inline-image mode))
+            (lsp--display-inline-image mode)
+            (when (eq mode 'lsp--render-markdown)
+              (lsp--fix-markdown-links)))
           (lsp--buffer-string-visible))
       (error str))))
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5230,19 +5230,20 @@ MODE is the mode used in the parent frame."
 
 (defun lsp--fix-markdown-links ()
   (let ((inhibit-read-only t)
+        (inhibit-modification-hooks t)
         (prop))
-    (while (setq prop (text-property-search-forward
-                       'face nil
-                       (lambda (_ face)
-                         (memq face '(markdown-link-face
-                                      markdown-url-face
-                                      markdown-plain-url-face)))))
-      (add-text-properties (prop-match-beginning prop)
-                           (prop-match-end prop)
-                           (list 'button t
-                                 'category 'lsp-help-link
-                                 'follow-link t
-                                 'keymap lsp-help-link-keymap)))))
+    (while (setq prop (markdown-find-next-prop 'face))
+      (let ((end (next-single-property-change (car prop) 'face)))
+        (when (memq (get-text-property (car prop) 'face)
+                    '(markdown-link-face
+                      markdown-url-face
+                      markdown-plain-url-face))
+            (add-text-properties (car prop) end
+                                 (list 'button t
+                                       'category 'lsp-help-link
+                                       'follow-link t
+                                       'keymap lsp-help-link-keymap)))
+        (goto-char end)))))
 
 (defun lsp--buffer-string-visible ()
   "Return visible buffer string.


### PR DESCRIPTION
Because markdown links are rendered during fontification I couldn't see where to integrate the link lookup except of the generic [lsp--fontlock-with-modelsp--fontlock-with-mode](https://github.com/emacs-lsp/lsp-mode/blob/ee6d0b030454218d9346b41696b3a9adaaef61e3/lsp-mode.el#L5346-L5363)

fixes emacs-lsp/lsp-ui#452