### PR TITLE
Delay lsp-help-mode hooks to allow users to operate on the help content

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5180,9 +5180,11 @@ If EXCLUDE-DECLARATION is non-nil, request the server to include declarations."
     (if (and contents (not (equal contents "")))
         (let ((lsp-help-buf-name "*lsp-help*"))
           (with-current-buffer (get-buffer-create lsp-help-buf-name)
-            (lsp-help-mode)
-            (with-help-window lsp-help-buf-name
-              (insert (string-trim-right (lsp--render-on-hover-content contents t))))))
+            (let ((delay-mode-hooks t))
+              (lsp-help-mode)
+              (with-help-window lsp-help-buf-name
+                (insert (string-trim-right (lsp--render-on-hover-content contents t)))))
+            (run-mode-hooks)))
       (lsp--info "No content at point."))))
 
 (defun lsp--point-in-bounds-p (bounds)


### PR DESCRIPTION
Currently help buffer content is inserted after the `lsp-help-mode-hook` has been run. This makes it hard for users to post-process   help content (e.g. reformatting, replacing unreadable characters etc). 

This PR fixes that by delaying the mode hooks after the content has been inserted. 