### PR TITLE
ruby-lsp: Enable all available lsp features

### DIFF
--- a/clients/lsp-ruby-lsp.el
+++ b/clients/lsp-ruby-lsp.el
@@ -47,20 +47,6 @@
  (make-lsp-client
   :new-connection (lsp-stdio-connection #'lsp-ruby-lsp--build-command)
   :activation-fn (lsp-activate-on "ruby")
-  :initialization-options `(
-			    :enabledFeatures ["documentHighlights"
-                            "documentSymbols"
-                            "documentLink"
-                            "diagnostics"
-                            "foldingRanges"
-                            "selectionRanges"
-                            "semanticHighlighting"
-                            "formatting"
-                            "onTypeFormatting"
-                            "codeActions"
-                            "completion"
-                            "inlayHint"
-                            "hover"])
   :priority -2
   :server-id 'ruby-lsp-ls))
 


### PR DESCRIPTION
Early versions of ruby-lsp server required clients to send all the features that shall be initialized on the server. Shortly after ruby-lsp was added to emacs lsp-mode (March 2023), upstream ruby-lsp removed this requirement. Simply removing the intialization-options makes ruby-lsp enable all the features that are supported by lsp-mode client.