### PR TITLE
lsp-rust: fix inlay hints

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1339,12 +1339,18 @@ meaning."
            (-let* (((&rust-analyzer:InlayHint :position :label :kind :padding-left :padding-right) hint)
                    (pos (lsp--position-to-point position))
                    (overlay (make-overlay pos pos nil 'front-advance 'end-advance)))
-             (when (stringp label)
+             (let ((concat-label
+                    (string-join
+                     (mapcar
+                      (lambda (label)
+                        (when (lsp-structure-p label)
+                          (gethash "value" label "")))
+                      label))))
                (overlay-put overlay 'lsp-rust-analyzer-inlay-hint t)
                (overlay-put overlay 'before-string
                             (format "%s%s%s"
                                     (if padding-left " " "")
-                                    (propertize (lsp-rust-analyzer-format-inlay label kind)
+                                    (propertize (lsp-rust-analyzer-format-inlay concat-label kind)
                                                 'font-lock-face (lsp-rust-analyzer-face-for-inlay kind))
                                     (if padding-right " " "")))))))
        :mode 'tick))


### PR DESCRIPTION
rust-analyzer has changed the inlay hint label from string to array of structs where struct has the member *value* contain inlay hints.

The algorithm just iterate over label array, and concats all *value* into one string that's printed out.

"label": [
      {
        "value": ": "
      },
      {
        "value": "File",
        "location": {
          "uri": "file:///home/nikola/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/fs.rs",
          "range": {
            "start": {
              "line": 97,
              "character": 11
            },
            "end": {
              "line": 97,
              "character": 15
            }
          }
        }
      },
      {
        "value": ""
      }

Close #3896
Signed-off-by: Nikola Pajkovsky <nikola@enhance.com>