### PR TITLE
Bump the magik language server to 0.8.1

### DIFF
--- a/clients/lsp-magik.el
+++ b/clients/lsp-magik.el
@@ -34,7 +34,7 @@
   :tag "Lsp Magik"
   :package-version '(lsp-mode . "8.0.1"))
 
-(defcustom lsp-magik-version "0.8.0"
+(defcustom lsp-magik-version "0.8.1"
   "Version of LSP server."
   :type `string
   :group `lsp-magik


### PR DESCRIPTION
Bump the magik language server to 0.8.1.

Release: https://github.com/StevenLooman/magik-tools/releases/tag/0.8.1
Change log: https://github.com/StevenLooman/magik-tools/blob/9eb1e38f6cb1dc32608cb559f6155753472b469b/CHANGES.md?plain=1#L5