### PR TITLE
fix clang-tidy error explainer url

### DIFF
--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -162,6 +162,9 @@ number of newlines."
   "Show clang-tidy documentation about ERROR-ID.
 
 Information comes from the clang.llvm.org website."
+  ;; Example error-id: modernize-loop-convert
+  ;; Example url: https://clang.llvm.org/extra/clang-tidy/checks/modernize/loop-convert.html
+  (setq error-id (s-join "/" (s-split-up-to "-" error-id 1 t)))
   (url-retrieve (format
                  "https://clang.llvm.org/extra/clang-tidy/checks/%s.html" error-id)
                 (lambda (status)


### PR DESCRIPTION
When you click on an error message in `*Flycheck errors*` it used to error out with 404 for me because clang-tidy seems to have changed their url style.

To check: open a C++ file with a warning from clang-tidy (e.g., `readability-braces-around-statements`), open flycheck errors `C-c ! l`, click on any button in the `ID` column, it should now pretty-print the explanation of a clang-tidy check.