### PR TITLE
Fix Nix documentation pages

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -499,7 +499,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "nix",
+    "name": "nix-nil",
     "full-name": "Nix",
     "server-name": "nix-nil",
     "server-url": "https://github.com/oxalica/nil",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,7 +100,7 @@ nav:
     - MSSQL: https://emacs-lsp.github.io/lsp-mssql
     - Nginx: page/lsp-nginx.md
     - Nim: page/lsp-nim.md
-    - Nix (rnix-lsp): page/lsp-nix-rnix.md
+    - Nix (rnix-lsp): page/lsp-nix.md
     - Nix (nil): page/lsp-nix-nil.md
     - OCaml (ocaml-lsp): page/lsp-ocaml-lsp-server.md
     - OpenSCAD: page/lsp-openscad.md


### PR DESCRIPTION
Currently the manual of both the nix language server docs points to 404.