### PR TITLE
Remove unbalanced parenthesis and double-quote in comments

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3008,7 +3008,7 @@ and end-of-string meta-characters."
   ;; `lsp-register-client-capabilities'. It's value is an alist of (PACKAGE-NAME
   ;; . CAPS), where PACKAGE-NAME is a symbol of the third-party package name,
   ;; and CAPS is either a plist of the client capabilities, or a function that
-  ;; takes no argument and returns a plist of the client capabilities or nil.")
+  ;; takes no argument and returns a plist of the client capabilities or nil.
   (extra-client-capabilities nil)
 
   ;; Workspace status


### PR DESCRIPTION
There is an unbalanced parenthesis in comments of lsp--workspace structure. It generates an error when you try to access documentation with helpful and Emacs 29 (see https://github.com/Wilfred/helpful/issues/329).

This PR just removes the faulty (and useless) parenthesis and double-quote.