### PR TITLE
Fix lsp-point-in-range? call: convert position to point

### DIFF
--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -251,7 +251,7 @@ version."
   "Return t if LENS has to be loaded."
   (and (not command?)
        (not pending)
-       (lsp-point-in-range? start range)))
+       (lsp-point-in-range? (lsp--position-to-point start) range)))
 
 (lsp-defun lsp--lens-backend-present? (range (&CodeLens :range (&Range :start) :command?))
   "Return t if LENS has to be loaded."


### PR DESCRIPTION
#4065 removes this call to `lsp--position-to-point` that was necessary. otherwise you get these errors:

```
Debugger entered--Lisp error: (wrong-type-argument hash-table-p (:line 37 :character 0))
  gethash("line" (:line 37 :character 0))
  lsp--position-compare((:line 37 :character 0) #<hash-table equal 2/2 0x15642abe71c5>)
```