### PR TITLE
lsp-openscad: fix completion when using plists

### DIFF
--- a/clients/lsp-openscad.el
+++ b/clients/lsp-openscad.el
@@ -84,6 +84,15 @@
                   :major-modes '(scad-mode)
                   :priority -1
                   :initialized-fn (lambda (workspace)
+                                    ;; OpenSCAD-LSP returns an empty list of
+                                    ;; completion options at initialization
+                                    ;; so completionProvider capability is {}
+                                    ;; When using plists, this value is parsed as
+                                    ;; null/nil so we need to force it to "t"
+                                    ;; to enable completion
+                                    (let ((caps (lsp--workspace-server-capabilities workspace)))
+                                      (unless (lsp-get caps :completionProvider)
+                                        (lsp:set-server-capabilities-completion-provider? caps t)))
                                     (with-lsp-workspace workspace
                                       (lsp--set-configuration
                                        (lsp-configuration-section "openscad"))))


### PR DESCRIPTION
When using plists, completion from `lsp-openscad` is disabled because the server returns an empty list of completion options.

This empty list is parsed as null/nil when using plists. It seems to be a common problem with plists but I didn't find a generic solution in the current `lsp-mode` code (tell me if I'm wrong). So I wrote a little fix specific to `lsp-openscad`.