### PR TITLE
Add a note how default `lsp-enable-indentation` settings can hit performance and editing experience.

### DIFF
--- a/docs/page/performance.md
+++ b/docs/page/performance.md
@@ -64,12 +64,20 @@ to be watched for performance reasons, you can add a regexp to that variable exc
 
 Check the [file watchers section](file-watchers.md) for details.
 
-## Check if logging is switched off.
+## Check if logging is switched off
 
 Make sure `lsp-log-io` is `nil`. You might have forgotten it after a debugging session, for example. It can cause a great performance hit.
 
 ```elisp
 (setq lsp-log-io nil) ; if set to true can cause a performance hit
+```
+
+## If your language server doesn't support formatting it is better to switch off identation
+
+`lsp-enable-indentation` is `t` by defult. This can cause performance issues caused by timeouts.
+
+```elisp
+(setq lsp-enable-indentation nil) ; causes timeouts if a server doesn't support textDocument/rangeFormatting
 ```
 
 Sometimes you might need to check logging for specific LSP server configuration as well, i.e. for `lsp-eslint` it is: `lsp-eslint-trace-server`.


### PR DESCRIPTION
My JS editing was halting during editing with this in Messages buffer:  `lsp-request: Timeout while waiting for response.  Method: textDocument/rangeFormatting`.  Disabling indentation in the config solved the problem. I think this has to be `nil` by default or correctly set based on server features. I used this gitter thread as a hint, although I couldn't find this issue mentioned anywhere in the docs