### PR TITLE
fix[headerline]: use lsp-workspace-root to avoid issues with multiple…

### DIFF
--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -423,10 +423,8 @@ PATH is the current folder to be checked."
   (lsp-headerline-breadcrumb-mode -1))
 
 (defun lsp-headerline--workspace-root ()
-  (when (null lsp-headerline--cached-workspace-root)
+(or lsp-headerline--cached-workspace-root
     (setq lsp-headerline--cached-workspace-root (lsp-workspace-root)))
-
-  lsp-headerline--cached-workspace-root)
 
 ;;;###autoload
 (define-minor-mode lsp-headerline-breadcrumb-mode

--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -144,6 +144,9 @@ is an hints in symbols range."
   "Holds the current breadcrumb path-up-to-project segments for
 caching purposes.")
 
+(defvar-local lsp-headerline--cached-workspace-root nil
+  "Holds the current value of lsp-workspace-root for caching purposes")
+
 ;; Redefine local vars of `all-the-icons' to avoid bytecode compilation errors.
 (defvar all-the-icons-default-adjust)
 (defvar all-the-icons-scale-factor)
@@ -420,8 +423,10 @@ PATH is the current folder to be checked."
   (lsp-headerline-breadcrumb-mode -1))
 
 (defun lsp-headerline--workspace-root ()
-  (--when-let (car lsp--buffer-workspaces)
-    (lsp--workspace-root it)))
+  (when (null lsp-headerline--cached-workspace-root)
+    (setq lsp-headerline--cached-workspace-root (lsp-workspace-root)))
+
+  lsp-headerline--cached-workspace-root)
 
 ;;;###autoload
 (define-minor-mode lsp-headerline-breadcrumb-mode


### PR DESCRIPTION
… active workspaces

Commit 16b13adf857f9cd2e7d48a1bfe3c0b1ed4107339 introduced a new function lsp-headerline--workspace-root aimed at speeding up the headerline update function, as lsp-workspace-root is expensive (https://github.com/emacs-lsp/lsp-mode/issues/3911)

Unfortunally, the strategy assumed that the buffer-local lsp--buffer-workspace would only contain workspaces that the current buffer belongs to. This assumption appears to be wrong.

As a result, when two buffers belonging to different workspaces (/path/to/workspace1 and /path/to/workspace2) had the headerline active, the idle function on the workspace2 buffer could actually assume its workspace root was /path/to/workspace1. 

As suggested by @yyoncho in https://github.com/emacs-lsp/lsp-mode/commit/16b13adf857f9cd2e7d48a1bfe3c0b1ed4107339#r98855365, we can cache the result of lsp-workspace-root and have the faster headerline introduced by @erikarvstedt and avoid the bug altogether.