### PR TITLE
lsp-php: Support `intelephense.environment.includePaths`

### DIFF
--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -122,7 +122,7 @@ from all language server features."
 (lsp-defcustom lsp-intelephense-paths-include
   []
   "Configure additional paths outside workspace."
-  :type '(repeat string)
+  :type 'lsp-string-vector
   :group 'lsp-intelephense
   :package-version '(lsp-mode . "8.1")
   :lsp-path "intelephense.environment.includePaths")

--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -119,6 +119,14 @@ from all language server features."
   :package-version '(lsp-mode . "6.1")
   :lsp-path "intelephense.files.exclude")
 
+(lsp-defcustom lsp-intelephense-paths-include
+  []
+  "Configure additional paths outside workspace."
+  :type '(repeat string)
+  :group 'lsp-intelephense
+  :package-version '(lsp-mode . "8.1")
+  :lsp-path "intelephense.environment.includePaths")
+
 (lsp-defcustom lsp-intelephense-stubs
   ["apache" "bcmath" "bz2" "calendar"
    "com_dotnet" "Core" "ctype" "curl" "date" "dba" "dom" "enchant"


### PR DESCRIPTION
Don't merge it: I can't get it to work and but can't understand why.

While a symlink does load external framework's code, I can't get this directive to have the same effects. Whether it's being forwarded incorrectly or interpreted incorrectly by vscode-intelephense, I can't understand how to debug it.

I also wished https://phpactor.readthedocs.io/en/master/reference/configuration.html#indexer-index-path directive would be implemented too. The ability to load code from custom directories is a must-have for all backends.

