### PR TITLE
Parse JSON false as :json-false instead of nil

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6740,7 +6740,7 @@ server. WORKSPACE is the active workspace."
                                            'plist
                                          'hash-table)
                           :null-object nil
-                          :false-object nil)
+                          :false-object :json-false)
     `(let ((json-array-type 'vector)
            (json-object-type (if lsp-use-plists
                                  'plist
@@ -6757,7 +6757,7 @@ server. WORKSPACE is the active workspace."
                                            'plist
                                          'hash-table)
                           :null-object nil
-                          :false-object nil)
+                          :false-object :json-false)
     `(let ((json-array-type 'vector)
            (json-object-type (if lsp-use-plists
                                  'plist
@@ -8626,7 +8626,7 @@ When ALL is t, erase all log buffers of the running session."
                 (done (lsp--handle-process-exit workspace ""))))))
           :object-type object-type
           :null-object nil
-          :false-object nil))
+          :false-object :json-false))
        "*json-rpc-connection*"))
     (cons con con)))
 


### PR DESCRIPTION
This would break code actions where the server sends us an action containing a `false` boolean parameter. `lsp-mode` would translate this into `nil`, and then send a `null` back to the language server. An example of this causing problems was
#4184.

There may be parts of `lsp-mode` that expect `false` values to be parsed as `nil`, so any logic involving parsed booleans may need to be updated. I have not dug around much, so input from people who are more familiar with `lsp-mode`'s internals is very much appreciated!

Fixes #4184.