### PR TITLE
Fix `lsp-completion--company-match` freezing #4192

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -351,6 +351,11 @@ The MARKERS and PREFIX value will be attached to each candidate."
                   (buffer-substring-no-properties
                    (plist-get (text-properties-at 0 candidate) 'lsp-completion-start-point)
                    (point))))
+         ;; Workaround for bug #4192
+         ;; `lsp-completion-start-point' above might be from cached/previous completion and
+         ;; pointing to a very distant point, which results in `prefix' being way too long.
+         ;; So let's consider only the first line.
+         (prefix (car (string-lines prefix)))
          (prefix-len (length prefix))
          (prefix-pos 0)
          (label (downcase candidate))


### PR DESCRIPTION
This is a workaround for #4192
Consider only the first line in `prefix`.

A proper solution is to invalidate cache, or recompute `start-point`. 
But i'm not familiar with how that cache works.
Please close this PR if someone is willing to make a clean fix