### PR TITLE
Add ruby-ts-mode support

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 8.0.1
+  * ~lsp-ruby-syntax-tree~, ~lsp-solargraph~, ~lsp-sorbet~, ~lsp-steep~, and ~lsp-typeprof~ now support ~ruby-ts-mode~
   * Drop support for emacs 26.1 and 26.2
   * Added support for ~textDocument/linkedEditingRange~ via
     ~lsp-iedit-linked-ranges~ and ~lsp-evil-multiedit-ranges~ (see [[https://github.com/emacs-lsp/lsp-mode/pull/3166][#3166]])

--- a/clients/lsp-ruby-syntax-tree.el
+++ b/clients/lsp-ruby-syntax-tree.el
@@ -51,7 +51,7 @@
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection #'lsp-ruby-syntax-tree--build-command)
-  :major-modes '(ruby-mode enh-ruby-mode)
+  :major-modes '(ruby-mode ruby-ts-mode enh-ruby-mode)
   :priority -4
   :server-id 'ruby-syntax-tree-ls))
 

--- a/clients/lsp-ruby-syntax-tree.el
+++ b/clients/lsp-ruby-syntax-tree.el
@@ -51,7 +51,7 @@
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection #'lsp-ruby-syntax-tree--build-command)
-  :major-modes '(ruby-mode ruby-ts-mode enh-ruby-mode)
+  :activation-fn (lsp-activate-on "ruby")
   :priority -4
   :server-id 'ruby-syntax-tree-ls))
 

--- a/clients/lsp-solargraph.el
+++ b/clients/lsp-solargraph.el
@@ -155,7 +155,7 @@
  (make-lsp-client
   :new-connection (lsp-stdio-connection
                    #'lsp-solargraph--build-command)
-  :major-modes '(ruby-mode ruby-ts-mode enh-ruby-mode)
+  :activation-fn (lsp-activate-on "ruby")
   :priority -1
   :multi-root lsp-solargraph-multi-root
   :library-folders-fn (lambda (_workspace) lsp-solargraph-library-directories)

--- a/clients/lsp-solargraph.el
+++ b/clients/lsp-solargraph.el
@@ -155,7 +155,7 @@
  (make-lsp-client
   :new-connection (lsp-stdio-connection
                    #'lsp-solargraph--build-command)
-  :major-modes '(ruby-mode enh-ruby-mode)
+  :major-modes '(ruby-mode ruby-ts-mode enh-ruby-mode)
   :priority -1
   :multi-root lsp-solargraph-multi-root
   :library-folders-fn (lambda (_workspace) lsp-solargraph-library-directories)

--- a/clients/lsp-sorbet.el
+++ b/clients/lsp-sorbet.el
@@ -57,7 +57,7 @@
   :new-connection (lsp-stdio-connection
                    #'lsp-sorbet--build-command)
   :priority -2
-  :major-modes '(ruby-mode ruby-ts-mode enh-ruby-mode)
+  :activation-fn (lsp-activate-on "ruby")
   :server-id 'sorbet-ls))
 
 (lsp-consistency-check lsp-sorbet)

--- a/clients/lsp-sorbet.el
+++ b/clients/lsp-sorbet.el
@@ -57,7 +57,7 @@
   :new-connection (lsp-stdio-connection
                    #'lsp-sorbet--build-command)
   :priority -2
-  :major-modes '(ruby-mode enh-ruby-mode)
+  :major-modes '(ruby-mode ruby-ts-mode enh-ruby-mode)
   :server-id 'sorbet-ls))
 
 (lsp-consistency-check lsp-sorbet)

--- a/clients/lsp-steep.el
+++ b/clients/lsp-steep.el
@@ -63,7 +63,7 @@ If specified, `lsp-steep-use-bundler' is ignored."
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection #'lsp-steep--build-command)
-  :major-modes '(ruby-mode enh-ruby-mode)
+  :major-modes '(ruby-mode ruby-ts-mode enh-ruby-mode)
   :priority -3
   :server-id 'steep-ls))
 

--- a/clients/lsp-steep.el
+++ b/clients/lsp-steep.el
@@ -63,7 +63,7 @@ If specified, `lsp-steep-use-bundler' is ignored."
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection #'lsp-steep--build-command)
-  :major-modes '(ruby-mode ruby-ts-mode enh-ruby-mode)
+  :activation-fn (lsp-activate-on "ruby")
   :priority -3
   :server-id 'steep-ls))
 

--- a/clients/lsp-typeprof.el
+++ b/clients/lsp-typeprof.el
@@ -51,7 +51,7 @@
   :new-connection (lsp-stdio-connection
                    #'lsp-typeprof--build-command)
   :priority -4
-  :major-modes '(ruby-mode ruby-ts-mode enh-ruby-mode)
+  :activation-fn (lsp-activate-on "ruby")
   :server-id 'typeprof-ls))
 
 (lsp-consistency-check lsp-typeprof)

--- a/clients/lsp-typeprof.el
+++ b/clients/lsp-typeprof.el
@@ -51,7 +51,7 @@
   :new-connection (lsp-stdio-connection
                    #'lsp-typeprof--build-command)
   :priority -4
-  :major-modes '(ruby-mode enh-ruby-mode)
+  :major-modes '(ruby-mode ruby-ts-mode enh-ruby-mode)
   :server-id 'typeprof-ls))
 
 (lsp-consistency-check lsp-typeprof)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -836,6 +836,7 @@ Changes take effect only when a new session is started."
                                         (yaml-ts-mode . "yaml")
                                         (ruby-mode . "ruby")
                                         (enh-ruby-mode . "ruby")
+                                        (ruby-ts-mode . "ruby")
                                         (fortran-mode . "fortran")
                                         (f90-mode . "fortran")
                                         (elm-mode . "elm")


### PR DESCRIPTION
Update supported major mode for all ruby lsp clients to include `ruby-ts-mode`.

This is in response to #3918 