### PR TITLE
json language server: Fix the binary name

### DIFF
--- a/clients/lsp-json.el
+++ b/clients/lsp-json.el
@@ -98,7 +98,7 @@
                   (list callback))))
 
 (lsp-dependency 'vscode-json-languageserver
-                '(:system "vscode-json-language-server")
+                '(:system "vscode-json-languageserver")
                 '(:npm :package "vscode-langservers-extracted"
                        :path "vscode-json-language-server"))
 


### PR DESCRIPTION
The binary name currently isn't used correct and this patch helps to fix it. The current situation makes the JSON language server present in my $PATH unusable. 

For reference, this is the confirmed binary named in the package.json
file: https://github.com/microsoft/vscode/blob/09c0b1f799d75edf284bc89c824bdd724c5b0fa7/extensions/json-language-features/server/package.json#L11