### PR TITLE
fix(marksman): Update Download URL for Marksman Linux Binaries

### DIFF
--- a/clients/lsp-marksman.el
+++ b/clients/lsp-marksman.el
@@ -48,10 +48,11 @@
 (defcustom lsp-marksman-download-url
   (format "https://github.com/artempyanykh/marksman/releases/latest/download/%s"
           (pcase system-type
-            ('gnu/linux "marksman-linux")
-            ('darwin (if (string-match "^aarch64-.*" system-configuration)
-                         "marksman-macos" ;; Note: probably wrong/will not work
-                       "marksman-macos"))
+            ('gnu/linux
+             (if (string-match "^aarch64-.*" system-configuration)
+                 "marksman-linux-arm64"
+               "marksman-linux-x64"))
+            ('darwin "marksman-macos")
             ('windows-nt "marksman.exe")))
   "Automatic download url for Marksman."
   :type 'string


### PR DESCRIPTION
The download URL for Marksman Linux binaries has been split by architecture, causing the previous URL to return a 404 error.
To resolve this issue,
the download URL has been updated to the new format. This ensures the correct architecture binary is downloaded properly.