### PR TITLE
[beancount] Use the Rust version of language server

### DIFF
--- a/clients/lsp-beancount.el
+++ b/clients/lsp-beancount.el
@@ -32,20 +32,17 @@
   :link '(url-link "https://github.com/polarmutex/beancount-language-server")
   :package-version '(lsp-mode . "8.0.0"))
 
-(defcustom lsp-beancount-langserver-executable "beancount-langserver"
+(defcustom lsp-beancount-langserver-executable "beancount-language-server"
   "Command to start Beancount language server."
   :type 'string
   :group 'lsp-beancount
   :package-version '(lsp-mode . "8.0.0"))
 
-(defcustom lsp-beancount-python-interpreter nil
-  "Path to Python executable."
-  :type 'string
-  :group 'lsp-beancount
-  :package-version '(lsp-mode . "8.0.0"))
-
 (defcustom lsp-beancount-journal-file nil
-  "Pathg to Beancount journal file."
+  "Path to Beancount journal file.
+
+The path can be absolute, or relative to the currently opened file.
+Use nil (the default) to use the current beancount buffer as the journal file."
   :type 'string
   :group 'lsp-beancount
   :package-version '(lsp-mode . "8.0.0"))
@@ -55,14 +52,10 @@
   :new-connection
   (lsp-stdio-connection
    (lambda ()
-     (when (null lsp-beancount-python-interpreter)
-       (setq lsp-beancount-python-interpreter (or (executable-find "python3")
-                                                  (executable-find "python"))))
-     `(,lsp-beancount-langserver-executable "--stdio")))
+      `(,lsp-beancount-langserver-executable "--stdio")))
   :major-modes '(beancount-mode)
   :initialization-options
-  `((journalFile . ,lsp-beancount-journal-file)
-    (pythonPath . ,lsp-beancount-python-interpreter))
+  `((journalFile . ,lsp-beancount-journal-file))
   :server-id 'beancount-ls))
 
 (lsp-consistency-check lsp-beancount)

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -63,9 +63,10 @@
   {
     "name": "beancount",
     "full-name": "Beancount",
-    "server-name": "beancount-langserver",
+    "server-name": "beancount-language-server",
     "server-url": "https://github.com/polarmutex/beancount-language-server",
-    "installation": "npm install -g beancount-langserver",
+    "installation": "cargo install beancount-language-server",
+    "installation-url": "https://github.com/polarmutex/beancount-language-server#installation",
     "lsp-install-server": "beancount-ls",
     "debugger": "Not available"
   },


### PR DESCRIPTION
The Python and Typescript versions of beancount-language-server are deprecated, the maintained version now is the Rust one.

TODO:

- [x] ~~Create a tutorial to help people set the path to journal file using a modeline (maybe with `eval` so that the absolute path to journal file is dynamically computed ??)~~ No need for tutorial, the journal file option will default to "current buffer", so it should cover most use cases.
- [ ] Do we want to maintain legacy arguments for the older versions?