### PR TITLE
fix: register awk client to account for custom executable

### DIFF
--- a/clients/lsp-awk.el
+++ b/clients/lsp-awk.el
@@ -40,7 +40,7 @@
 
 (lsp-register-client
  (make-lsp-client
-  :new-connection (lsp-stdio-connection lsp-awk-executable)
+  :new-connection (lsp-stdio-connection (lambda () lsp-awk-executable))
   :activation-fn (lsp-activate-on "awk")
   :priority -1
   :server-id 'awkls))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -788,6 +788,7 @@ Changes take effect only when a new session is started."
     ("^settings.json$" . "jsonc")
     (ada-mode . "ada")
     (awk-mode . "awk")
+    (awk-ts-mode . "awk")
     (nxml-mode . "xml")
     (sql-mode . "sql")
     (vimrc-mode . "vim")


### PR DESCRIPTION
Registers the awk client with lambda so changes to `lsp-awk-executable` have 
effect.  The server also doesn't work for me without the `--noIndex` flag, but I'm
not sure that should be the default?
Also, adds entry to support `awk-ts-mode`.