### PR TITLE
Add to lsp-file-watch-ignored-directories

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -366,6 +366,8 @@ the server has requested that."
     "[/\\\\]\\.venv\\'"
     "[/\\\\]\\.mypy_cache\\'"
     "[/\\\\]\\.pytest_cache\\'"
+    ;; Swift Package Manager
+    "[/\\\\]\\.build\\'"
     ;; Python
     "[/\\\\]__pycache__\\'"
     ;; Autotools output


### PR DESCRIPTION
- default build/cache directory of Swift package manager (`.build`)