### PR TITLE
Revert "Filter lenses that are not visible without converting to Posi…

### DIFF
--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -243,26 +243,21 @@ version."
       (lsp-lens--display (apply #'append (-map #'cl-rest backend-data)))))
   version)
 
-(lsp-defun lsp--lens-backend-not-loaded? (range
-                                          (&CodeLens :range
+(lsp-defun lsp--lens-backend-not-loaded? ((&CodeLens :range
                                                      (&Range :start)
                                                      :command?
                                                      :_pending pending))
   "Return t if LENS has to be loaded."
-  (and (not command?)
-       (not pending)
-       (lsp-point-in-range? start range)))
-
-(lsp-defun lsp--lens-backend-present? (range (&CodeLens :range (&Range :start) :command?))
-  "Return t if LENS has to be loaded."
-  (or command? (not (lsp-point-in-range? start range))))
-
-(defun lsp-lens--window-range ()
-  "Return the window Range"
   (let ((window (get-buffer-window (current-buffer))))
-    (lsp-make-range
-     :start (lsp--point-to-position (window-start window))
-     :end (lsp--point-to-position (window-end window)))))
+    ;; (window-start/end) does not consider current window buffer if not passed manually
+    (and (< (window-start window) (lsp--position-to-point start) (window-end window))
+         (not command?)
+         (not pending))))
+
+(lsp-defun lsp--lens-backend-present? ((&CodeLens :range (&Range :start) :command?))
+  "Return t if LENS has to be loaded."
+  (or command?
+      (not (< (window-start) (lsp--position-to-point start) (window-end)))))
 
 (defun lsp-lens--backend-fetch-missing (lenses callback file-version)
   "Fetch LENSES without command in for the current window.
@@ -281,14 +276,10 @@ FILE-VERSION - the version of the file."
                           (-lambda ((&CodeLens :command?))
                             (lsp-put it :_pending nil)
                             (lsp-put it :command command?)
-                            (when (seq-every-p (-partial #'lsp--lens-backend-present?
-                                                         (lsp-lens--window-range))
-                                               lenses)
+                            (when (seq-every-p #'lsp--lens-backend-present? lenses)
                               (funcall callback lenses file-version)))
                           :mode 'tick)))
-   (seq-filter (-partial #'lsp--lens-backend-not-loaded?
-                         (lsp-lens--window-range))
-               lenses)))
+   (seq-filter #'lsp--lens-backend-not-loaded? lenses)))
 
 (defun lsp-lens--backend (modified? callback)
   "Lenses backend using `textDocument/codeLens'.
@@ -315,9 +306,7 @@ CALLBACK - callback for the lenses."
                              :mode 'tick
                              :no-merge t
                              :cancel-token (concat (buffer-name (current-buffer)) "-lenses")))
-      (if (-all? (-partial #'lsp--lens-backend-present?
-                           (lsp-lens--window-range))
-                 lsp-lens--backend-cache)
+      (if (-all? #'lsp--lens-backend-present? lsp-lens--backend-cache)
           (funcall callback lsp-lens--backend-cache lsp--cur-version)
         (lsp-lens--backend-fetch-missing lsp-lens--backend-cache callback lsp--cur-version)))))
 


### PR DESCRIPTION
…tion"

This reverts commit 18c94fa20c7039471dbca1dee7e68d9025f0e7b2. (#4065)

The use of `lsp--point-to-position` is not correct since there appears to be a lot of unfinished work regarding the use of the `Position` structure. currently this function always returns a plist and a lot of other code depends on this fact:

- https://github.com/emacs-lsp/lsp-mode/blob/9ee4a2b38de0bb65c8e8e0f9cb2319d05ee6e316/lsp-mode.el#L6208

- https://github.com/emacs-lsp/lsp-mode/blob/9ee4a2b38de0bb65c8e8e0f9cb2319d05ee6e316/clients/lsp-csharp.el#L195

in order to write `lsp-lens--window-range` like this, further refactoring work needs to be finished