### PR TITLE
Fix customization parent group of lsp-volar

### DIFF
--- a/clients/lsp-volar.el
+++ b/clients/lsp-volar.el
@@ -37,7 +37,7 @@
 
 (defgroup lsp-volar nil
   "Lsp support for vue3."
-  :group 'lsp-volar
+  :group 'lsp-mode
   :link '(url-link "https://github.com/johnsoncodehk/volar")
   :package-version '(lsp-mode . "8.0.1"))
 


### PR DESCRIPTION
`M-x customize-group RET lsp-volar` previously showed itself as parent group. It should display **Language Server (lsp-mode)** instead, as other clients do. Below shows the customize buffer after fix:

![grafik](https://user-images.githubusercontent.com/4026819/218730314-aee50205-d499-43d2-af71-17ab34f077f6.png)
