### PR TITLE
Initial support for wgsl-analyzer

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 8.0.1
+  * Add support for wgsl using [[https://github.com/wgsl-analyzer/wgsl-analyzer][wgsl-analyzer]]
   * Add [[https://github.com/wader/jq-lsp][jq-lsp]]
   * Add architecture triples for [[https://github.com/WhatsApp/erlang-language-platform][erlang-language-platform]] file downloads, to support macos on ARM and X86.
   * Add semantic token support for [[https://github.com/WhatsApp/erlang-language-platform][erlang-language-platform]] in lsp-erlang client.

--- a/clients/lsp-wgsl.el
+++ b/clients/lsp-wgsl.el
@@ -1,0 +1,52 @@
+;;; lsp-wgsl.el --- description -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2023 emacs-lsp maintainers
+
+;; Author: emacs-lsp maintainers
+;; Keywords: lsp, wgsl, shaders, graphics programming,
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP Clients for WGSL (WebGPU Shading Language).
+
+;;; Code:
+
+(defgroup lsp-wgsl nil
+  "LSP support for wgsl, using wgsl-analyzer."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/wgsl-analyzer/wgsl-analyzer")
+  :package-version '(lsp-mode . "8.0.1"))
+
+
+(defcustom lsp-wgsl-server-command "wgsl_analyzer"
+  "Command to run the wgsl-analyzer executable."
+  :type 'boolean
+  :group 'lsp-wgsl
+  :package-version '(lsp-mode . "8.0.1"))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   (lambda ()
+                                     lsp-wgsl-server-command))
+                  :activation-fn (lsp-activate-on "wgsl")
+                  :priority -1
+                  :server-id 'wgsl-analyzer))
+
+
+(lsp-consistency-check lsp-wgsl)
+
+(provide 'lsp-wgsl)
+;;; lsp-wgsl.el ends here

--- a/clients/lsp-wgsl.el
+++ b/clients/lsp-wgsl.el
@@ -37,6 +37,26 @@
   :group 'lsp-wgsl
   :package-version '(lsp-mode . "8.0.1"))
 
+
+;; Various interactive functions to use the custom LSP extensions from the server
+(defun lsp-wgsl-full-source ()
+  "Gets the full source of the file with all imports and preprocessor definitions resolved."
+  (interactive)
+  (lsp-request-async
+   "wgsl-analyzer/fullSource"
+   (list :textDocument (list :uri (lsp--buffer-uri)))
+   (lambda (source)
+     (let ((buffer (get-buffer-create "*WGSL-full-source*")))
+       (with-current-buffer buffer
+         (setq-local buffer-read-only nil)
+         (erase-buffer)
+         (insert source)
+         (read-only-mode)
+         ;; activate only syntax highlighting
+         (font-lock-add-keywords nil wgsl-font-lock-keywords)
+         (font-lock-mode))
+       (switch-to-buffer buffer)))))
+
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection
                                    (lambda ()

--- a/clients/lsp-wgsl.el
+++ b/clients/lsp-wgsl.el
@@ -98,18 +98,20 @@
 (defcustom lsp-wgsl-custom-imports (lsp-ht)
   "List of custom imports in the style of Bevy"
   :type 'ht
-  :group 'lsp-wgsl)
+  :group 'lsp-wgsl
+  :package-version '(lsp-mode . "8.0.1"))
 
-(defcustom lsp-wgsl-shaderdefs []
-  "Defines that should be valid for preprocessor operations like ifdef."
-  :type 'vector
-  :group 'lsp-wgsl)
-
+;; (defcustom lsp-wgsl-shaderdefs []
+;;   "Defines that should be valid for preprocessor operations like ifdef."
+;;   :type 'vector
+;;   :group 'lsp-wgsl
+;;   :package-version '(lsp-mode . "8.0.1"))
 
 ;; wgsl-analyzer is a bit weird with how it gets config.
 ;; Currently it relies on a custom extension to query the clients.
 ;; (could not get standard custom-settings blocks to work)
 (defun lsp-wgsl--send-configuration (&rest _)
+  ;; TODO: why doesnt this behave like the normal lists?!?!? I cant just send a list?!?!?! why the fuck?!?!
   (list :customImports lsp-wgsl-custom-imports
         :diagnostics (list :typeErrors (lsp-json-bool lsp-wgsl-diagnostics-type-errors)
                            :nagaParsingErrors (lsp-json-bool lsp-wgsl-diagnostics-naga-parsing-errors)
@@ -120,9 +122,7 @@
                           :parameterHints (lsp-json-bool lsp-wgsl-inlayhints-parameterhints)
                           :structLayoutHints (lsp-json-bool lsp-wgsl-inlayhints-structlayout)
                           :typeVerbosity lsp-wgsl-inlayhints-type-verbosity)
-        ;; using lsp-wgsl-shaderdefs seems to fail even when lsp-wgsl-shaderdefs is [],
-        ;;  which is the reason for this hack. wrong argument consp, nil
-        :shaderDefs (if (length= lsp-wgsl-shaderdefs 0) [] lsp-wgsl-shaderdefs)
+        :shaderDefs []
         ;; not configurable at the moment, as they don't seem to have much effect.
         ;; Fails if not given.
         :trace (list :extension t

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -1030,6 +1030,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "wgsl-analyzer",
+    "full-name": "wgsl",
+    "server-name": "wgsl-analyzer",
+    "server-url": "https://github.com/wgsl-analyzer/wgsl-analyzer",
+    "installation": "cargo install --git https://github.com/wgsl-analyzer/wgsl-analyzer wgsl_analyzer",
+    "debugger": "Not available"
+  },
+  {
     "name": "xml",
     "full-name": "XML",
     "server-name": "lsp4xml",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -929,6 +929,7 @@ Changes take effect only when a new session is started."
     (rst-mode . "restructuredtext")
     (glsl-mode . "glsl")
     (shader-mode . "shaderlab")
+    (wgsl-mode . "wgsl")
     (jq-mode . "jq")
     (jq-ts-mode . "jq"))
   "Language id configuration.")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,7 @@ nav:
     - Vimscript: page/lsp-vimscript.md
     - Vue 2: page/lsp-vetur.md
     - Vue 3: page/lsp-volar.md
+    - wgsl: page/lsp-wgsl.md
     - XML: page/lsp-xml.md
     - YAML: page/lsp-yaml.md
     - Zig: page/lsp-zig.md


### PR DESCRIPTION
Fixes #3983


wgsl-analyzer does a lot of non-standard things, including how it handles the configuration requests. Others have also pointed out this in the issue tracker: https://github.com/wgsl-analyzer/wgsl-analyzer/issues/77 . Had to fight a bit with the language server to get it to read my configuration. Tried the standard way without success in several different ways. (standard way meaning using `lsp-register-custom-settings`). Have tried commenting the reasoning for the next person.


Implements the basic functionality to make the server usable, as well as configuration properties for it. Also implements the custom request to get the full source code (which includes preprocessor step being executed, as well as symbols fetched from dependencies etc.). Other custom requests like source tree I did not understand the response format of, so leaving that for a further improvement later.


Could not get the `lsp-wgsl-shaderdefs` settings variable to be serialized as a sequence in any way... Lists and vectors with contents give the famous `wrong argument consp, nil` error. Only thing working so far is an empty vector. Would very much like feedback on how this could be solved.


Feel free to suggest any improvements! 🙂 Felt a bit dirty with all the custom configuration handling 😛 