### PR TITLE
Correctly set workspace progress status

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2172,11 +2172,13 @@ PARAMS - the data sent from WORKSPACE."
                                                                 (value &as &WorkDoneProgress :kind)))
   "PARAMS contains the progress data.
 WORKSPACE is the workspace that contains the progress token."
-  (add-to-list 'global-mode-string '(t (:eval (lsp--progress-status))))
+  (lsp-workspace-status (lsp--progress-status) workspace)
   (pcase kind
     ("begin" (lsp-workspace-set-work-done-token token value workspace))
     ("report" (lsp-workspace-set-work-done-token token value workspace))
-    ("end" (lsp-workspace-rem-work-done-token token workspace)))
+    ("end"
+     (lsp-workspace-rem-work-done-token token workspace)
+     (lsp-workspace-status nil workspace)))
   (force-mode-line-update))
 
 (lsp-defun lsp-on-progress-legacy (workspace (&ProgressParams :token :value


### PR DESCRIPTION
Due to https://github.com/seagle0128/doom-modeline/issues/121, the %%
wasn't properly rendering in the modeline.

This commit updates the general progress updater to use the logic
defined in #1415

For some reason, `lsp--progress-status` doesn't properly return `nil` hence the final call when `end` is passed