### PR TITLE
create a new face for lsp xref items to make it customizable

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -986,6 +986,11 @@ must be used for handling a particular message.")
   "Face used for highlighting symbols being written to."
   :group 'lsp-mode)
 
+(defface lsp-face-xref-items
+  '((t :inherit highlight))
+  "Face used for highlighting xref items."
+  :group 'lsp-mode)
+
 (define-obsolete-variable-alias 'lsp-lens-auto-enable
   'lsp-lens-enable "lsp-mode 7.0.1")
 
@@ -5039,7 +5044,7 @@ identifier and the position respectively."
          (len (length line)))
     (add-face-text-property (max (min start-char len) 0)
                             (max (min end-char len) 0)
-                            'highlight t line)
+                            'lsp-face-xref-items t line)
     ;; LINE is nil when FILENAME is not being current visited by any buffer.
     (xref-make (or line filename)
                (xref-make-file-location


### PR DESCRIPTION
Hi,

In this PR, I created a new face for highlighting xref items in LSP buffer, instead of hard-coding to the `highlight` face.

This is to make it easy to customize the highlighting of xref items, without having to modify the `highlight` face: the `highlight` face is often inherited by many other faces.

Can you review and merge this PR?

Thank!