### PR TITLE
Allow using the project's tsserver.js

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -61,6 +61,9 @@
   * ~lsp-kotlin~ now supports ~kotlin-ts-mode~
   * ~lsp-elixir~ now supports ~elixir-ts-mode~ and ~heex-ts-mode~
   * Update Magik
+  * Add ~lsp-clients-typescript-prefer-use-project-ts-server~ custom
+    variable to try to use the project's tsserver.js instead of the
+    one installed by lsp-mode.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.


### PR DESCRIPTION
By using the project's tsserver.js, TypeScript language service plugins specified in the tsconfig.json will automatically be loaded.

VS Code has [a similar option][1], as mentioned by the typescript-plugin-css-modules plugin's [recommendation][2].

[1]: https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript
[2]: https://github.com/mrmckeb/typescript-plugin-css-modules#recommended-usage