### PR TITLE
lsp-erlang: set priority lower than erlang_ls if elp not selected

### DIFF
--- a/clients/lsp-erlang.el
+++ b/clients/lsp-erlang.el
@@ -131,7 +131,7 @@ It can use erlang-ls or erlang-language-platform (ELP)."
                             "elp")
                        ,@(cl-rest lsp-erlang-elp-server-command))))
   :activation-fn (lsp-activate-on "erlang")
-  :priority (if (eq lsp-erlang-server 'erlang-language-platform) 1 -1)
+  :priority (if (eq lsp-erlang-server 'erlang-language-platform) 1 -2)
   :server-id 'elp
   :custom-capabilities `((experimental . ((snippetTextEdit . ,(and lsp-enable-snippet (featurep 'yasnippet))))))
   :download-server-fn (lambda (_client callback error-callback _update?)


### PR DESCRIPTION
Previously if `elp` was not selected, its priority was set to the same as `erlang_ls`, so it both were on the path it chose `elp`.

Rather set is priority to -2, vs erlang_ls  -1, so the default remains `erlang_ls`, as intended.