### PR TITLE
Handle string inlay hints

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1348,7 +1348,7 @@ meaning."
                         (mapcar
                          (lambda (label)
                            (when (lsp-structure-p label)
-                             (gethash "value" label "")))
+                             (lsp-get label :value)))
                          label)))
                       (string
                        label)


### PR DESCRIPTION
Also show a message if we get an inlay hint of an unexpected type.  Fixes #3945