### PR TITLE
lsp-erlang: Add semantic token support for erlang-language-platform

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 8.0.1
+  * Add semantic token support for [[https://github.com/WhatsApp/erlang-language-platform][erlang-language-platform]] in lsp-erlang client.
   * Update [[https://github.com/WhatsApp/erlang-language-platform][erlang-language-platform]] download file names to match new upstream names.
   * Add [[https://github.com/WhatsApp/erlang-language-platform][erlang-language-platform]] support in lsp-erlang client.
   * Add [[https://github.com/elixir-tools/credo-language-server][credo-language-server]]


### PR DESCRIPTION
Supporting
"bound"               default :underline, bound variable in pattern
"exported_function"   default :underline
"deprecated_function" default :strike-through

![image](https://github.com/emacs-lsp/lsp-mode/assets/409607/aca9f889-8d19-4c0c-8a41-e6528e8c0b9a)
