### PR TITLE
Add credo-language-server support

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 8.0.1
+  * Add [[https://github.com/elixir-tools/credo-language-server][credo-language-server]]
   * Add support for clojure-ts-mode in clojure-lsp client
   * terraform-ls now supports prefill requied fields and the ability to validate on save.
   * Ignore =.terraform= and =.terragrunt-cache= directories

--- a/clients/lsp-credo.el
+++ b/clients/lsp-credo.el
@@ -1,8 +1,8 @@
 ;;; lsp-credo.el --- lsp-mode Credo integration -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2022 emacs-lsp maintainers
+;; Copyright (C) 2023 Wilhelm H Kirschbaum
 
-;; Author: lsp-mode maintainers
+;; Author: Wilhelm H Kirschbaum
 ;; Keywords: lsp, elixir, credo
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/clients/lsp-credo.el
+++ b/clients/lsp-credo.el
@@ -26,33 +26,71 @@
 
 (require 'lsp-mode)
 
-(defgroup lsp-credo-ls nil
-  "Settings for credo-ls."
+(defgroup lsp-credo nil
+  "Settings for credo language server."
   :group 'lsp-mode
   :link '(url-link "https://github.com/elixir-tools/credo-language-server")
   :package-version '(lsp-mode . "8.0.1"))
 
-(defcustom lsp-credo-ls-command '("credo-language-server" "--stdio=true")
-  "The command that starts credo-ls."
+(defcustom lsp-credo-command '("credo-language-server" "--stdio=true")
+  "The command that starts credo-language-server."
   :type '(repeat :tag "List of string values" string)
-  :group 'lsp-credo-ls
+  :group 'lsp-credo
   :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-credo-version "0.1.1"
+  "Credo language server version to download.
+It has to be set before `lsp-credo.el' is loaded and it has to
+be available here: https://github.com/elixir-tools/credo-language-server/releases."
+  :type 'string
+  :group 'lsp-credo
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-credo-download-url
+  (format (concat "https://github.com/elixir-tools/credo-language-server"
+                  "/archive/refs/tags/v%s.zip")
+          lsp-credo-version)
+  "Automatic download url for credo-language-server."
+  :type 'string
+  :group 'lsp-credo
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-credo-binary-path
+  (f-join lsp-server-install-dir
+          (format "credo-language-server/credo-language-server-%s/bin"
+                  lsp-credo-version)
+          "credo-language-server")
+  "The path to `credo-language-server' binary."
+  :type 'file
+  :group 'lsp-credo
+  :package-version '(lsp-mode . "8.0.1"))
+
+(lsp-dependency
+ 'credo-language-server
+ `(:download :url lsp-credo-download-url
+             :decompress :zip
+             :store-path
+             ,(f-join lsp-server-install-dir "credo-language-server"
+                      (format "credo-language-server-%s.zip" lsp-credo-version))
+             :binary-path lsp-credo-binary-path
+             :set-executable? t))
 
 (lsp-register-client
  (make-lsp-client
   :new-connection
   (lsp-stdio-connection
    (lambda ()
-     `(,(or (executable-find (cl-first lsp-credo-ls-command))
-            (lsp-package-path 'credo-ls))
-       ,@(cl-rest lsp-credo-ls-command))))
+     `(,(or (executable-find (cl-first lsp-credo-command))
+            (lsp-package-path 'credo-language-server))
+       ,@(cl-rest lsp-credo-command))))
   :activation-fn (lsp-activate-on "elixir")
   :priority -1
   :add-on? t
   :multi-root t
-  :server-id 'credo-ls
-  :download-server-fn (lambda (_client callback error-callback _update?)
-                        (lsp-package-ensure 'credo-ls callback error-callback))))
+  :server-id 'credo-language-server
+  :download-server-fn
+  (lambda (_client callback error-callback _update?)
+    (lsp-package-ensure 'credo-language-server callback error-callback))))
 
 (lsp-consistency-check lsp-credo)
 

--- a/clients/lsp-credo.el
+++ b/clients/lsp-credo.el
@@ -38,7 +38,7 @@
   :group 'lsp-credo
   :package-version '(lsp-mode . "8.0.1"))
 
-(defcustom lsp-credo-version "0.1.1"
+(defcustom lsp-credo-version "0.1.2"
   "Credo language server version to download.
 It has to be set before `lsp-credo.el' is loaded and it has to
 be available here: https://github.com/elixir-tools/credo-language-server/releases."
@@ -48,7 +48,7 @@ be available here: https://github.com/elixir-tools/credo-language-server/release
 
 (defcustom lsp-credo-download-url
   (format (concat "https://github.com/elixir-tools/credo-language-server"
-                  "/archive/refs/tags/v%s.zip")
+                  "/releases/download/v%s/credo-language-server")
           lsp-credo-version)
   "Automatic download url for credo-language-server."
   :type 'string
@@ -57,8 +57,7 @@ be available here: https://github.com/elixir-tools/credo-language-server/release
 
 (defcustom lsp-credo-binary-path
   (f-join lsp-server-install-dir
-          (format "credo-language-server/credo-language-server-%s/bin"
-                  lsp-credo-version)
+          "credo-language-server"
           "credo-language-server")
   "The path to `credo-language-server' binary."
   :type 'file
@@ -68,10 +67,9 @@ be available here: https://github.com/elixir-tools/credo-language-server/release
 (lsp-dependency
  'credo-language-server
  `(:download :url lsp-credo-download-url
-             :decompress :zip
-             :store-path
-             ,(f-join lsp-server-install-dir "credo-language-server"
-                      (format "credo-language-server-%s.zip" lsp-credo-version))
+             :store-path ,(f-join lsp-server-install-dir
+                                  "credo-language-server"
+                                  "credo-language-server")
              :binary-path lsp-credo-binary-path
              :set-executable? t))
 

--- a/clients/lsp-credo.el
+++ b/clients/lsp-credo.el
@@ -1,0 +1,61 @@
+;;; lsp-credo.el --- lsp-mode Credo integration -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022 emacs-lsp maintainers
+
+;; Author: lsp-mode maintainers
+;; Keywords: lsp, elixir, credo
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP Client for Elixir Credo
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-credo-ls nil
+  "Settings for credo-ls."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/elixir-tools/credo-language-server")
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-credo-ls-command '("credo-language-server" "--stdio=true")
+  "The command that starts credo-ls."
+  :type '(repeat :tag "List of string values" string)
+  :group 'lsp-credo-ls
+  :package-version '(lsp-mode . "8.0.1"))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection
+  (lsp-stdio-connection
+   (lambda ()
+     `(,(or (executable-find (cl-first lsp-credo-ls-command))
+            (lsp-package-path 'credo-ls))
+       ,@(cl-rest lsp-credo-ls-command))))
+  :activation-fn (lsp-activate-on "elixir")
+  :priority -1
+  :add-on? t
+  :multi-root t
+  :server-id 'credo-ls
+  :download-server-fn (lambda (_client callback error-callback _update?)
+                        (lsp-package-ensure 'credo-ls callback error-callback))))
+
+(lsp-consistency-check lsp-credo)
+
+(provide 'lsp-credo)
+
+;;; lsp-credo.el ends here

--- a/clients/lsp-credo.el
+++ b/clients/lsp-credo.el
@@ -84,7 +84,7 @@ be available here: https://github.com/elixir-tools/credo-language-server/release
   :activation-fn (lsp-activate-on "elixir")
   :priority -1
   :add-on? t
-  :multi-root t
+  :multi-root nil
   :server-id 'credo-language-server
   :download-server-fn
   (lambda (_client callback error-callback _update?)

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -70,6 +70,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "credo",
+    "full-name": "Credo",
+    "server-name": "credo-ls",
+    "server-url": "https://github.com/elixir-tools/credo-language-server",
+    "installation-url": "https://github.com/elixir-tools/credo-language-server#installation",
+    "debugger": "Not available"
+  },
+  {
     "name": "csharp-ls",
     "common-group-name": "csharp",
     "full-name": "C# (csharp-ls)",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -400,6 +400,8 @@ the server has requested that."
     "[/\\\\]_build\\'"
     ;; Elixir
     "[/\\\\]\\.elixir_ls\\'"
+    ;; Elixir Credo
+    "[/\\\\]\\.elixir-tools\\'"
     ;; terraform and terragrunt
     "[/\\\\]\\.terraform\\'"
     "[/\\\\]\\.terragrunt-cache\\'"

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -175,7 +175,7 @@ As defined by the Language Server Protocol 3.16."
 
 (defcustom lsp-client-packages
   '( ccls lsp-actionscript lsp-ada lsp-angular lsp-ansible lsp-astro lsp-bash
-     lsp-beancount lsp-clangd lsp-clojure lsp-cmake lsp-crystal lsp-csharp lsp-css
+     lsp-beancount lsp-clangd lsp-clojure lsp-cmake lsp-credo lsp-crystal lsp-csharp lsp-css
      lsp-d lsp-dart lsp-dhall lsp-docker lsp-dockerfile lsp-elm lsp-elixir lsp-emmet
      lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript lsp-go lsp-gleam
      lsp-glsl lsp-graphql lsp-hack lsp-grammarly lsp-groovy lsp-haskell lsp-haxe


### PR DESCRIPTION
This is a linting server for the Elixir programming language.

* clients/lsp-credo.el: New file.
* docs/lsp-clients.json: Add credo-ls entry.
* lsp-mode.el: Add directory for server cache.
* CHANGELOG.org: Add entry.