### PR TITLE
lsp-javascript: fix inlay hints

### DIFF
--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -832,7 +832,7 @@ name (e.g. `data' variable passed as `data' parameter)."
 (defun lsp-javascript--update-inlay-hints (start end)
   (if (lsp-javascript-initialized?)
       (lsp-request-async
-       "typescript/inlayHints"
+       "textDocument/inlayHint"
        (lsp-make-javascript-inlay-hints-params
         :text-document (lsp--text-document-identifier)
         :range (lsp-make-range :start
@@ -841,24 +841,18 @@ name (e.g. `data' variable passed as `data' parameter)."
                                (lsp-point-to-position end)))
        (lambda (res)
          (lsp--remove-overlays 'lsp-javascript-inlay-hint)
-         (let ((hints (lsp-get res :inlayHints)))
-           (unless (seq-empty-p hints)
-             (overlay-recenter
-              (-let* (([hint] hints)
-                      ((&javascript:InlayHint :position) hint))
-                (lsp--position-to-point position))))
-           (-each hints
-             (lambda (hint)
-                 (-let* (((&javascript:InlayHint :text :position :kind :whitespace-before? :whitespace-after?) hint)
-                         (pos (lsp--position-to-point position))
-                         (overlay (make-overlay pos pos nil 'front-advance 'end-advance)))
-                   (overlay-put overlay 'lsp-javascript-inlay-hint t)
-                   (overlay-put overlay 'before-string
-                                (format "%s%s%s"
-                                        (if (and whitespace-before? (not (string= kind lsp/javascript-inlay-hint-kind-type-hint))) " " "")
-                                        (propertize (lsp-javascript-format-inlay text kind)
-                                                    'font-lock-face (lsp-javascript-face-for-inlay kind))
-                                        (if whitespace-after? " " ""))))))))
+         (dolist (hint res)
+           (-let* (((&javascript:InlayHint :label :position :kind :padding-left? :padding-right?) hint)
+                   (pos (lsp--position-to-point position))
+                   (overlay (make-overlay pos pos nil 'front-advance 'end-advance)))
+              (when (stringp label)
+                (overlay-put overlay 'lsp-javascript-inlay-hint t)
+                (overlay-put overlay 'before-string
+                             (format "%s%s%s"
+                                     (if padding-left? " " "")
+                                     (propertize (lsp-javascript-format-inlay label kind)
+                                                 'font-lock-face (lsp-javascript-face-for-inlay kind))
+                                     (if padding-right? " " "")))))))
        :mode 'tick)))
 
 (defun lsp-javascript-column-at-pos (pos)

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -435,7 +435,7 @@ See `-let' for a description of the destructuring mechanism."
 (defconst lsp/javascript-inlay-hint-kind-type-hint "Type")
 (defconst lsp/javascript-inlay-hint-kind-parameter-hint "Parameter")
 (defconst lsp/javascript-inlay-hint-kind-enum-hint "Enum")
-(lsp-interface (javascript:InlayHint (:text :position :kind) (:whitespaceBefore :whitespaceAfter))
+(lsp-interface (javascript:InlayHint (:label :position :kind) (:paddingLeft :paddingRight?))
                (javascript:InlayHintsParams (:textDocument) (:range)))
 
 (lsp-interface (clojure-lsp:TestTreeParams (:uri :tree) nil)


### PR DESCRIPTION
ts-ls has dropped experimental typescript/inlayHints and now uses textDocument/inlayHint.

Response structure is also different.
```
Result: [
  {
    "position": {
      "line": 24,
      "character": 37
    },
    "label": ": Promise<void>",
    "kind": 1,
    "paddingLeft": true
  },
```
Close #3934
Link: https://github.com/typescript-language-server/typescript-language-server/blob/master/CHANGELOG.md#-breaking-changes
Signed-off-by: Nikola Pajkovsky <nikola@enhance.com>