### PR TITLE
Configurable nimlsp executable

### DIFF
--- a/clients/lsp-nim.el
+++ b/clients/lsp-nim.el
@@ -81,7 +81,7 @@
  (make-lsp-client :new-connection (lsp-stdio-connection "nimlsp")
                   :activation-fn (lsp-activate-on "nim")
                   :priority -1
-                  :server-id 'nimls))
+                  :server-id 'nimlsp))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection

--- a/clients/lsp-nim.el
+++ b/clients/lsp-nim.el
@@ -77,8 +77,15 @@
   :group 'lsp-nim
   :package-version '(lsp-mode . "8.0.1"))
 
+(defcustom lsp-nim-lsp "nimlsp"
+  "Path to `nimlsp'"
+  :type 'number
+  :group 'lsp-nim
+  :package-version '(lsp-mode . "8.0.1"))
+
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection "nimlsp")
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   (lambda () lsp-nim-lsp))
                   :activation-fn (lsp-activate-on "nim")
                   :priority -1
                   :server-id 'nimlsp))


### PR DESCRIPTION
nim has 2 lsp implementations, `nimlangserver` and `nimlsp`, however only the first was configurable for its executable path. Also, the server id is renamed from `nimls` to `nimlsp`