### PR TITLE
Fix a typo in lsp-steep

### DIFF
--- a/clients/lsp-steep.el
+++ b/clients/lsp-steep.el
@@ -42,7 +42,7 @@
   :group 'lsp-steep)
 
 (defcustom lsp-steep-use-bundler nil
-  "Run Steep using Bunder."
+  "Run Steep using Bundler."
   :type 'boolean
   :safe #'booleanp
   :group 'lsp-steep)


### PR DESCRIPTION
This PR fixes a typo in the following doc:
https://emacs-lsp.github.io/lsp-mode/page/lsp-steep/#lsp-steep-use-bundler