### PR TITLE
lsp-javascript: supply correct path to tsserver for ts-ls

### DIFF
--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -800,13 +800,11 @@ name (e.g. `data' variable passed as `data' parameter)."
      (f-exists? (lsp-clients-typescript-project-ts-server-path)))
     (lsp-clients-typescript-project-ts-server-path))
    (t
-    (lsp-package-path 'typescript))))
+    (f-join (f-parent (lsp-package-path 'typescript)) "node_modules" "typescript" "lib"))))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda ()
                                                           `(,(lsp-package-path 'typescript-language-server)
-                                                            "--tsserver-path"
-                                                            ,(lsp-clients-typescript-server-path)
                                                             ,@lsp-clients-typescript-server-args)))
                   :activation-fn 'lsp-typescript-javascript-tsx-jsx-activate-p
                   :priority -2
@@ -825,8 +823,8 @@ name (e.g. `data' variable passed as `data' parameter)."
                                                (list :plugins lsp-clients-typescript-plugins))
                                              (when lsp-clients-typescript-preferences
                                                (list :preferences lsp-clients-typescript-preferences))
-                                             (when lsp-clients-typescript-tsserver
-                                               (list :tsserver lsp-clients-typescript-tsserver))))
+                                             `(:tsserver ( :path ,(lsp-clients-typescript-server-path)
+                                                           ,@lsp-clients-typescript-tsserver))))
                   :initialized-fn (lambda (workspace)
                                     (with-lsp-workspace workspace
                                       (lsp--set-configuration


### PR DESCRIPTION
According to the [docs](https://github.com/typescript-language-server/typescript-language-server#initializationoptions), the `--tsserver-path` is deprecated and we should use the initialization option of `tsserver.path` instead.
Also, the path should point to `tsserver.js` or the typescript lib directory.

Currently the newest `ts-ls` is broken on Windows. This PR fixes that.