### PR TITLE
Allow clients to specify code action arguments where nil values should be treated as :json-false

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -4,6 +4,7 @@
   * Add SQL support
   * Add support for Meson build system. (~meson-mode~).
   * Add support for go to definition for external files (.dll) in CSharp projects for OmniSharp server.
+  * Added a new optional ~:action-filter~ argument when defining LSP clients that allows code action requests to be modified before they are sent to the server. This is used by the Haskell language server client to work around an ~lsp-mode~ parsing quirk that incorrectly sends ~null~ values instead of ~false~ in code action requests.
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.


### PR DESCRIPTION
This lets us fix #4184 by selectively changing `nil` code action argument values to `:json-false`. Once this is merged, HLS needs to set the field to `'(:withSig)` (and possibly some other values).

Some possible alternatives to this would be to:

1. Turn `boolean-action-arguments` into an alist that matches (part of) the command's name. This needs to support partial matches because HLS includes a plugin ID in the command name, and these are not guaranteed to stay constant.
2. Have it take a function instead, and implement the patching on the client level. This is more flexible, but I don't think the extra generalization is needed. At least not for now.

Supersedes #4191.