### PR TITLE
fix: Do not update the headerline of different windows

### DIFF
--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -408,7 +408,7 @@ PATH is the current folder to be checked."
 
 (defun lsp-headerline--check-breadcrumb (&rest _)
   "Request for document symbols to build the breadcrumb."
-  (set-frame-parameter (selected-frame) 'lsp-headerline--string (lsp-headerline--build-string))
+  (set-window-parameter (selected-window) 'lsp-headerline--string (lsp-headerline--build-string))
   (force-mode-line-update))
 
 (defun lsp-headerline--enable-breadcrumb ()
@@ -437,7 +437,7 @@ PATH is the current folder to be checked."
     ;; symbol or a list."
     (unless (listp header-line-format)
       (setq header-line-format (list header-line-format)))
-    (add-to-list 'header-line-format '(t (:eval (frame-parameter nil 'lsp-headerline--string) )))
+    (add-to-list 'header-line-format '(t (:eval (window-parameter nil 'lsp-headerline--string) )))
 
     (add-hook 'xref-after-jump-hook #'lsp-headerline--check-breadcrumb nil t)
 
@@ -452,7 +452,7 @@ PATH is the current folder to be checked."
     (remove-hook 'xref-after-jump-hook #'lsp-headerline--check-breadcrumb t)
 
     (setq lsp-headerline--path-up-to-project-segments nil)
-    (setq header-line-format (remove '(t (:eval (frame-parameter nil 'lsp-headerline--string) )) header-line-format)))))
+    (setq header-line-format (remove '(t (:eval (window-parameter nil 'lsp-headerline--string) )) header-line-format)))))
 
 ;;;###autoload
 (defun lsp-breadcrumb-go-to-symbol (symbol-position)


### PR DESCRIPTION
When two windows (A and B) are opened in the same frame, changing the cursor position in winthe A would update the headerline of window B.

This behavior can be visually confusing, specially if windows A and B display different buffers.

This commit updates the headerline code to use window-parameters instead of frame-parameters. This ensures that updating the headerline while navigating window A won't trigger an update in other window's headerline.