### PR TITLE
Bump magik language server to 0.7.1

### DIFF
--- a/clients/lsp-magik.el
+++ b/clients/lsp-magik.el
@@ -34,7 +34,7 @@
   :tag "Lsp Magik"
   :package-version '(lsp-mode . "8.0.1"))
 
-(defcustom lsp-magik-version "0.7.0"
+(defcustom lsp-magik-version "0.7.1"
   "Version of LSP server."
   :type `string
   :group `lsp-magik


### PR DESCRIPTION
Bump the magik language server to 0.7.1.

Release: https://github.com/StevenLooman/magik-tools/releases/tag/0.7.1
Change log: https://github.com/StevenLooman/magik-tools/blob/18282a8c580d50e3e09defb2f3cf2aa1805513db/CHANGES.md?plain=1#L7

Version 0.7.1 contains a few fixes not in 0.7.0.