### PR TITLE
headerline: Fix error for files with symlinks

### DIFF
--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -310,7 +310,7 @@ PATH is the current folder to be checked."
                           (setq lsp-headerline--path-up-to-project-segments
                                 (list (lsp-headerline--path-up-to-project-root
                                        root
-                                       (lsp-f-parent (buffer-file-name))))))
+                                       (file-name-directory (file-truename (buffer-file-name)))))))
                         (car lsp-headerline--path-up-to-project-segments))))
         (mapconcat (lambda (next-dir)
                      (propertize next-dir

--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -305,12 +305,13 @@ PATH is the current folder to be checked."
 (defun lsp-headerline--build-path-up-to-project-string ()
   "Build the path-up-to-project segment for the breadcrumb."
   (if-let ((root (lsp-headerline--workspace-root)))
-      (let ((segments (or
-                       lsp-headerline--path-up-to-project-segments
-                       (setq lsp-headerline--path-up-to-project-segments
-                             (lsp-headerline--path-up-to-project-root
-                              root
-                              (lsp-f-parent (buffer-file-name)))))))
+      (let ((segments (progn
+                        (unless lsp-headerline--path-up-to-project-segments
+                          (setq lsp-headerline--path-up-to-project-segments
+                                (list (lsp-headerline--path-up-to-project-root
+                                       root
+                                       (lsp-f-parent (buffer-file-name))))))
+                        (car lsp-headerline--path-up-to-project-segments))))
         (mapconcat (lambda (next-dir)
                      (propertize next-dir
                                  'font-lock-face


### PR DESCRIPTION
#### Copy of main commit msg

`lsp--workspace-root` (returned by `lsp-headerline--workspace-root`) always stores a fully resolved path with no symlinks.

When `(buffer-file-name)` includes a symlinked path to the workspace root, `root` is not a prefix of `(buffer-file-name)`.
In this case, the path parents traversing in `lsp-headerline--path-up-to-project-root` doesn't stop at root
and ultimately fails with a `(wrong-type-argument stringp nil)` error when "/" is reached.

Fix this by resolving symlinks in `(buffer-file-name)`.

Also simply use `file-name-directory` because `(buffer-file-name)` is always an absolute path to a file.

#### Discussion

The bug fixed here is a result of 16b13adf857f9cd2e7d48a1bfe3c0b1ed4107339.
Before 16b13adf857f9cd2e7d48a1bfe3c0b1ed4107339, the workspace root was never detected for buffers whose file name pointed to a symlinked root. In this case, `lsp-headerline--build-path-up-to-project-string` exited early.

You can reproduce the bug like so:
- Create a project in `/tmp/repro/myproject`
- Create a symlink `/tmp/repro/mylink` -> `/tmp/repro/myproject`
- Open a file in `/tmp/repro/mylink` with `lsp-mode`