### PR TITLE
fix lsp-javascript-rename-file

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 8.0.1
+  * Fix lsp-javascript-rename-file bug
   * Add support for clojure-ts-mode in clojure-lsp client
   * terraform-ls now supports prefill requied fields and the ability to validate on save.
   * Ignore =.terraform= and =.terragrunt-cache= directories

--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -816,7 +816,7 @@ name (e.g. `data' variable passed as `data' parameter)."
       (when (file-exists-p new)
         (error "A file named '%s' already exists." new))
       (lsp--send-execute-command
-       "_typescript.applyRenameFile"
+       "_typescript.willRenameFiles"
        (vector (list :sourceUri (lsp--buffer-uri)
                      :targetUri (lsp--path-to-uri new))))
       (mkdir (file-name-directory new) t)


### PR DESCRIPTION
resolve #4001 

_typescript.applyRenameFile is not part of the LSP spec, and is a custom function written by the people of typescript-language-server. [See this conversation about its possible deprecation](https://github.com/typescript-language-server/typescript-language-server/pull/685#pullrequestreview-1294721542)
Another problem that was the cause of the issue, is the fact that it wasn't used as it should : applyRenameFile must be called **after** the file is renamed.
Anyway, the commit uses the proper function [willRenameFile](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles) that must be called **before** the file is renamed.
