### PR TITLE
fix(lsp-mode.el): Drop support for 26.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
-          - 26.3
           - 27.2
           - 28.2
           - 29.1

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -83,6 +83,7 @@
   * Add [[https://semgrep.dev][Semgrep]] support
   * Add AWK language server support.
   * Add support for ~scala-ts-mode~.
+  * Drop support for emacs 26.3
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/Eask
+++ b/Eask
@@ -29,7 +29,7 @@
  "lsp-semantic-tokens.el"
  "clients/*.el")
 
-(depends-on "emacs" "26.3")
+(depends-on "emacs" "27.1")
 (depends-on "dash")
 (depends-on "f")
 (depends-on "ht")

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: Vibhav Pant, Fangrui Song, Ivan Yonchovski
 ;; Keywords: languages
-;; Package-Requires: ((emacs "26.3") (dash "2.18.0") (f "0.20.0") (ht "2.3") (spinner "1.7.3") (markdown-mode "2.3") (lv "0") (eldoc "1.11"))
+;; Package-Requires: ((emacs "27.1") (dash "2.18.0") (f "0.20.0") (ht "2.3") (spinner "1.7.3") (markdown-mode "2.3") (lv "0") (eldoc "1.11"))
 ;; Version: 8.0.1
 
 ;; URL: https://github.com/emacs-lsp/lsp-mode


### PR DESCRIPTION
The CI is reporting errors due to one of our dependency `markdown-mode` has recently dropped support for 26.x. Another solution is to set `markdown-mode` as an optional dependency instead of the required one. 🤔 

cc @yyoncho @ericdallo 