### PR TITLE
lsp-terraform: fix typo in make-tf-module call

### DIFF
--- a/clients/lsp-terraform.el
+++ b/clients/lsp-terraform.el
@@ -305,7 +305,7 @@ This is a synchronous action."
 (lsp-defun construct-tf-module ((&terraform-ls:Module :name :docs-link :version :source-type :dependent-modules))
   "Construct `TF-MODULE' using MODULE."
   (make-tf-module :name name
-                  :doc-link docs-link
+                  :docs-link docs-link
                   :version version
                   :source-type source-type
                   :dependent-modules dependent-modules))


### PR DESCRIPTION
Before this change, I could not use`lsp-mode` in a terraform buffer. For more details in the issue, see #4222 

Closes: #4222