### PR TITLE
Add Move language client

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -85,6 +85,7 @@
   * Add support for ~scala-ts-mode~.
   * Drop support for emacs 26.3
   * Add [https://github.com/rubocop/rubocop][RuboCop built-in language server]] for linting and formatting Ruby code.
+  * Add Move language server support.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-move.el
+++ b/clients/lsp-move.el
@@ -1,0 +1,71 @@
+;;; lsp-move.el --- MOVE client settings -*- lexical-binding: t -*-
+
+;; Copyright (C) 2023 Dmitri Makarov
+
+;; Author: Dmitri Makarov
+;; Keywords: lsp, move
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; To enable lsp-move include the following lisp code in init.el after
+;;; loading lsp-mode
+;;;
+;;;    (with-eval-after-load 'lsp-mode
+;;;      (require 'move-mode)
+;;;      (require 'lsp-move)
+;;;      (add-hook 'move-mode-hook #'lsp)
+;;;
+;;; See `lsp-clients-move-analyzer-executable' to customize the path to move-analyzer.
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-move nil
+  "LSP support for Move."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/move-language/move"))
+
+(defcustom lsp-clients-move-analyzer-executable "move-analyzer"
+  "The move-analyzer executable to use.
+Leave as just the executable name to use the default behavior of
+finding the executable with `exec-path'."
+  :group 'lsp-move
+  :risky t
+  :type 'file)
+
+(defcustom lsp-clients-move-analyzer-args '()
+  "Extra arguments for the move-analyzer executable."
+  :group 'lsp-move
+  :risky t
+  :type '(repeat string))
+
+(defun lsp-clients--move-analyzer-command ()
+  "Generate the language server startup command."
+  `(,lsp-clients-move-analyzer-executable ,@lsp-clients-move-analyzer-args))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection
+                   'lsp-clients--move-analyzer-command)
+  :activation-fn (lsp-activate-on "move")
+  :major-modes '(move-mode)
+  :priority -1
+  :server-id 'move-analyzer))
+
+(provide 'lsp-move)
+
+;;; lsp-move.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -502,6 +502,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "move",
+    "full-name": "Move Language",
+    "server-name": "move-analyzer",
+    "server-url": "https://github.com/move-language/move",
+    "installation-url": "https://github.com/move-language/move/tree/main/language/move-analyzer",
+    "debugger": "Not available"
+  },
+  {
     "name": "nginx",
     "full-name": "Nginx",
     "server-name": "nginx-lsp",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -180,7 +180,7 @@ As defined by the Language Server Protocol 3.16."
      lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript lsp-go lsp-gleam
      lsp-glsl lsp-graphql lsp-hack lsp-grammarly lsp-groovy lsp-haskell lsp-haxe
      lsp-idris lsp-java lsp-javascript lsp-json lsp-kotlin lsp-latex lsp-ltex
-     lsp-lua lsp-markdown lsp-marksman lsp-mint lsp-nginx lsp-nim lsp-nix lsp-magik
+     lsp-lua lsp-markdown lsp-marksman lsp-mint lsp-move lsp-nginx lsp-nim lsp-nix lsp-magik
      lsp-metals lsp-mssql lsp-ocaml lsp-openscad lsp-pascal lsp-perl lsp-perlnavigator
      lsp-pls lsp-php lsp-pwsh lsp-pyls lsp-pylsp lsp-pyright lsp-python-ms lsp-purescript
      lsp-r lsp-racket lsp-remark lsp-ruff-lsp lsp-rf lsp-rubocop lsp-rust lsp-semgrep lsp-shader
@@ -809,6 +809,7 @@ Changes take effect only when a new session is started."
     (python-ts-mode . "python")
     (cython-mode . "python")
     (lsp--render-markdown . "markdown")
+    (move-mode . "move")
     (rust-mode . "rust")
     (rust-ts-mode . "rust")
     (rustic-mode . "rust")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
     - Magik: page/lsp-magik.md
     - Markdown: page/lsp-markdown.md
     - Marksman: page/lsp-marksman.md
+    - Move: page/lsp-move.md
     - MSSQL: https://emacs-lsp.github.io/lsp-mssql
     - Nginx: page/lsp-nginx.md
     - Nim: page/lsp-nim.md


### PR DESCRIPTION
This PR adds very basic support for using move-analyzer LSP server in lsp-mode for developing in Move programming language https://github.com/move-language/move