### PR TITLE
Add configuration to use new experimental ondisk cache for lsp-kotlin

### DIFF
--- a/clients/lsp-kotlin.el
+++ b/clients/lsp-kotlin.el
@@ -107,8 +107,8 @@ to Kotlin."
   :package-version '(lsp-mode . "8.0.1"))
 
 ;; cache in this case is the dependency cache. Given as an initialization option.
-(defcustom lsp-kotlin-ondisk-cache-path ""
-  "Path to the ondisk cache if used."
+(defcustom lsp-kotlin-ondisk-cache-path nil
+  "Path to the ondisk cache if used. If lsp-kotlin-ondisk-cache-enabled is t, but path is nil, then the project root is used as a default."
   :type 'string
   :group 'lsp-kotlin)
 
@@ -273,7 +273,8 @@ to Kotlin."
                       (lsp--set-configuration (lsp-configuration-section "kotlin"))))
   :initialization-options (lambda ()
                             (when lsp-kotlin-ondisk-cache-enabled
-                              (list :storagePath lsp-kotlin-ondisk-cache-path)))
+                              (list :storagePath (or lsp-kotlin-ondisk-cache-path
+                                                     (lsp-workspace-root)))))
   :download-server-fn (lambda (_client callback error-callback _update?)
                         (lsp-package-ensure 'kotlin-language-server callback error-callback))))
 

--- a/clients/lsp-kotlin.el
+++ b/clients/lsp-kotlin.el
@@ -272,9 +272,8 @@ to Kotlin."
                     (with-lsp-workspace workspace
                       (lsp--set-configuration (lsp-configuration-section "kotlin"))))
   :initialization-options (lambda ()
-                            (if lsp-kotlin-ondisk-cache-enabled
-                                (list :storagePath lsp-kotlin-ondisk-cache-path)
-                              (list)))
+                            (when lsp-kotlin-ondisk-cache-enabled
+                              (list :storagePath lsp-kotlin-ondisk-cache-path)))
   :download-server-fn (lambda (_client callback error-callback _update?)
                         (lsp-package-ensure 'kotlin-language-server callback error-callback))))
 

--- a/clients/lsp-kotlin.el
+++ b/clients/lsp-kotlin.el
@@ -106,6 +106,17 @@ to Kotlin."
   :group 'lsp-kotlin
   :package-version '(lsp-mode . "8.0.1"))
 
+;; cache in this case is the dependency cache. Given as an initialization option.
+(defcustom lsp-kotlin-ondisk-cache-path ""
+  "Path to the ondisk cache if used."
+  :type 'string
+  :group 'lsp-kotlin)
+
+(defcustom lsp-kotlin-ondisk-cache-enabled nil
+  "Specifies whether to enable ondisk cache or not. If nil, in-memory cache will be used."
+  :type 'boolean
+  :group 'lsp-kotlin)
+
 (lsp-register-custom-settings
  '(("kotlin.externalSources.autoConvertToKotlin" lsp-kotlin-external-sources-auto-convert-to-kotlin t)
    ("kotlin.externalSources.useKlsScheme" lsp-kotlin-external-sources-use-kls-scheme t)
@@ -260,6 +271,10 @@ to Kotlin."
   :initialized-fn (lambda (workspace)
                     (with-lsp-workspace workspace
                       (lsp--set-configuration (lsp-configuration-section "kotlin"))))
+  :initialization-options (lambda ()
+                            (if lsp-kotlin-ondisk-cache-enabled
+                                (list :storagePath lsp-kotlin-ondisk-cache-path)
+                              (list)))
   :download-server-fn (lambda (_client callback error-callback _update?)
                         (lsp-package-ensure 'kotlin-language-server callback error-callback))))
 


### PR DESCRIPTION
Recently a PR in kotlin-language-server for using an on-disk cache was merged: https://github.com/fwcd/kotlin-language-server/pull/337


While it is merged, it is still considered experimental. The PR I have created here adds configuration to lsp-kotlin to be able to use this new on-disk cache. If no configuration is done, it will just use the old in-memory approach to caching. If one uses the on-disk cache, it is probably wise to configure it for each of your projects (maybe using dir-locals, setq-local in hooks, or something else).