### PR TITLE
Introduce lsp-defcustom

### DIFF
--- a/clients/lsp-ada.el
+++ b/clients/lsp-ada.el
@@ -32,7 +32,7 @@
   :tag "Language Server"
   :package-version '(lsp-mode . "6.2"))
 
-(defcustom-lsp lsp-ada-project-file "default.gpr"
+(lsp-defcustom lsp-ada-project-file "default.gpr"
   "Set the project file full path to configure the language server with.
   The ~ prefix (for the user home directory) is supported.
   See https://github.com/AdaCore/ada_language_server for a per-project
@@ -42,14 +42,14 @@
   :package-version '(lsp-mode . "6.2")
   :lsp-path "ada.projectFile")
 
-(defcustom-lsp lsp-ada-option-charset "UTF-8"
+(lsp-defcustom lsp-ada-option-charset "UTF-8"
   "The charset to use by the Ada Language server. Defaults to 'UTF-8'."
   :type 'string
   :group 'lsp-ada
   :package-version '(lsp-mode . "6.2")
   :lsp-path "ada.defaultCharset")
 
-(defcustom-lsp lsp-ada-enable-diagnostics t
+(lsp-defcustom lsp-ada-enable-diagnostics t
   "A boolean to disable diagnostics. Defaults to true."
   :type 'boolean
   :group 'lsp-ada

--- a/clients/lsp-nim.el
+++ b/clients/lsp-nim.el
@@ -32,7 +32,7 @@
   :group 'lsp-mode
   :link '(url-link "https://github.com/PMunch/nimlsp"))
 
-(defcustom-lsp lsp-nim-project-mapping []
+(lsp-defcustom lsp-nim-project-mapping []
   "Nimsuggest project mapping. Sample value
 
 [(:projectFile \"root.nim\"
@@ -43,28 +43,28 @@
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "nim.projectMapping")
 
-(defcustom-lsp lsp-nim-timeout 120000
+(lsp-defcustom lsp-nim-timeout 120000
   "Timeout for restarting `nimsuggest'"
   :type 'number
   :group 'lsp-nim
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "nim.timeout")
 
-(defcustom-lsp lsp-nim-nimsuggest-path "nimsuggest"
+(lsp-defcustom lsp-nim-nimsuggest-path "nimsuggest"
   "Path to `nimsuggest' to use."
   :type 'number
   :group 'lsp-nim
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "nim.nimsuggestPath")
 
-(defcustom-lsp lsp-nim-auto-check-file t
+(lsp-defcustom lsp-nim-auto-check-file t
   "Check the file on the fly"
   :type 'boolean
   :group 'lsp-nim
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "nim.autoCheckFile")
 
-(defcustom-lsp lsp-nim-auto-check-project t
+(lsp-defcustom lsp-nim-auto-check-project t
   "Check the project after saving the file"
   :type 'boolean
   :group 'lsp-nim

--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -54,7 +54,7 @@
   :type 'string
   :package-version '(lsp-mode . "8.0.1"))
 
-(defcustom-lsp lsp-nix-nil-formatter nil
+(lsp-defcustom lsp-nix-nil-formatter nil
   "External formatter command with arguments.
 
   Example [nixpkgs-fmt]."
@@ -63,14 +63,14 @@
   :lsp-path "nil.formatting.command"
   :package-version '(lsp-mode . "8.0.1"))
 
-(defcustom-lsp lsp-nix-nil-ignored-diagnostics nil
+(lsp-defcustom lsp-nix-nil-ignored-diagnostics nil
   "Ignored diagnostic kinds."
   :type 'lsp-string-vector
   :group 'lsp-nix-nil
   :lsp-path "nil.diagnostics.ignored"
   :package-version '(lsp-mode . "8.0.1"))
 
-(defcustom-lsp lsp-nix-nil-exclude-files-diagnostic nil
+(lsp-defcustom lsp-nix-nil-exclude-files-diagnostic nil
   "Files to exclude from showing diagnostics."
   :type 'lsp-string-vector
   :group 'lsp-nix-nil

--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -85,7 +85,7 @@
   :link '(url-link "https://github.com/bmewburn/vscode-intelephense")
   :package-version '(lsp-mode . "6.1"))
 
-(defcustom-lsp lsp-intelephense-php-version "8.0.1"
+(lsp-defcustom lsp-intelephense-php-version "8.0.1"
   "Minimum version of PHP to refer to. Affects code actions, diagnostic &
 completions."
   :type 'string
@@ -93,14 +93,14 @@ completions."
   :package-version '(lsp-mode . "6.1")
   :lsp-path "intelephense.environment.phpVersion")
 
-(defcustom-lsp lsp-intelephense-files-max-size 1000000
+(lsp-defcustom lsp-intelephense-files-max-size 1000000
   "Maximum file size in bytes."
   :type 'number
   :group 'lsp-intelephense
   :package-version '(lsp-mode . "6.1")
   :lsp-path "intelephense-files.maxSize")
 
-(defcustom-lsp lsp-intelephense-files-associations
+(lsp-defcustom lsp-intelephense-files-associations
   ["*.php" "*.phtml"]
   "Configure glob patterns to make files available for language
 server features."
@@ -109,7 +109,7 @@ server features."
   :package-version '(lsp-mode . "6.1")
   :lsp-path "intelephense.files.associations")
 
-(defcustom-lsp lsp-intelephense-files-exclude
+(lsp-defcustom lsp-intelephense-files-exclude
   ["**/.git/**" "**/.svn/**" "**/.hg/**" "**/CVS/**" "**/.DS_Store/**"
    "**/node_modules/**" "**/bower_components/**" "**/vendor/**/{Test,test,Tests,tests}/**"]
   "Configure glob patterns to exclude certain files and folders
@@ -119,7 +119,7 @@ from all language server features."
   :package-version '(lsp-mode . "6.1")
   :lsp-path "intelephense.files.exclude")
 
-(defcustom-lsp lsp-intelephense-stubs
+(lsp-defcustom lsp-intelephense-stubs
   ["apache" "bcmath" "bz2" "calendar"
    "com_dotnet" "Core" "ctype" "curl" "date" "dba" "dom" "enchant"
    "exif" "fileinfo" "filter" "fpm" "ftp" "gd" "hash" "iconv" "imap" "interbase"
@@ -138,7 +138,7 @@ bundled extensions."
   :package-version '(lsp-mode . "6.1")
   :lsp-path "intelephense.stubs")
 
-(defcustom-lsp lsp-intelephense-completion-insert-use-declaration t
+(lsp-defcustom lsp-intelephense-completion-insert-use-declaration t
   "Use declarations will be automatically inserted for namespaced
 classes, traits, interfaces, functions, and constants."
   :type 'boolean
@@ -146,7 +146,7 @@ classes, traits, interfaces, functions, and constants."
   :package-version '(lsp-mode . "6.1")
   :lsp-path "intelephense.completion.insertUseDeclaration")
 
-(defcustom-lsp lsp-intelephense-completion-fully-qualify-global-constants-and-functions nil
+(lsp-defcustom lsp-intelephense-completion-fully-qualify-global-constants-and-functions nil
   "Global namespace constants and functions will be fully
 qualified (prefixed with a backslash)."
   :type 'boolean
@@ -154,7 +154,7 @@ qualified (prefixed with a backslash)."
   :package-version '(lsp-mode . "6.1")
   :lsp-path "intelephense.completion.fullyQualifyGlobalConstantsAndFunctions")
 
-(defcustom-lsp lsp-intelephense-completion-trigger-parameter-hints t
+(lsp-defcustom lsp-intelephense-completion-trigger-parameter-hints t
   "Method and function completions will include parentheses and
 trigger parameter hints."
   :type 'boolean
@@ -162,21 +162,21 @@ trigger parameter hints."
   :package-version '(lsp-mode . "6.2")
   :lsp-path "intelephense.completion.triggerParameterHints")
 
-(defcustom-lsp lsp-intelephense-completion-max-items 100
+(lsp-defcustom lsp-intelephense-completion-max-items 100
   "The maximum number of completion items returned per request."
   :type 'number
   :group 'lsp-intelephense
   :package-version '(lsp-mode . "6.2")
   :lsp-path "intelephense.completion.maxItems")
 
-(defcustom-lsp lsp-intelephense-format-enable t
+(lsp-defcustom lsp-intelephense-format-enable t
   "Enables formatting."
   :type 'boolean
   :group 'lsp-intelephense
   :package-version '(lsp-mode . "6.1")
   :lsp-path "intelephense.format.enable")
 
-(defcustom-lsp lsp-intelephense-format-braces "psr12"
+(lsp-defcustom lsp-intelephense-format-braces "psr12"
   "Formatting braces style. psr12, allman or k&r"
   :type 'string
   :group 'lsp-intelephense
@@ -190,7 +190,7 @@ features."
   :group 'lsp-intelephense
   :package-version '(lsp-mode . "6.2"))
 
-(defcustom-lsp lsp-intelephense-telemetry-enabled nil
+(lsp-defcustom lsp-intelephense-telemetry-enabled nil
   "Anonymous usage and crash data will be sent to Azure
 Application Insights."
   :type 'boolean
@@ -198,7 +198,7 @@ Application Insights."
   :package-version '(lsp-mode . "6.2")
   :lsp-path "intelephense.telemetry.enabled")
 
-(defcustom-lsp lsp-intelephense-rename-exclude
+(lsp-defcustom lsp-intelephense-rename-exclude
   ["**/vendor/**"]
   "Glob patterns to exclude files and folders from having symbols
 renamed. Rename operation will fail if references and/or
@@ -208,7 +208,7 @@ definitions are found in excluded files/folders."
   :package-version '(lsp-mode . "6.2")
   :lsp-path "intelephense.rename.exclude")
 
-(defcustom-lsp lsp-intelephense-trace-server "off"
+(lsp-defcustom lsp-intelephense-trace-server "off"
   "Traces the communication between VSCode and the intelephense
 language server."
   :type '(choice (:tag "off" "messages" "verbose"))

--- a/clients/lsp-purescript.el
+++ b/clients/lsp-purescript.el
@@ -50,7 +50,7 @@
             (lsp-package-path 'purescript-language-server))
         lsp-purescript-server-args))
 
-(defcustom-lsp lsp-purescript-add-spago-sources t
+(lsp-defcustom lsp-purescript-add-spago-sources t
   "Whether to add spago sources to the globs.
 Passed to the IDE server for source locations."
   :type 'boolean
@@ -58,14 +58,14 @@ Passed to the IDE server for source locations."
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "purescript.addSpagoSources")
 
-(defcustom-lsp lsp-purescript-add-npm-path nil
+(lsp-defcustom lsp-purescript-add-npm-path nil
   "Whether to add the local npm bin directory to the PATH."
   :type 'boolean
   :group 'lsp-purescript
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "purescript.addNpmPath")
 
-(defcustom-lsp lsp-purescript-formatter "purty"
+(lsp-defcustom lsp-purescript-formatter "purty"
   "Tool to use to for formatting.
 Must be installed and on PATH (or npm installed with addNpmPath set)"
   :type '(choice (:tag none purty purs-tidy pose))

--- a/clients/lsp-toml.el
+++ b/clients/lsp-toml.el
@@ -46,42 +46,42 @@
   :group 'lsp-toml
   :package-version '(lsp-mode . "8.0.1"))
 
-(defcustom-lsp lsp-toml-taplo-config-file-path nil
+(lsp-defcustom lsp-toml-taplo-config-file-path nil
   "An absolute, or workspace relative path to the Taplo configuration file."
   :type 'string
   :group 'lsp-toml
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "evenBetterToml.taplo.configFile.path")
 
-(defcustom-lsp lsp-toml-taplo-config-file-enabled t
+(lsp-defcustom lsp-toml-taplo-config-file-enabled t
   "Whether to enable the usage of a Taplo configuration file."
   :type 'boolean
   :group 'lsp-toml
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "evenBetterToml.taplo.configFile.enabled")
 
-(defcustom-lsp lsp-toml-semantic-tokens nil
+(lsp-defcustom lsp-toml-semantic-tokens nil
   "Enable semantic tokens for inline table and array keys."
   :type 'boolean
   :group 'lsp-toml
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "evenBetterToml.semanticTokens")
 
-(defcustom-lsp lsp-toml-schema-enabled t
+(lsp-defcustom lsp-toml-schema-enabled t
   "Enable completion and validation based on JSON schemas."
   :type 'boolean
   :group 'lsp-toml
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "evenBetterToml.schema.enabled")
 
-(defcustom-lsp lsp-toml-schema-links nil
+(lsp-defcustom lsp-toml-schema-links nil
   "Whether to show clickable links for keys in the editor."
   :type 'boolean
   :group 'lsp-toml
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "evenBetterToml.schema.links")
 
-(defcustom-lsp lsp-toml-schema-catalogs
+(lsp-defcustom lsp-toml-schema-catalogs
   ["https://www.schemastore.org/api/json/catalog.json"]
   "A list of URLs to schema catalogs where schemas and associations
 can be fetched from"
@@ -90,7 +90,7 @@ can be fetched from"
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "evenBetterToml.schema.catalogs")
 
-(defcustom-lsp lsp-toml-schema-associations nil
+(lsp-defcustom lsp-toml-schema-associations nil
   "Additional document and schema associations.
 
 The key must be a regular expression, this pattern is used to
@@ -102,14 +102,14 @@ The value must be an absolute URI to the JSON schema"
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "evenBetterToml.schema.associations")
 
-(defcustom-lsp lsp-toml-schema-cache-memory-expiration 60
+(lsp-defcustom lsp-toml-schema-cache-memory-expiration 60
   "The amount of seconds after which schemas will be invalidated from memory."
   :type 'number
   :group 'lsp-toml
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "evenBetterToml.schema.cache.memoryExpiration")
 
-(defcustom-lsp lsp-toml-schema-cache-disk-expiration 600
+(lsp-defcustom lsp-toml-schema-cache-disk-expiration 600
   "The amount of seconds after which cached catalogs and schemas
 expire and will be attempted to be fetched again."
   :type 'number
@@ -117,7 +117,7 @@ expire and will be attempted to be fetched again."
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "evenBetterToml.schema.cache.diskExpiration")
 
-(defcustom-lsp lsp-toml-completion-max-keys 5
+(lsp-defcustom lsp-toml-completion-max-keys 5
   "The maximum amount of keys in a dotted key to display during
 completion, 0 effectively disables key completions."
   :type 'number
@@ -125,7 +125,7 @@ completion, 0 effectively disables key completions."
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "evenBetterToml.completion.maxKeys")
 
-(defcustom-lsp lsp-toml-syntax-semantic-tokens t
+(lsp-defcustom lsp-toml-syntax-semantic-tokens t
   "Whether to enable semantic tokens for tables and arrays."
   :type 'boolean
   :group 'lsp-toml

--- a/docs/page/adding-new-language.md
+++ b/docs/page/adding-new-language.md
@@ -97,7 +97,7 @@ from [Generate Settings script](https://github.com/emacs-lsp/lsp-mode/blob/maste
 VScode plugin manifest. Example:
 
 ``` elisp
-(defcustom-lsp lsp-foo-language-server-property "bar"
+(lsp-defcustom lsp-foo-language-server-property "bar"
   "Demo property."
   :group 'foo-ls
   :lsp-path "foo.section.property")

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8422,8 +8422,12 @@ TBL - a hash table, PATHS is the path to the nested VALUE."
 
 ;; sections
 
-(defmacro defcustom-lsp (symbol standard doc &rest args)
+(defalias 'defcustom-lsp 'lsp-defcustom)
+
+(defmacro lsp-defcustom (symbol standard doc &rest args)
   "Defines `lsp-mode' server property."
+  (declare (doc-string 3) (debug (name body))
+           (indent defun))
   (let ((path (plist-get args :lsp-path)))
     (cl-remf args :lsp-path)
     `(progn

--- a/scripts/lsp-generate-settings.el
+++ b/scripts/lsp-generate-settings.el
@@ -63,7 +63,7 @@ FILE-NAME is path to package.json vscode manifest."
             (let ((type (lsp--convert-type type enum))
                   (prop-symbol (intern (format "lsp-%s" (s-dashed-words (symbol-name prop-name)))) ))
               (unless (boundp prop-symbol)
-                (format "(defcustom-lsp %s %s
+                (format "(lsp-defcustom %s %s
   \"%s\"
   :type '%s
   :group '%s


### PR DESCRIPTION
- we used `defcustom-lsp` due to formatting. Now the new version of elisp
formatter works fine