### PR TITLE
docs(json-ls): yasnippet required to receive completions

### DIFF
--- a/docs/manual-language-docs/lsp-json-ls.md
+++ b/docs/manual-language-docs/lsp-json-ls.md
@@ -3,4 +3,6 @@ root_file: docs/manual-language-docs/lsp-json-ls.md
 ---
 # Completions
 
-In order for json-ls (vscode-json-language-server) to provide completions, you'll need to enable snippet support. To do that, make sure you have installed `yasnippet` and that you have enabled the `yasnippet` minor mode.
+json-ls (vscode-json-language-server) provides completions for [well known files](https://github.com/emacs-lsp/lsp-mode/blob/master/clients/lsp-json.el#L65-L85) and files which manually specify their JSON Schema using the `$schema` property.
+
+In order for json-ls to provide completions, you need to enable snippet support. To do that, make sure you have installed `yasnippet` and that you have enabled the `yasnippet` minor mode.

--- a/docs/manual-language-docs/lsp-json-ls.md
+++ b/docs/manual-language-docs/lsp-json-ls.md
@@ -1,0 +1,6 @@
+---
+root_file: docs/manual-language-docs/lsp-json-ls.md
+---
+# Completions
+
+In order for json-ls (vscode-json-language-server) to provide completions, you'll need to enable snippet support. To do that, make sure you have installed `yasnippet` and that you have enabled the `yasnippet` minor mode.


### PR DESCRIPTION
Turns out json-ls won't advertise its completionProvider capability, unless the client supports snippets.

Please see:
1. https://github.com/emacs-lsp/lsp-mode/issues/3693#issuecomment-1524069670
2. https://github.com/emacs-lsp/lsp-mode/issues/3693#issuecomment-1525874078  
    I'm relying entirely on yyoncho's judgement here, I don't have any code snippets from the VSC repo that prove the completionProvider capability works that way

4. https://github.com/emacs-lsp/lsp-mode/discussions/4033

There are two commits in this PR, one makes the docs super short and the second one is longer and provides more context. Let me know which one works best for you, or let me know about the changes you'd like made further.

Closes #3693 (as per yyoncho comment - 2nd on numbered list at the top of the description) 