### PR TITLE
lsp-mode: Fix sending shutdown message

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3546,9 +3546,9 @@ and expand the capabilities section"
   "Shut down the language server process for ‘lsp--cur-workspace’."
   (with-demoted-errors "LSP error: %S"
     (let ((lsp-response-timeout 0.5))
-      (condition-case _err
-          (lsp-request "shutdown" lsp--empty-ht)
-        (error (lsp--error "Timeout while sending shutdown request"))))
+      (condition-case err
+          (lsp-request "shutdown" nil)
+        (error (lsp--error "%s" err))))
     (lsp-notify "exit" nil))
   (setf (lsp--workspace-shutdown-action lsp--cur-workspace) (or (and restart 'restart) 'shutdown))
   (lsp--uninitialize-workspace))


### PR DESCRIPTION
This fixes two related problems.

First, according to the [spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#shutdown) the shutdown message should have no parameters.

rust-analyzer and erlang-language-platform respond with an "unable to deserialized error" when given an empty map instead.  e.g.

`LSP :: (error Failed to deserialize shutdown: invalid type: map, expected unit; {})`

But this was hidden because the condition case swallows the error info and always reports timeout.

A genuine timeout is now reported as

`LSP :: (error Timeout while waiting for response.  Method: shutdown)`