### PR TITLE
Fix lsp--suggest-project-root always suggesting something

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3848,8 +3848,7 @@ If any filters, checks if it applies for PATH."
        (if (fboundp 'project-root)
            (project-root project)
          (car (with-no-warnings
-                (project-roots project))))))
-   default-directory))
+                (project-roots project))))))))
 
 (defun lsp--read-from-file (file)
   "Read FILE content."


### PR DESCRIPTION
This reverts #2112.

The intent of `lsp--suggest-project-root` is not to always return non-nil but instead return nil when no good suggestion is found and let the caller decide what to do in such case. This can be seen in 2 different ways:

1. All calls except in `lsp--calculate-root` (see 2 below) use the following form which demonstrates that the function should sometimes return nil.

    ```
    (or (lsp--suggest-project-root) default-directory)
    ```

2. We find the following snippet in `lsp--calculate-root` which demonstrates that the function should sometimes return nil (otherwise `unless lsp-auto-guess-root` could be removed since always true).

    ```
    (or
     (when lsp-auto-guess-root
       (lsp--suggest-project-root))
     (lsp-find-session-folder session file-name)
     (unless lsp-auto-guess-root
    ```