### PR TITLE
feat(lsp-mojo): add LSP support for Mojo 🔥

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 8.0.1
+  * Add Mojo 🔥 support
   * Add lsp-solidity, using the implementation from NomicFoundation
   * Change rust-analyzer base URL to be github.com/rust-lang/rust-analyzer, rather than rust-analyzer/rust-analyzer.
   * Add [[https://github.com/wader/jq-lsp][jq-lsp]]

--- a/clients/lsp-mojo.el
+++ b/clients/lsp-mojo.el
@@ -1,0 +1,50 @@
+;;; lsp-mojo.el --- lsp-mode Mojo integration -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2023 Adam Liter
+
+;; Author: Adam Liter <io@adamliter.org>
+;; Keywords: languages,tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;  client for Mojo 🔥
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-mojo nil
+  "LSP support for Mojo 🔥, using mojo-lsp-server."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/modularml/mojo"))
+
+(defcustom lsp-mojo-executable "mojo-lsp-server"
+  "The Mojo 🔥 LSP executable to use.
+Leave as just the executable name to use the default behavior of
+finding the executable with variable `exec-path'."
+  :group 'lsp-mojo
+  :type 'string)
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection (lambda () lsp-mojo-executable))
+  :activation-fn (lsp-activate-on "mojo")
+  :server-id 'mojo))
+
+(lsp-consistency-check lsp-mojo)
+
+(provide 'lsp-mojo)
+;;; lsp-mojo.el ends here

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -181,7 +181,7 @@ As defined by the Language Server Protocol 3.16."
      lsp-glsl lsp-graphql lsp-hack lsp-grammarly lsp-groovy lsp-haskell lsp-haxe
      lsp-idris lsp-java lsp-javascript lsp-json lsp-kotlin lsp-latex lsp-ltex
      lsp-lua lsp-markdown lsp-marksman lsp-mdx lsp-mint lsp-move lsp-nginx lsp-nim lsp-nix lsp-magik
-     lsp-metals lsp-mssql lsp-ocaml lsp-openscad lsp-pascal lsp-perl lsp-perlnavigator
+     lsp-mojo lsp-metals lsp-mssql lsp-ocaml lsp-openscad lsp-pascal lsp-perl lsp-perlnavigator
      lsp-pls lsp-php lsp-pwsh lsp-pyls lsp-pylsp lsp-pyright lsp-python-ms lsp-purescript
      lsp-r lsp-racket lsp-remark lsp-ruff-lsp lsp-rf lsp-rubocop lsp-rust lsp-semgrep lsp-shader
      lsp-solargraph lsp-sorbet lsp-sourcekit lsp-sonarlint lsp-tailwindcss lsp-tex lsp-terraform
@@ -812,6 +812,7 @@ Changes take effect only when a new session is started."
     (python-mode . "python")
     (python-ts-mode . "python")
     (cython-mode . "python")
+    ("\\(\\.mojo\\|\\.🔥\\)\\'" . "mojo")
     (lsp--render-markdown . "markdown")
     (move-mode . "move")
     (rust-mode . "rust")


### PR DESCRIPTION
Not super familiar with `elisp` or the `lsp-mode` code base, but here is an attempt to add support for Mojo 🔥 (closes #4206). Very much open to feedback on this PR! 😄 Do I need to do anything to update the documentation or anything? I think I saw somewhere that the docs are autogenerated.

Also, let me know if there's any testing that should be added to this PR (would appreciate a pointer in how to do that). I've tested this out locally by doing the following, and it seems to be working for me.

```sh
cd /tmp
git clone https://github.com/modularml/mojo.git
cat << EOF > init.el
(defvar bootstrap-version)
(let ((bootstrap-file
       (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
      (bootstrap-version 6))
  (unless (file-exists-p bootstrap-file)
    (with-current-buffer
        (url-retrieve-synchronously
         "https://raw.githubusercontent.com/radian-software/straight.el/develop/install.el"
         'silent 'inhibit-cookies)
      (goto-char (point-max))
      (eval-print-last-sexp)))
  (load bootstrap-file nil 'nomessage))
(straight-use-package 'use-package)
(setq straight-use-package-by-default t)

(use-package lsp-mode
  ;; my local copy of this repo with the changes in this PR
  :load-path "/Users/adamliter/git/lsp-mode" 
  :straight (:local-repo "/Users/adamliter/git/lsp-mode"))

(use-package company)
EOF
emacs -q --load init.el &
```

Then, I did `C-x C-f` `mojo/examples/matmul.mojo`, then `M-x lsp-mode`, then you can see I'm getting completion from the LSP with `lsp-mode` and `company` like so:

<img width="580" alt="image" src="https://github.com/emacs-lsp/lsp-mode/assets/4974404/b1923b47-971e-4050-97a7-d03789e94500">