### PR TITLE
lsp-go: Add possibility to wrap gopls binary (mostly for nix)

### DIFF
--- a/clients/lsp-go.el
+++ b/clients/lsp-go.el
@@ -317,9 +317,33 @@ $GOPATH/pkg/mod along with the value of
    ("gopls.symbolMatcher" lsp-go-symbol-matcher)
    ("gopls.symbolStyle" lsp-go-symbol-style)))
 
+(defcustom lsp-go-server-wrapper-function
+  #'identity
+  "Function to wrap the language server process started by lsp-go.
+
+For example, you can pick a go binary provided by a repository's
+flake.nix file with:
+
+  (use-package nix-sandbox)
+  (defun my/nix--lsp-go-wrapper (args)
+    (if-let ((sandbox (nix-current-sandbox)))
+        (apply 'nix-shell-command sandbox args)
+      args))
+  (setq lsp-go-server-path \"gopls\"
+        lsp-go-server-wrapper-function 'my/nix--lsp-go-wrapper)"
+  :group 'lsp-go
+  :type '(choice
+          (function-item :tag "None" :value identity)
+          (function :tag "Custom function")))
+
+(defun lsp-go--server-command ()
+  "Command and arguments for launching the inferior language server process.
+These are assembled from the customizable variables `lsp-go-server-path'
+and `lsp-go-server-wrapper-function'."
+  (funcall lsp-go-server-wrapper-function (append (list lsp-go-server-path) lsp-go-gopls-server-args)))
+
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection
-                                   (lambda () (cons lsp-go-gopls-server-path lsp-go-gopls-server-args)))
+ (make-lsp-client :new-connection (lsp-stdio-connection (lambda () (lsp-go--server-command)))
                   :activation-fn (lsp-activate-on "go" "go.mod")
                   :language-id "go"
                   :priority 0

--- a/clients/lsp-go.el
+++ b/clients/lsp-go.el
@@ -343,7 +343,7 @@ and `lsp-go-server-wrapper-function'."
   (funcall lsp-go-server-wrapper-function (append (list lsp-go-server-path) lsp-go-gopls-server-args)))
 
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection (lambda () (lsp-go--server-command)))
+ (make-lsp-client :new-connection (lsp-stdio-connection 'lsp-go--server-command)
                   :activation-fn (lsp-activate-on "go" "go.mod")
                   :language-id "go"
                   :priority 0


### PR DESCRIPTION
Fixes #1933 for `lsp-go`.

This allows for example to pick the go version that's provided in a repository's `flake.nix` or by home-manager or NixOS. This follows the example of [lsp-haskell](https://github.com/emacs-lsp/lsp-haskell/blob/89d16370434e9a247e95b8b701f524f5abfc884b/lsp-haskell.el#L481-L485).

In my `init.el` I have:

```elisp
(use-package nix-sandbox)

(defun my/nix--lsp-go-wrapper (args)
  (if-let ((sandbox (nix-current-sandbox)))
      (apply 'nix-shell-command sandbox args)
    args))

(setq lsp-go-server-path "gopls"
      lsp-go-server-wrapper-function 'my/nix--lsp-go-wrapper)
```

One of my repos provides the `go` binary with such a `flake.nix` (abridged version):

```nix
{
  outputs = { ... }: {
    devShells.default = pkgs.mkShell {
      packages = [ pkgs.go ];
    };
  };
}
```

And a `shell.nix` (needed for the `nix-sandbox` emacs package):

```nix
(import (
  let
    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
  in fetchTarball {
    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
    sha256 = lock.nodes.flake-compat.locked.narHash;
  }
) {
  src =  ./.;
}).shellNix
```

And also, the `gopls` binary is provided by home-manager:

```
$ type gopls
gopls is $HOME/.nix-profile/bin/gopls
$ type go
go not found
$ nix develop

bash-5.2$ type gopls
gopls is $HOME/.nix-profile/bin/gopls
bash-5.2$ type go
go is /nix/store/5p6bk8gmc8m8sm0766nb5qmxwp3f64gj-go/bin/go
```

Now, if I open a file in that repo, I get the `go` binary from the `flake.nix`:

```elisp
(nix-executable-find (nix-current-sandbox) "go")
"/nix/store/5p6bk8gmc8m8sm0766nb5qmxwp3f64gj-go/bin/go"

(nix-executable-find (nix-current-sandbox) "gopls")
"/Users/pierre/.nix-profile/bin/gopls"
```