### PR TITLE
Fixe makdown help rendering

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5383,21 +5383,20 @@ In addition, each can have property:
 (defun lsp--fontlock-with-mode (str mode)
   "Fontlock STR with MODE."
   (let ((lsp-buffer-major-mode major-mode))
-    (condition-case nil
-        (with-temp-buffer
-          (insert str)
-          (delay-mode-hooks (funcall mode))
-          (cl-flet ((window-body-width () lsp-window-body-width))
-            ;; This can go wrong in some cases, and the fontification would
-            ;; not work as expected.
-            ;;
-            ;; See #2984
-            (ignore-errors (font-lock-ensure))
-            (lsp--display-inline-image mode)
-            (when (eq mode 'lsp--render-markdown)
-              (lsp--fix-markdown-links)))
-          (lsp--buffer-string-visible))
-      (error str))))
+    (with-temp-buffer
+      (with-demoted-errors "Error during doc rendering: %s"
+        (insert str)
+        (delay-mode-hooks (funcall mode))
+        (cl-flet ((window-body-width () lsp-window-body-width))
+          ;; This can go wrong in some cases, and the fontification would
+          ;; not work as expected.
+          ;;
+          ;; See #2984
+          (ignore-errors (font-lock-ensure))
+          (lsp--display-inline-image mode)
+          (when (eq mode 'lsp--render-markdown)
+            (lsp--fix-markdown-links))))
+      (lsp--buffer-string-visible))))
 
 (defun lsp--render-string (str language)
   "Render STR using `major-mode' corresponding to LANGUAGE.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5260,7 +5260,8 @@ MODE is the mode used in the parent frame."
     (save-restriction
       (goto-char (point-min))
       (while (setq prop (markdown-find-next-prop 'face))
-        (let ((end (next-single-property-change (car prop) 'face)))
+        (let ((end (or (next-single-property-change (car prop) 'face)
+                       (point-max))))
           (when (memq (get-text-property (car prop) 'face)
                       '(markdown-link-face
                         markdown-url-face


### PR DESCRIPTION

 - Fixes emacs-lsp/lsp-ui#742
 - Use with-demoted-errors instead of the condition case
 - Display the processed string regardless of the errors
