### PR TITLE
Revert "Correctly set workspace progress status"

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2179,13 +2179,11 @@ PARAMS - the data sent from WORKSPACE."
                                                                 (value &as &WorkDoneProgress :kind)))
   "PARAMS contains the progress data.
 WORKSPACE is the workspace that contains the progress token."
-  (lsp-workspace-status (lsp--progress-status) workspace)
+  (add-to-list 'global-mode-string '(t (:eval (lsp--progress-status))))
   (pcase kind
     ("begin" (lsp-workspace-set-work-done-token token value workspace))
     ("report" (lsp-workspace-set-work-done-token token value workspace))
-    ("end"
-     (lsp-workspace-rem-work-done-token token workspace)
-     (lsp-workspace-status nil workspace)))
+    ("end" (lsp-workspace-rem-work-done-token token workspace)))
   (force-mode-line-update))
 
 (lsp-defun lsp-on-progress-legacy (workspace (&ProgressParams :token :value


### PR DESCRIPTION
Reverts emacs-lsp/lsp-mode#4041

Reverting as per https://clojurians.slack.com/archives/CPABC1H61/p1685523472207629?thread_ts=1684992345.630389&cid=CPABC1H61, there is a bug where this makes progress bar not work anymore, @elken agreed in reverting until a proper fix