### PR TITLE
Fix parsing of response of textDocument/inlayHint method

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -36,7 +36,7 @@
   * Add support for ~typescript-language-server~’s inlay hints.
   * Add support for ~workspace/willRenameFiles~ and ~workspace/didRenameFiles~.
   * Improve project root import to read specific keys instead of any events.
-  * Support ~labelDetails~ of Lsp Specification 3.17
+  * Support ~labelDetails~ of LSP Specification 3.17
   * Add Gleam support
   * Drop deprecated rust-analyzer variable lsp-rust-analyzer-import-merge-behaviour
   * Added run and debug code lenses to ~lsp-kotlin~
@@ -76,6 +76,8 @@
     ~lsp-inlay-hint-enable~ instead of ~lsp-rust-analyzer-server-display-inlay-hints~ and
     ~lsp-javascript-server-display-inlay-hints~
   * Add ShaderLab support.
+  * Remove custom variable ~lsp-inlay-hint-enum-format~ since LSP Specification 3.17 only has ~type~ and
+    ~parameter~ hint kinds.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -406,9 +406,6 @@ See `-let' for a description of the destructuring mechanism."
 
 (lsp-interface (rls:Cmd (:args :binary :env :cwd) nil))
 
-(defconst lsp/rust-analyzer-inlay-hint-kind-type-hint 1)
-(defconst lsp/rust-analyzer-inlay-hint-kind-param-hint 2)
-(defconst lsp/rust-analyzer-inlay-hint-kind-nonstandard-hint nil)
 (lsp-interface (rust-analyzer:AnalyzerStatusParams (:textDocument))
                (rust-analyzer:SyntaxTreeParams (:textDocument) (:range))
                (rust-analyzer:ViewHir (:textDocument :position))
@@ -426,8 +423,6 @@ See `-let' for a description of the destructuring mechanism."
                (rust-analyzer:RunnableArgs (:cargoArgs :executableArgs) (:workspaceRoot :expectTest))
                (rust-analyzer:RelatedTestsParams (:textDocument :position) nil)
                (rust-analyzer:RelatedTests (:runnable) nil)
-               (rust-analyzer:InlayHint (:position :label :kind :paddingLeft :paddingRight) nil)
-               (rust-analyzer:InlayHintsParams (:textDocument :range) nil)
                (rust-analyzer:SsrParams (:query :parseOnly) nil)
                (rust-analyzer:CommandLink (:title :command) (:arguments :tooltip))
                (rust-analyzer:CommandLinkGroup (:commands) (:title)))
@@ -787,13 +782,13 @@ See `-let' for a description of the destructuring mechanism."
  (WillSaveTextDocumentParams (:reason :textDocument) nil)
  (WorkspaceSymbolParams (:query) nil)
  ;; 3.17
- (InlayHint (:label :position :kind) (:paddingLeft :paddingRight))
+ (InlayHint (:label :position) (:kind :paddingLeft :paddingRight))
+ (InlayHintLabelPart (:value) (:tooltip :location :command))
  (InlayHintsParams (:textDocument) (:range)))
 
 ;; 3.17
-(defconst lsp/inlay-hint-kind-type-hint "Type")
-(defconst lsp/inlay-hint-kind-parameter-hint "Parameter")
-(defconst lsp/inlay-hint-kind-enum-hint "Enum")
+(defconst lsp/inlay-hint-kind-type-hint 1)
+(defconst lsp/inlay-hint-kind-parameter-hint 2)
 
 
 (provide 'lsp-protocol)


### PR DESCRIPTION
The ``kind`` field has been marked as optional, and the label can be built from an array of ``InlayHintLabelParts``.

The custom variable ``lsp-inlay-hint-enum-format`` has been removed since LSP Specification 3.17 only has ``type`` and ``parameter`` hint kinds.