### PR TITLE
Make lsp-ansible work on yaml-ts-mode buffers

### DIFF
--- a/clients/lsp-ansible.el
+++ b/clients/lsp-ansible.el
@@ -201,7 +201,8 @@ Python virtual environment."
 (defun lsp-ansible-check-ansible-minor-mode (&rest _)
   "Check whether ansible minor mode is active.
 This prevents the Ansible server from being turned on in all yaml files."
-  (and (derived-mode-p 'yaml-mode)
+  (and (or (derived-mode-p 'yaml-mode)
+           (derived-mode-p 'yaml-ts-mode))
        ;; emacs-ansible provides ansible, not ansible-mode
        (with-no-warnings (bound-and-true-p ansible))))
 


### PR DESCRIPTION
yaml-ts-mode derives from text-mode, so `(derived-mode-p 'yaml-mode)` returns
`nil`.

```emacs-lisp
(define-derived-mode yaml-ts-mode text-mode "YAML"
  "Major mode for editing YAML, powered by tree-sitter."
  :group 'yaml
  :syntax-table yaml-ts-mode--syntax-table
  [...])
```