### PR TITLE
lsp-erlang: update ELP download file names

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 8.0.1
+  * Update [[https://github.com/WhatsApp/erlang-language-platform][erlang-language-platform]] download file names to match new upstream names.
   * Add [[https://github.com/WhatsApp/erlang-language-platform][erlang-language-platform]] support in lsp-erlang client.
   * Add [[https://github.com/elixir-tools/credo-language-server][credo-language-server]]
   * Add support for clojure-ts-mode in clojure-lsp client

--- a/clients/lsp-erlang.el
+++ b/clients/lsp-erlang.el
@@ -94,8 +94,8 @@ It can use erlang-ls or erlang-language-platform (ELP)."
 (defcustom lsp-erlang-elp-download-url
   (format "https://github.com/WhatsApp/erlang-language-platform/releases/latest/download/%s"
           (pcase system-type
-            ('gnu/linux "elp-linux.tar.gz")
-            ('darwin "elp-macos.tar.gz")))
+            ('gnu/linux "elp-linux-otp-26.tar.gz")
+            ('darwin "elp-macos-otp-25.3.tar.gz")))
   "Automatic download url for erlang-language-platform."
   :type 'string
   :group 'lsp-erlang-elp


### PR DESCRIPTION
They now include the OTP version in the name, but do not offer a choice (yet).