### PR TITLE
Remove use of `string-lines` (#4217)

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -355,8 +355,13 @@ The MARKERS and PREFIX value will be attached to each candidate."
          ;; `lsp-completion-start-point' above might be from cached/previous completion and
          ;; pointing to a very distant point, which results in `prefix' being way too long.
          ;; So let's consider only the first line.
-         (prefix (car (string-lines prefix)))
-         (prefix-len (length prefix))
+         (prefix-len (let ((idx 0)
+                           (len (length prefix)))
+		       (while (and (< idx len)
+                                   (not (= ?\n (elt prefix idx))))
+			 (setq idx (1+ idx)))
+		       idx))
+         (prefix (substring prefix 0 prefix-len))
          (prefix-pos 0)
          (label (downcase candidate))
          (label-len (length label))

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -355,13 +355,8 @@ The MARKERS and PREFIX value will be attached to each candidate."
          ;; `lsp-completion-start-point' above might be from cached/previous completion and
          ;; pointing to a very distant point, which results in `prefix' being way too long.
          ;; So let's consider only the first line.
-         (prefix-len (let ((idx 0)
-                           (len (length prefix)))
-		       (while (and (< idx len)
-                                   (not (= ?\n (elt prefix idx))))
-			 (setq idx (1+ idx)))
-		       idx))
-         (prefix (substring prefix 0 prefix-len))
+         (prefix (car (s-lines prefix)))
+         (prefix-len (length prefix))
          (prefix-pos 0)
          (label (downcase candidate))
          (label-len (length label))


### PR DESCRIPTION
Fixes #4217.

The Elisp function `string-lines` is not available prior to Emacs version 28.1, so its presence breaks compatibility with earlier versions.