### PR TITLE
fix rust inlay hints when label is hashtable instead of string

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1339,14 +1339,15 @@ meaning."
            (-let* (((&rust-analyzer:InlayHint :position :label :kind :padding-left :padding-right) hint)
                    (pos (lsp--position-to-point position))
                    (overlay (make-overlay pos pos nil 'front-advance 'end-advance)))
-             (when (stringp label)
-               (overlay-put overlay 'lsp-rust-analyzer-inlay-hint t)
-               (overlay-put overlay 'before-string
-                            (format "%s%s%s"
-                                    (if padding-left " " "")
-                                    (propertize (lsp-rust-analyzer-format-inlay label kind)
-                                                'font-lock-face (lsp-rust-analyzer-face-for-inlay kind))
-                                    (if padding-right " " "")))))))
+             (when (hash-table-p label)
+               (setq label (mapconcat '(lambda (h) (lsp-get h :value)) label)))
+             (overlay-put overlay 'lsp-rust-analyzer-inlay-hint t)
+             (overlay-put overlay 'before-string
+                          (format "%s%s%s"
+                                  (if padding-left " " "")
+                                  (propertize (lsp-rust-analyzer-format-inlay label kind)
+                                              'font-lock-face (lsp-rust-analyzer-face-for-inlay kind))
+                                  (if padding-right " " ""))))))
        :mode 'tick))
   nil)
 


### PR DESCRIPTION
close #3896