### PR TITLE
Ignore bazel-* directories outside the root directory

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -374,7 +374,7 @@ the server has requested that."
     "[/\\\\]autom4te.cache\\'"
     "[/\\\\]\\.reference\\'"
     ;; Bazel
-    "bazel-[^/\\\\]+\\'"
+    "[/\\\\]bazel-[^/\\\\]+\\'"
     ;; CSharp
     "[/\\\\]\\.meta\\'"
     ;; Unity


### PR DESCRIPTION
# Why is this change necessary?

[This previous PR](https://github.com/emacs-lsp/lsp-mode/pull/3768) added a default to ignore `bazel-*` directories that were children of the project root. However, the regex used does not ignore `bazel-*` directories elsewhere in the project repo. This can occur when a git submodule uses bazel.

# What does this change do?

Change the default value of `lsp-file-watch-ignored-directories` to ignore `bazel-*` directories wherever they are found in the repo, not just the root directory.

# How is this change tested?

I tested it locally by adding the new regex using the approach described [here](https://emacs-lsp.github.io/lsp-mode/page/file-watchers/) and I no longer see LSP warning that the number of file watches has exceeded its limit.