### PR TITLE
Update volar npm package name

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -1033,8 +1033,8 @@
     "name": "volar",
     "full-name": "Vue 3",
     "server-name": "volar-language-server",
-    "server-url": "https://github.com/johnsoncodehk/volar",
-    "installation": "npm install -g @volar/vue-language-server",
+    "server-url": "https://github.com/vuejs/language-tools",
+    "installation": "npm install -g @vue/language-server",
     "lsp-install-server": "vue-semantic-server",
     "debugger": "Not available"
   },


### PR DESCRIPTION
`@volar/vue-language-server` has been renamed to `@vue/language-server`. https://github.com/emacs-lsp/lsp-mode/pull/4076