### PR TITLE
Add renamed rust-analyzer triggerParameterHints action.

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1252,7 +1252,8 @@ tokens legend."
   :notification-handlers (ht<-alist lsp-rust-notification-handlers)
   :action-handlers (ht ("rust-analyzer.runSingle" #'lsp-rust--analyzer-run-single)
                        ("rust-analyzer.debugSingle" #'lsp-rust--analyzer-debug-lens)
-                       ("rust-analyzer.showReferences" #'lsp-rust--analyzer-show-references))
+                       ("rust-analyzer.showReferences" #'lsp-rust--analyzer-show-references)
+                       ("rust-analyzer.triggerParameterHints" #'lsp--action-trigger-parameter-hints))
   :library-folders-fn (lambda (_workspace) lsp-rust-analyzer-library-directories)
   :after-open-fn (lambda ()
                    (when lsp-rust-analyzer-server-display-inlay-hints


### PR DESCRIPTION
rust-analyzer PR #14147 removes the editor.action VSCode internal command for triggerParameterHints, so the new handler name needs to be added to lsp-rust..