### PR TITLE
feat: Add support for Semgrep

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -78,6 +78,7 @@
   * Add ShaderLab support.
   * Remove custom variable ~lsp-inlay-hint-enum-format~ since LSP Specification 3.17 only has ~type~ and
     ~parameter~ hint kinds.
+  * Add [[https://semgrep.dev][Semgrep]] support
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-semgrep.el
+++ b/clients/lsp-semgrep.el
@@ -45,14 +45,14 @@
 
 ;; General options
 
-(defcustom lsp-semgrep-trace-server "verbose"
+(defcustom lsp-semgrep-trace-server "off"
   "Trace Semgrep LS server"
   :group 'lsp-semgrep
   :type '(choice (const "off")
           (const "messages")
           (const "verbose")))
 
-(defcustom lsp-semgrep-server-command '("semgrep" "lsp" "--debug")
+(defcustom lsp-semgrep-server-command '("semgrep" "lsp")
   "Semgrep LS server command."
   :group 'lsp-semgrep
   :type '(repeat string))

--- a/clients/lsp-semgrep.el
+++ b/clients/lsp-semgrep.el
@@ -1,0 +1,155 @@
+;;; lsp-semgrep.el --- semgrep support -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2023 Austin Theriault
+;;
+;; Author: Austin Theriault <austin@cutedogs.org>
+;; Keywords: language tools sast
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;;  semgrep support for lsp-mode
+;;
+;;; Code:
+
+
+
+(require 'lsp-mode)
+
+(defgroup lsp-semgrep nil
+  "LSP support for Semgrep."
+  :group 'lsp-mode
+  :link `(url-link "https://github.com/returntocorp/semgrep"))
+
+(defgroup lsp-semgrep-scan nil
+  "Semgrep LS scan options."
+  :group 'lsp-semgrep
+  )
+
+(defgroup lsp-semgrep-metrics nil
+  "Semgrep LS metrics options."
+  :group 'lsp-semgrep)
+
+;; General options
+
+(defcustom lsp-semgrep-trace-server "off"
+  "Trace Semgrep LS server"
+  :group 'lsp-semgrep
+  :type '(choice (const "off")
+                 (const "messages")
+                 (const "verbose")))
+
+(defcustom lsp-semgrep-server-command-options ["lsp"]
+  "Semgrep LS server command options."
+  :group 'lsp-semgrep
+  :type '(repeat string))
+
+(defcustom lsp-semgrep-server-path "semgrep"
+  "Semgrep LS server path."
+  :group 'lsp-semgrep
+  :type 'string)
+
+;; Scan options
+
+(defcustom lsp-semgrep-scan-configuration []
+  "Semgrep rule files, or registry rules to scan with, e.g. ['r/all','rules.yaml']."
+  :group 'lsp-semgrep-scan
+  :type '(repeat string))
+
+(defcustom lsp-semgrep-scan-exclude []
+  "List of files or directories to exclude from scan."
+   :group 'lsp-semgrep-scan
+   :type '(repeat string))
+
+(defcustom lsp-semgrep-scan-include []
+        "List of files or directories to include in scan."
+        :group 'lsp-semgrep-scan
+        :type '(repeat string))
+
+(defcustom lsp-semgrep-scan-jobs 1
+  "Number of parallel jobs to run."
+  :group 'lsp-semgrep-scan
+  :type 'integer)
+
+(defcustom lsp-semgrep-scan-max-memory 0
+  "Maximum memory to use for scan, in MB."
+  :group 'lsp-semgrep-scan
+  :type 'integer)
+
+(defcustom lsp-semgrep-scan-max-target-bytes 1000000
+  "Maximum size of target file to scan, in bytes."
+  :group 'lsp-semgrep-scan
+  :type 'integer)
+
+(defcustom lsp-semgrep-scan-timeout 30
+  "Maximum time to wait for scan to complete, in seconds."
+  :group 'lsp-semgrep-scan
+  :type 'integer)
+
+(defcustom lsp-semgrep-scan-timeout-threshold 30
+  "Maximum time to wait for scan to complete, in seconds."
+  :group 'lsp-semgrep-scan
+  :type 'integer)
+
+(defcustom lsp-semgrep-scan-only-git-dirty t
+  "Only scan files that are dirty in git"
+  :group 'lsp-semgrep-scan
+  :type 'boolean)
+
+;; Metrics options
+
+(defcustom lsp-semgrep-metrics-enabled t
+  "Enable metrics collection."
+  :group 'lsp-semgrep-metrics
+  :type 'boolean)
+
+(defcustom lsp-semgrep-metrics-extension-type "emacs"
+  "Extension host type."
+  :group 'lsp-semgrep-metrics
+  :type 'string)
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection
+                   (lambda () (concat lsp-semgrep-server-path " "
+                                 (mapconcat
+                                  'identity lsp-semgrep-server-command-options " "))))
+  :activation-fn (lsp-activate-on "python" "ocaml" "elixir")
+  :server-id 'semgrep-ls
+  :priority -10
+  :initialization-options
+  (lambda ()
+    (list
+     :scan (list
+            :configuration lsp-semgrep-scan-configuration
+            :exclude lsp-semgrep-scan-exclude
+            :include lsp-semgrep-scan-include
+            :jobs lsp-semgrep-scan-jobs
+            :maxMemory lsp-semgrep-scan-max-memory
+            :maxTargetBytes lsp-semgrep-scan-max-target-bytes
+            :timeout lsp-semgrep-scan-timeout
+            :timeoutThreshold lsp-semgrep-scan-timeout-threshold
+            :onlyGitDirty lsp-semgrep-scan-only-git-dirty)
+     :metrics (list
+               :enabled lsp-semgrep-metrics-enabled
+               :extensionType lsp-semgrep-metrics-extension-type)
+     :trace (list
+             :server lsp-semgrep-trace-server)))))
+
+(lsp-consistency-check lsp-semgrep)
+
+(provide 'lsp-semgrep)
+;;; lsp-semgrep.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -754,7 +754,7 @@
     "full-name": "Semgrep",
     "server-name": "semgrep-ls",
     "server-url": "https://github.com/returntocorp/semgrep",
-    "installation": "pip install semgrep",
+    "installation": "pip install semgrep --user",
     "debugger": "Not available"
   },
   {

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -750,6 +750,14 @@
     "debugger": "Yes"
   },
   {
+    "name": "semgrep",
+    "full-name": "Semgrep",
+    "server-name": "semgrep-ls",
+    "server-url": "https://github.com/returntocorp/semgrep",
+    "installation": "pip install semgrep",
+    "debugger": "Not available"
+  },
+  {
     "name": "serenata",
     "common-group-name": "php",
     "full-name": "PHP (Serenata)",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -183,7 +183,7 @@ As defined by the Language Server Protocol 3.16."
      lsp-lua lsp-markdown lsp-marksman lsp-mint lsp-nginx lsp-nim lsp-nix lsp-magik
      lsp-metals lsp-mssql lsp-ocaml lsp-openscad lsp-pascal lsp-perl lsp-perlnavigator
      lsp-pls lsp-php lsp-pwsh lsp-pyls lsp-pylsp lsp-pyright lsp-python-ms lsp-purescript
-     lsp-r lsp-racket lsp-remark lsp-ruff-lsp lsp-rf lsp-rust lsp-shader lsp-solargraph
+     lsp-r lsp-racket lsp-remark lsp-ruff-lsp lsp-rf lsp-rust lsp-semgrep lsp-shader lsp-solargraph
      lsp-sorbet lsp-sourcekit lsp-sonarlint lsp-tailwindcss lsp-tex lsp-terraform
      lsp-toml lsp-ttcn3 lsp-typeprof lsp-v lsp-vala lsp-verilog lsp-vetur lsp-volar
      lsp-vhdl lsp-vimscript lsp-xml lsp-yaml lsp-ruby-lsp lsp-ruby-syntax-tree

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,7 @@ nav:
     - Rust (rust-analyzer): page/lsp-rust-analyzer.md
     - Rust (rls): page/lsp-rust-rls.md
     - Scala: https://emacs-lsp.github.io/lsp-metals
+    - Semgrep: page/lsp-semgrep.md
     - ShaderLab: page/lsp-shader.md
     - SQL (sqls): page/lsp-sqls.md
     - Standard ML (Millet): page/lsp-sml.md


### PR DESCRIPTION
This PR adds support for Semgrep, a SAST tool.

Checkout [Semgrep](https://github.com/returntocorp/semgrep) here.