### PR TITLE
lsp-erlang: update erlang-language-platform download file names

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 8.0.1
+  * Add architecture triples for [[https://github.com/WhatsApp/erlang-language-platform][erlang-language-platform]] file downloads, to support macos on ARM and X86.
   * Add semantic token support for [[https://github.com/WhatsApp/erlang-language-platform][erlang-language-platform]] in lsp-erlang client.
   * Update [[https://github.com/WhatsApp/erlang-language-platform][erlang-language-platform]] download file names to match new upstream names.
   * Add [[https://github.com/WhatsApp/erlang-language-platform][erlang-language-platform]] support in lsp-erlang client.

--- a/clients/lsp-erlang.el
+++ b/clients/lsp-erlang.el
@@ -101,8 +101,11 @@ It can use erlang-ls or erlang-language-platform (ELP)."
 (defcustom lsp-erlang-elp-download-url
   (format "https://github.com/WhatsApp/erlang-language-platform/releases/latest/download/%s"
           (pcase system-type
-            ('gnu/linux "elp-linux-otp-26.tar.gz")
-            ('darwin "elp-macos-otp-25.3.tar.gz")))
+            ('gnu/linux "elp-linux-x86_64-unknown-linux-gnu-otp-26.tar.gz")
+            ('darwin
+             (if (string-match "^aarch64-.*" system-configuration)
+                 "elp-macos-aarch64-apple-darwin-otp-25.3.tar.gz"
+               "elp-macos-x86_64-apple-darwin-otp-25.3.tar.gz"))))
   "Automatic download url for erlang-language-platform."
   :type 'string
   :group 'lsp-erlang-elp


### PR DESCRIPTION
Include architecture triples to be able to download the appropriate macos variant.