### PR TITLE
MDX support

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -88,6 +88,7 @@
   * Drop support for emacs 26.3
   * Add [https://github.com/rubocop/rubocop][RuboCop built-in language server]] for linting and formatting Ruby code.
   * Add Move language server support.
+  * Add mdx support using [[https://github.com/mdx-js/mdx-analyzer/tree/main/packages/language-server][mdx-language-server]]
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-mdx.el
+++ b/clients/lsp-mdx.el
@@ -1,0 +1,66 @@
+;;; lsp-mdx.el --- lsp-mode mdx integration -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2023 lsp-mode maintainers
+
+;; Author: lsp-mode maintainers
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;  LSP client for mdx-analyzer language-server
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-mdx nil
+  "Settings for the mdx language server client."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/mdx-js/mdx-analyzer/tree/main/packages/language-server")
+  :package-version '(lsp-mode . "8.0.0"))
+
+(defcustom lsp-mdx-server-command "mdx-language-server"
+  "The binary (or full path to binary) which executes the server."
+  :type 'string
+  :group 'lsp-mdx
+  :package-version '(lsp-mode . "8.0.0"))
+
+(defcustom lsp-mdx-server-command-args '("--stdio")
+  "Command-line arguments for the mdx lsp server."
+  :type '(repeat 'string)
+  :group 'lsp-mdx
+  :package-version '(lsp-mode . "8.0.0"))
+
+(lsp-dependency 'mdx-language-server
+                '(:system "mdx-language-server")
+                '(:npm :package "@mdx-js/language-server"
+                       :path "mdx-language-server"))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   (lambda ()
+                                     (cons (or (executable-find lsp-mdx-server-command)
+                                               (lsp-package-path 'mdx-language-server))
+                                           lsp-mdx-server-command-args)))
+                  :activation-fn (lambda (&rest _args)
+                                   (string-match-p "\\.mdx\\'" (buffer-file-name)))
+                  :priority -2
+                  :server-id 'mdx-analyzer
+                  :download-server-fn (lambda (_client callback error-callback _update?)
+                                        (lsp-package-ensure 'mdx-language-server callback error-callback))))
+
+(provide 'lsp-mdx)
+;;; lsp-mdx.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -510,6 +510,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "mdx",
+    "full-name": "mdx",
+    "server-name": "mdx-analyzer",
+    "server-url": "https://github.com/mdx-js/mdx-analyzer/tree/main/packages/language-server",
+    "installation": "npm install -g @mdx-js/language-server",
+    "debugger": "Not available"
+  },
+  {
     "name": "nginx",
     "full-name": "Nginx",
     "server-name": "nginx-lsp",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -180,7 +180,7 @@ As defined by the Language Server Protocol 3.16."
      lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript lsp-go lsp-gleam
      lsp-glsl lsp-graphql lsp-hack lsp-grammarly lsp-groovy lsp-haskell lsp-haxe
      lsp-idris lsp-java lsp-javascript lsp-json lsp-kotlin lsp-latex lsp-ltex
-     lsp-lua lsp-markdown lsp-marksman lsp-mint lsp-move lsp-nginx lsp-nim lsp-nix lsp-magik
+     lsp-lua lsp-markdown lsp-marksman lsp-mdx lsp-mint lsp-move lsp-nginx lsp-nim lsp-nix lsp-magik
      lsp-metals lsp-mssql lsp-ocaml lsp-openscad lsp-pascal lsp-perl lsp-perlnavigator
      lsp-pls lsp-php lsp-pwsh lsp-pyls lsp-pylsp lsp-pyright lsp-python-ms lsp-purescript
      lsp-r lsp-racket lsp-remark lsp-ruff-lsp lsp-rf lsp-rubocop lsp-rust lsp-semgrep lsp-shader
@@ -771,6 +771,7 @@ Changes take effect only when a new session is started."
     ("\\.jsonc$" . "jsonc")
     ("\\.jsx$" . "javascriptreact")
     ("\\.lua$" . "lua")
+    ("\\.mdx\\'" . "mdx")
     ("\\.php$" . "php")
     ("\\.rs\\'" . "rust")
     ("\\.sql$" . "sql")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
     - Markdown: page/lsp-markdown.md
     - Marksman: page/lsp-marksman.md
     - Move: page/lsp-move.md
+    - MDX: page/lsp-mdx.md
     - MSSQL: https://emacs-lsp.github.io/lsp-mssql
     - Nginx: page/lsp-nginx.md
     - Nim: page/lsp-nim.md


### PR DESCRIPTION
Fixes #4129 

Uses:
https://github.com/mdx-js/mdx-analyzer/tree/main/packages/language-server


Adds basic MDX support. MDX has no editing mode in Emacs, so I usually just use Markdown mode. That is the main reason for the priority and activation settings here. Found no configuration options, but they might come later.