### PR TITLE
Lsp volar activate

### DIFF
--- a/clients/lsp-volar.el
+++ b/clients/lsp-volar.el
@@ -100,13 +100,13 @@ in the WORKSPACE-ROOT."
   "Check if the volar-language-server should be enabled base on FILENAME."
   (if lsp-volar-take-over-mode
       (or (or
-            (and (lsp-workspace-root) (lsp-volar--vue-project-p (lsp-workspace-root)))
-            (and (lsp-workspace-root) lsp-volar-activate-file (f-file-p (f-join (lsp-workspace-root) lsp-volar-activate-file))))
-           (or (or (string-match-p "\\.mjs\\|\\.[jt]sx?\\'" filename)
-                   (and (derived-mode-p 'js-mode 'typescript-mode 'typescript-ts-mode)
-                        (not (derived-mode-p 'json-mode))))
-               (string= (file-name-extension filename) "vue")))
-   (string= (file-name-extension filename) "vue")))
+           (and (lsp-workspace-root) (lsp-volar--vue-project-p (lsp-workspace-root)))
+           (and (lsp-workspace-root) lsp-volar-activate-file (f-file-p (f-join (lsp-workspace-root) lsp-volar-activate-file))))
+          (or (or (string-match-p "\\.mjs\\|\\.[jt]sx?\\'" filename)
+                  (and (derived-mode-p 'js-mode 'typescript-mode 'typescript-ts-mode)
+                       (not (derived-mode-p 'json-mode))))
+              (string= (file-name-extension filename) "vue")))
+    (string= (file-name-extension filename) "vue")))
 
 (lsp-register-client
  (make-lsp-client

--- a/clients/lsp-volar.el
+++ b/clients/lsp-volar.el
@@ -99,7 +99,7 @@ in the WORKSPACE-ROOT."
 (defun lsp-volar--activate-p (filename &optional _)
   "Check if the volar-language-server should be enabled base on FILENAME."
   (if lsp-volar-take-over-mode
-      (and (or
+      (or (or
             (and (lsp-workspace-root) (lsp-volar--vue-project-p (lsp-workspace-root)))
             (and (lsp-workspace-root) lsp-volar-activate-file (f-file-p (f-join (lsp-workspace-root) lsp-volar-activate-file))))
            (or (or (string-match-p "\\.mjs\\|\\.[jt]sx?\\'" filename)


### PR DESCRIPTION
### Symptom
lsp-volar will not activate on a fresh Vue project - meaning `(lsp-workspace-root)` will return nil when first opening a Vue SFC file (ending in .vue). As a consequence, the list of suggested servers to auto-install will not include lsp-volar (or `vue-semantic-server`, as it is called in lsp-mode). Only vls, graphql-lsp and eslint will be suggested.
### Background
Should the [outer boolean condition](https://github.com/emacs-lsp/lsp-mode/blob/a655f3600e040f872408da0e9c1b9fe65ca0aad9/clients/lsp-volar.el#L102) in `lsp-volar--activate-p` be **or** instead of **and**?
### Repro
Try this to install a fresh vue3 project and then run a fresh lsp-mode install on src/App.vue
Preconditions:
* emacs installed and in $PATH
* npm installed and in $PATH

```
tmpdir="$(mktemp -d)" && \
pushd "$tmpdir" && \
project="test-project" && \
npm init --yes vue@latest -- --default "$project" && \
cd "$project" && \
npm install && \
env HOME="$tmpdir" \
    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
    emacs -Q -nw --eval "$(cat<<eof
(progn (require 'package) (add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t) (package-initialize) (package-refresh-contents) (package-install 'lsp-mode) (find-file "src/App.vue") (lsp-mode 1))
eof
)" && \
popd && \
rm -rf "$tmpdir"
```
With the current master of lsp-mode, this will result in the following promt (vue-semantic-server/lsp-volar missing):
![lsp-volar-activate-1](https://user-images.githubusercontent.com/4026819/219078985-cd9b35bf-6662-40db-805c-82e57f1f80ef.png)

With this pull request, volar will be included:
![lsp-volar-activate-2](https://user-images.githubusercontent.com/4026819/219079163-8e988b64-b800-4839-b83f-aaa012abf78a.png)

