### PR TITLE
Add ebuild-mode support to lsp-bash

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -4,7 +4,7 @@
   * Add support for clojure-ts-mode in clojure-lsp client
   * terraform-ls now supports prefill requied fields and the ability to validate on save.
   * Ignore =.terraform= and =.terragrunt-cache= directories
-  * ~lsp-bash~ now supports ~bash-ts-mode~
+  * ~lsp-bash~ now supports ~bash-ts-mode~ and ~ebuild-mode~
   * ~lsp-ruby-syntax-tree~, ~lsp-solargraph~, ~lsp-sorbet~, ~lsp-steep~, and ~lsp-typeprof~ now support ~ruby-ts-mode~
   * Drop support for emacs 26.1 and 26.2
   * Added support for ~textDocument/linkedEditingRange~ via

--- a/clients/lsp-bash.el
+++ b/clients/lsp-bash.el
@@ -68,13 +68,13 @@ See instructions at https://marketplace.visualstudio.com/items?itemName=mads-har
   "Check whether `sh-shell' is sh or bash.
 
 This prevents the Bash server from being turned on in zsh files."
-  (and (memq major-mode '(sh-mode bash-ts-mode))
+  (and (memq major-mode '(sh-mode bash-ts-mode ebuild-mode))
        (memq sh-shell '(sh bash))))
 
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection #'lsp-bash--bash-ls-server-command)
-  :major-modes '(sh-mode bash-ts-mode)
+  :major-modes '(sh-mode bash-ts-mode ebuild-mode)
   :priority -1
   :activation-fn #'lsp-bash-check-sh-shell
   :environment-fn (lambda ()


### PR DESCRIPTION
PR #3281 initially added the ebuild-mode language id configuration. However, commit b77aecf added a major mode check that prevents bash-ls from loading up for ebuild-mode.

Ebuilds (Gentoo's package file "format") are explicitly executed within a Bash environment regardless of the user's or dev's preference.