### PR TITLE
Fix a typo for lsp-rubocop

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -733,7 +733,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "robocop",
+    "name": "rubocop",
     "full-name": "Ruby (RuboCop)",
     "server-name": "rubocop",
     "server-url": "https://github.com/rubocop/rubocop",


### PR DESCRIPTION
`robocop` is a misspelling of `rubocop`:
https://github.com/rubocop/rubocop