### PR TITLE
Add accessibility check for watched directories

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1879,7 +1879,7 @@ IGNORED-DIRECTORIES is a list of regexes to filter out directories we don't
 want to watch."
   (let
       ((full-path (f-join dir path)))
-    (and (f-dir-p full-path)
+    (and (file-accessible-directory-p full-path)
          (not (equal path "."))
          (not (equal path ".."))
          (not (lsp--string-match-any ignored-directories full-path)))))


### PR DESCRIPTION
Do directory accessibility check in the `lsp--path-is-watchable-directory` function. Fixes #3993.