### PR TITLE
Improve documentation for `lsp-execute-code-action`

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5873,7 +5873,9 @@ It will filter by KIND if non nil."
          (lsp-send-execute-command command arguments?))))))
 
 (lsp-defun lsp-execute-code-action ((action &as &CodeAction :command? :edit?))
-  "Execute code action ACTION.
+  "Execute code action ACTION. For example, when text under the
+caret has a suggestion to apply a fix from an lsp-server, calling
+this function will do so.
 If ACTION is not set it will be selected from `lsp-code-actions-at-point'.
 Request codeAction/resolve for more info if server supports."
   (interactive (list (lsp--select-action (lsp-code-actions-at-point))))


### PR DESCRIPTION
`lsp-execute-code-action` is a user-facing function that can be executed e.g. when clangd says "fix available". But as it stands, the function description is too abstract, so unless you know details around lsp-protocol `codeAction`, you won't figure out what it's for. Fix that by clarifying what a user can use it for.

This came up after me trying to find some way to "apply the clangd fix" and not finding anything useful offhand, and then going to gitter and asking a question there.