### PR TITLE
Change npm package for volar manual installation

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -906,7 +906,7 @@
     "full-name": "Vue 3",
     "server-name": "volar-language-server",
     "server-url": "https://github.com/johnsoncodehk/volar",
-    "installation": "npm install -g @volar/server",
+    "installation": "npm install -g @volar/vue-language-server",
     "lsp-install-server": "volar-api",
     "debugger": "Not available"
   },


### PR DESCRIPTION
@volar/server has been deprecated in favor of @volar/vue-language-server. This should be reflected in the documentation.