### PR TITLE
lsp-ph: 'format.braces'

### DIFF
--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -176,6 +176,13 @@ trigger parameter hints."
   :package-version '(lsp-mode . "6.1")
   :lsp-path "intelephense.format.enable")
 
+(defcustom-lsp lsp-intelephense-format-braces "psr12"
+  "Formatting braces style. psr12, allman or k&r"
+  :type 'string
+  :group 'lsp-intelephense
+  :package-version '(lsp-mode . "8.1")
+  :lsp-path "intelephense.format.braces")
+
 (defcustom lsp-intelephense-licence-key nil
   "Enter your intelephense licence key here to access premium
 features."


### PR DESCRIPTION
Allow to set intelephense.format.braces.
Possible values: "psr12", "allman", "k&r".

Unsure about the lsp-mode version to use (opted for 8.1)