### PR TITLE
Report multiline token support, ...

### DIFF
--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -72,7 +72,9 @@ associated with the requesting language server."
   :type 'boolean)
 
 (defcustom lsp-semantic-tokens-enable-multiline-token-support t
-  "When set to nil, tokens will be truncated after end-of-line.")
+  "When set to nil, tokens will be truncated after end-of-line."
+  :group 'lsp-semantic-tokens
+  :type 'boolean)
 
 (defface lsp-face-semhl-constant
   '((t :inherit font-lock-constant-face))

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -71,6 +71,9 @@ associated with the requesting language server."
   :group 'lsp-semantic-tokens
   :type 'boolean)
 
+(defcustom lsp-semantic-tokens-enable-multiline-token-support t
+  "When set to nil, tokens will be truncated after end-of-line.")
+
 (defface lsp-face-semhl-constant
   '((t :inherit font-lock-constant-face))
   "Face used for semantic highlighting scopes matching constant scopes."
@@ -279,6 +282,8 @@ Faces to use for semantic token modifiers if
         (tokenModifiers . ,(if lsp-semantic-tokens-apply-modifiers
                                (apply 'vector (mapcar #'car (lsp-semantic-tokens--modifier-faces-for (lsp--workspace-client lsp--cur-workspace))))
                              []))
+        (overlappingTokenSupport . t)
+        (multilineTokenSupport . ,(if lsp-semantic-tokens-enable-multiline-token-support t json-false))
         (tokenTypes . ,(apply 'vector (mapcar #'car (lsp-semantic-tokens--type-faces-for (lsp--workspace-client lsp--cur-workspace)))))
         (formats . ["relative"])))))
 
@@ -544,7 +549,10 @@ LOUDLY will be forwarded to OLD-FONTIFY-REGION as-is."
                (setq column (+ column (aref data (1+ i))))
                (setq face (aref faces (aref data (+ i 3))))
                (setq text-property-beg (+ line-start-pos column))
-               (setq text-property-end (+ text-property-beg (aref data (+ i 2))))
+               (setq text-property-end
+                     (min (if lsp-semantic-tokens-enable-multiline-token-support
+                              (point-max) (line-end-position))
+                      (+ text-property-beg (aref data (+ i 2)))))
                (when face
                  (put-text-property text-property-beg text-property-end 'face face))
                ;; Deal with modifiers. We cache common combinations of


### PR DESCRIPTION
... truncate tokens to current line if multiline token support is disabled, as required by the lsp spec. Also, report overlappingTokenSupport.

This should fix issue #3881, though even if we report multilineTokenSupport, lua-language-server still reports out-of-bounds token lengths which I think is an error on the server side. With `lsp-semantic-tokens-enable-multiline-token-support` set to `nil`, however, lsp-mode will now truncate token ends to the end-of-line position and should thus produce the highlighting intended by the lua language server.