### PR TITLE
lsp-erlang: Add initial support for erlang-language-platform

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 8.0.1
+  * Add [[https://github.com/WhatsApp/erlang-language-platform][erlang-language-platform]] support in lsp-erlang client.
   * Add [[https://github.com/elixir-tools/credo-language-server][credo-language-server]]
   * Add support for clojure-ts-mode in clojure-lsp client
   * terraform-ls now supports prefill required fields and the ability to validate on save.

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -220,11 +220,19 @@
     "debugger": "Not available"
   },
   {
-    "name": "erlang",
+    "name": "erlang-ls",
     "full-name": "Erlang",
     "server-name": "erlang_ls",
     "server-url": "https://github.com/erlang-ls/erlang_ls",
     "installation-url": "https://github.com/erlang-ls/erlang_ls",
+    "debugger": "Not available"
+  },
+  {
+    "name": "erlang-elp",
+    "full-name": "Erlang",
+    "server-name": "elp",
+    "server-url": "https://github.com/WhatsApp/erlang-language-platform",
+    "installation-url": "https://github.com/WhatsApp/erlang-language-platform",
     "debugger": "Not available"
   },
   {


### PR DESCRIPTION
So it now still supports  [erlang-ls](https://github.com/erlang-ls/erlang_ls), but also [erlang-language-platform](https://github.com/WhatsApp/erlang-language-platform).