### PR TITLE
Add a language ID entry for ConTeXt

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -849,6 +849,7 @@ Changes take effect only when a new session is started."
                                         (csharp-tree-sitter-mode . "csharp")
                                         (csharp-ts-mode . "csharp")
                                         (plain-tex-mode . "plaintex")
+                                        (context-mode . "context")
                                         (latex-mode . "latex")
                                         (v-mode . "v")
                                         (vhdl-mode . "vhdl")


### PR DESCRIPTION
This is needed to lsp-mode to pick up the AUCTeX ConTeXt-mode. With this change and setting `ConTeXt-Mark-version` to `"IV"` the digestif language server can be used with ConTeXt-mode+lsp-mode.