### PR TITLE
 Add support for xref-auto-jump for defs and refs

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6376,7 +6376,10 @@ to check if server wants to apply any workspaceEdits after renamed."
         (funcall (if references? xref-show-xrefs-function xref-show-definitions-function)
                  (-const xrefs)
                  `((window . ,(selected-window))
-                   (display-action . ,display-action))))
+                   (display-action . ,display-action)
+                   ,(if references?
+                        `(auto-jump . ,xref-auto-jump-to-first-xref)
+                      `(auto-jump . ,xref-auto-jump-to-first-definition)))))
     (xref--show-xrefs xrefs display-action)))
 
 (cl-defmethod seq-empty-p ((ht hash-table))


### PR DESCRIPTION
Hi,

This PR adds support to jump to first definition/reference if the variables `xref-auto-jump-to-first-definition` or `xref-auto-jump-to-first-xref` are non-nil, when running `xref-find-definitions` or `xref-find-references` under `lsp-mode`.

Thanks!