### PR TITLE
Advertise utf-32 support

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3549,7 +3549,8 @@ disappearing, unset all the variables related to it."
 (defun lsp--client-capabilities (&optional custom-capabilities)
   "Return the client capabilities appending CUSTOM-CAPABILITIES."
   (append
-   `((workspace . ((workspaceEdit . ((documentChanges . t)
+   `((general . ((positionEncodings . ["utf-32", "utf-16"])))
+     (workspace . ((workspaceEdit . ((documentChanges . t)
                                      (resourceOperations . ["create" "rename" "delete"])))
                    (applyEdit . t)
                    (symbol . ((symbolKind . ((valueSet . ,(apply 'vector (number-sequence 1 26)))))))


### PR DESCRIPTION
LSP currently uses "emacs positions" to specify offsets. I don't fully understand what exactly are positions (and I was already mistaken once thinking they are utf8), but it seems like they are Unicode codepoints basically. So let's just tell the world that we are using unicode. Together with https://github.com/rust-lang/rust-analyzer/pull/14141, this should fix the issue for rust-analyzer at least. 