### PR TITLE
Add support for python-lsp-server pyls-isort plugin.

### DIFF
--- a/clients/lsp-pylsp.el
+++ b/clients/lsp-pylsp.el
@@ -259,6 +259,11 @@ Drastically increases startup time."
   :type 'boolean
   :group 'lsp-pylsp)
 
+(defcustom lsp-pylsp-plugins-isort-enabled nil
+  "Enable of disable the plugin."
+  :type 'boolean
+  :group 'lsp-pylsp)
+
 (defcustom lsp-pylsp-rope-extension-modules nil
   "Builtin and c-extension modules that are allowed to be
 imported and inspected by rope."
@@ -393,6 +398,7 @@ So it will rename only references it can find."
    ("pylsp.plugins.autopep8.enabled" lsp-pylsp-plugins-autopep8-enabled t)
    ("pylsp.plugins.yapf.enabled" lsp-pylsp-plugins-yapf-enabled t)
    ("pylsp.plugins.black.enabled" lsp-pylsp-plugins-black-enabled t)
+   ("pylsp.plugins.pyls_isort.enabled" lsp-pylsp-plugins-isort-enabled t)
    ("pylsp.plugins.rope_autoimport.enabled" lsp-pylsp-plugins-rope-autoimport-enabled t)
    ("pylsp.plugins.rope_autoimport.memory" lsp-pylsp-plugins-rope-autoimport-memory t)
    ("pylsp.plugins.rope_completion.enabled" lsp-pylsp-plugins-rope-completion-enabled t)

--- a/clients/lsp-pylsp.el
+++ b/clients/lsp-pylsp.el
@@ -260,7 +260,7 @@ Drastically increases startup time."
   :group 'lsp-pylsp)
 
 (defcustom lsp-pylsp-plugins-isort-enabled nil
-  "Enable of disable the plugin."
+  "Enable or disable the plugin."
   :type 'boolean
   :group 'lsp-pylsp)
 


### PR DESCRIPTION
Add support for [`pyls-isort`](https://github.com/paradoxxxzero/pyls-isort) plugin for `python-lsp-server`.