### PR TITLE
Bump magik language server to 0.8.0

### DIFF
--- a/clients/lsp-magik.el
+++ b/clients/lsp-magik.el
@@ -34,7 +34,7 @@
   :tag "Lsp Magik"
   :package-version '(lsp-mode . "8.0.1"))
 
-(defcustom lsp-magik-version "0.7.1"
+(defcustom lsp-magik-version "0.8.0"
   "Version of LSP server."
   :type `string
   :group `lsp-magik


### PR DESCRIPTION
Bump the magik language server to 0.8.0.

Release: https://github.com/StevenLooman/magik-tools/releases/tag/0.8.0
Change log: https://github.com/StevenLooman/magik-tools/blob/e5bde11df02d1802e4cab85f2164963df03b6eba/CHANGES.md?plain=1#L5