### PR TITLE
Fix so that lsp-semgrep-languages will take effect immediately

### DIFF
--- a/clients/lsp-semgrep.el
+++ b/clients/lsp-semgrep.el
@@ -204,7 +204,8 @@ If FULL is non-nil, scan all files in workspace, regardless of git status."
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection (lambda () lsp-semgrep-server-command))
-  :activation-fn (apply 'lsp-activate-on lsp-semgrep-languages)
+  :activation-fn (lambda (_file-name _mode)
+                   (-contains? lsp-semgrep-languages (lsp-buffer-language)))
   :server-id 'semgrep-ls
   :priority -1
   :add-on? t


### PR DESCRIPTION
Updating `lsp-semgrep-languages` didn't take effect until a restart (or recompile of lsp-semgrep.el).  This is because it's `:activation-fn` is `(apply 'lsp-activate-on lsp-semgrep-languages)` which effectively embeds the versions rather than checking the value of the variable each time.