### PR TITLE
ignore terraform and terragrunt cache directories

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,6 +1,7 @@
 * Changelog
 ** Unreleased 8.0.1
   * terraform-ls now supports prefill requied fields and the ability to validate on save.
+  * Ignore =.terraform= and =.terragrunt-cache= directories
   * ~lsp-bash~ now supports ~bash-ts-mode~
   * ~lsp-ruby-syntax-tree~, ~lsp-solargraph~, ~lsp-sorbet~, ~lsp-steep~, and ~lsp-typeprof~ now support ~ruby-ts-mode~
   * Drop support for emacs 26.1 and 26.2

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -380,6 +380,9 @@ the server has requested that."
     "[/\\\\]_build\\'"
     ;; Elixir
     "[/\\\\]\\.elixir_ls\\'"
+    ;; terraform and terragrunt
+    "[/\\\\]\\.terraform\\'"
+    "[/\\\\]\\.terragrunt-cache\\'"
     ;; nix-direnv
     "[/\\\\]\\.direnv\\'")
   "List of regexps matching directory paths which won't be monitored when


### PR DESCRIPTION
Hi

This PR instructs `lsp-mode` to ignore 2 directories used by Terraform and Terragrunt as cache directories.

All the best