### PR TITLE
Fix JSON LSP command name when installing vscode-langservers-extracted globally

### DIFF
--- a/clients/lsp-json.el
+++ b/clients/lsp-json.el
@@ -98,7 +98,7 @@
                   (list callback))))
 
 (lsp-dependency 'vscode-json-languageserver
-                '(:system "vscode-json-languageserver")
+                '(:system "vscode-json-language-server")
                 '(:npm :package "vscode-langservers-extracted"
                        :path "vscode-json-language-server"))
 


### PR DESCRIPTION
Might've been renamed at some point from `vscode-json-languageserver` to `vscode-json-language-server` (current one) to be consistent with the others.

Now it doesn't nag you to install json-ls anymore if you've manually installed the language server using `sudo npm i vscode-langservers-extracted -g`.