### PR TITLE
Fix lsp-mode's tramp support

### DIFF
--- a/docs/manual-language-docs/lsp-rust-analyzer.md
+++ b/docs/manual-language-docs/lsp-rust-analyzer.md
@@ -119,22 +119,3 @@ In the example below, first you see that:
 
 This [unmerged PR](https://github.com/emacs-lsp/lsp-mode/pull/1740) contains an example method that allows
 modifying the signature that is displayed by eldoc.
-
-### TRAMP Example
-
-The following is an example configuration for using lsp-mode with a remote rust-analyzer server:
-
-```
-(with-eval-after-load "lsp-rust"
-  (lsp-register-client
-   (make-lsp-client
-    :new-connection (lsp-tramp-connection "rust-analyzer")
-    :remote? t
-    :major-modes '(rust-mode rustic-mode)
-    :initialization-options 'lsp-rust-analyzer--make-init-options
-    :notification-handlers (ht<-alist lsp-rust-notification-handlers)
-    :action-handlers (ht ("rust-analyzer.runSingle" #'lsp-rust--analyzer-run-single))
-    :library-folders-fn (lambda (_workspace) lsp-rust-analyzer-library-directories)
-    :ignore-messages nil
-    :server-id 'rust-analyzer-remote)))
-```

--- a/docs/page/remote.md
+++ b/docs/page/remote.md
@@ -5,33 +5,14 @@ root_file: docs/page/remote.md
 
 ## TRAMP
 
-LSP mode has support for tramp buffers with the following requirements:
+`lsp-mode` has support for tramp buffers with the following requirements:
 
 - The language server has to be present on the remote server.
 - Having multi folder language server (like [Eclipse JDT LS](https://github.com/eclipse/eclipse.jdt.ls)) cannot have local and remote workspace folders.
 
 ### How does it work?
 
-`lsp-mode` detects whether a particular file is located on remote machine and looks for a client which matches current file and it is marked as `:remote?` t. Then `lsp-mode` starts the client through tramp.
-
-### Sample configuration
-
-Here it is example how you can configure python language server to work when using `TRAMP`. Note that if you are trying to convert existing language server configuration you should copy all of it's properties(e. g. `:request-handlers`, `activation-fn`, etc). Also, when you are doing that you should make sure that none of the custom language server settings are not pointing to local path because those settings will be sent to the remote server.
-
-```elisp
-(lsp-register-client
-    (make-lsp-client :new-connection (lsp-tramp-connection "<binary name (e. g. pyls, rls)>")
-                     :major-modes '(python-mode)
-                     :remote? t
-                     :server-id 'pyls-remote))
-```
-
-_Note:_ when you do not have root privileges on the remote machine to put the language server on the path you may alter the remote path by changing `tramp-remote-path`.
-
-### Dealing with stderr
-
-With TRAMP, Emacs does not have an easy way to distinguish stdout and stderr, so when the underlying LSP process writes to stderr, it breaks the `lsp-mode` parser. As a workaround, `lsp-mode` is redirecting stderr to `/tmp/<process-name>-<id>~stderr`.
-
+`lsp-mode` detects whether a particular file is located on remote machine and looks for a client which matches current file and it is marked as `:remote?` t. Then `lsp-mode` starts the client through tramp. By default `lsp-mode` will copy the local client and mark it as `remote? t`. In most of the cases it is good enough but certain cases this may not work (e. g. if the server configuration contains references to local paths). In this case the user is supposed to create `.dir-local` configuration to override the references to local paths or open an issue on `lsp-mode` side to make the setting remote agnostic. To turn of automatic remote clients registration you can set `lsp-auto-register-remote-clients` to `nil`.
 
 ## Docker
 


### PR DESCRIPTION
Fix lsp-mode's tramp support

- This fixes the implementation of `lsp-mode` tramp support. After this PR the
remote clients will be automatically registered and in most of the cases it will
work out of the box. The remote connection is managed to a way similar to what
eglot does.

Fixes https://github.com/emacs-lsp/lsp-mode/issues/4158
Fixes https://github.com/emacs-lsp/lsp-mode/issues/4150
Fixes https://github.com/emacs-lsp/lsp-mode/issues/4158
Fixes https://github.com/emacs-lsp/lsp-mode/issues/4150
Fixes https://github.com/emacs-lsp/lsp-mode/issues/3841
Fixes https://github.com/emacs-lsp/lsp-mode/issues/3642
Fixes https://github.com/emacs-lsp/lsp-mode/issues/3579
Fixes https://github.com/emacs-lsp/lsp-mode/issues/3530
Fixes https://github.com/emacs-lsp/lsp-mode/issues/3491
Fixes https://github.com/emacs-lsp/lsp-mode/issues/3490
Fixes https://github.com/emacs-lsp/lsp-mode/issues/3391
Fixes https://github.com/emacs-lsp/lsp-mode/issues/3369
Fixes https://github.com/emacs-lsp/lsp-mode/issues/3364
Fixes https://github.com/emacs-lsp/lsp-mode/issues/3020
Fixes https://github.com/emacs-lsp/lsp-mode/issues/3018
Fixes https://github.com/emacs-lsp/lsp-mode/issues/3020
