### PR TITLE
Add :exclusive 'no to capf backend

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -523,7 +523,8 @@ The MARKERS and PREFIX value will be attached to each candidate."
        :company-doc-buffer (-compose #'lsp-doc-buffer
                                      #'lsp-completion--get-documentation)
        :exit-function
-       (-rpartial #'lsp-completion--exit-fn candidates)))))
+       (-rpartial #'lsp-completion--exit-fn candidates)
+       :exclusive 'no))))
 
 (defun lsp-completion--find-workspace (server-id)
   (--first (eq (lsp--client-server-id (lsp--workspace-client it)) server-id)


### PR DESCRIPTION
Problem: Often lsp backend cannot find completions at point (in my case pylsp) but the good-old `python-completion-at-point` happily completes. 

This solution was also mentioned in #3550, so I would presume this also addresses that issue.