### PR TITLE
fix: Only detect CSS when .css is final extension

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -734,7 +734,7 @@ Changes take effect only when a new session is started."
                                         ("\\(^Dockerfile\\(?:\\..*\\)?\\|\\.[Dd]ockerfile\\)\\'" . "dockerfile")
                                         ("\\.astro$" . "astro")
                                         ("\\.cs\\'" . "csharp")
-                                        ("\\.css" . "css")
+                                        ("\\.css$" . "css")
                                         ("\\.ebuild$" . "shellscript")
                                         ("\\.go\\'" . "go")
                                         ("\\.html$" . "html")


### PR DESCRIPTION
Prevents misidentifying e.g. *.css.ts, which is a convention used by for instance [vanilla-extract](https://vanilla-extract.style/).