### PR TITLE
Make lsp-ansible client multi-root

### DIFF
--- a/clients/lsp-ansible.el
+++ b/clients/lsp-ansible.el
@@ -245,6 +245,7 @@ Pretty print the content of PARAMS."
                        ,@(cl-rest lsp-ansible-language-server-command))))
   :priority 1
   :add-on? lsp-ansible-add-on?
+  :multi-root t
   :notification-handlers (ht ("update/ansible-metadata" #'lsp-ansible-update-metadata-handler))
   :activation-fn #'lsp-ansible-check-ansible-minor-mode
   :server-id 'ansible-ls


### PR DESCRIPTION
First of all, thanks for lsp-mode, it really makes Emacs even more of a joy to use.

I was having issues when using lsp-ansible where the results from ansible-lint in Emacs as reported via ansible-language-server were not matching what I saw when running in the terminal (in Emacs files had no errors while the results I saw in the terminal did indicate valid errors). There were also a lot of log lines in the `*lsp-log*` buffer about "workspace folder explicitly set to" followed by the directory name for whichever file I was working on at the time (those messages [originate in ansible-language-server](https://github.com/ansible/ansible-language-server/blob/a2f98f28810740fc85e937a88b2e3d531bfb421c/src/services/workspaceManager.ts#L92), in a code path which contains a comment which says that no workspace is configured by the client).

Now ansible-lint is dependent on the directory from which it is run, I believe since it needs to know if files are located in a role or similar to apply the correct rules. And my investigations showed that ansible-language-server was running it with the current working directory being same directory that was reported in `*lsp-log*`. (When I ran ansible-lint in the terminal my current working directory was the project root.)

After investigating further, it turns out ansible-language-server [expects](https://github.com/ansible/ansible-language-server/blob/a2f98f28810740fc85e937a88b2e3d531bfb421c/src/ansibleLanguageService.ts#L56) to receive the workspace folders through the workspaceFolders property in InitializeParams. It does not read rootUri at all. And for this to fit with lsp-mode, I read that multi-root must be enabled.

After modifying my local install of lsp-mode to set `:multi-root t`, the correct errors from ansible-lint are shown in Emacs. All other functionality (highlighting, completion) work correctly as before.