### PR TITLE
Fix typo (`lsp-text-executable` -> `lsp-tex-executable`) in "adding languages" page

### DIFF
--- a/docs/page/adding-new-language.md
+++ b/docs/page/adding-new-language.md
@@ -92,8 +92,8 @@ client has been loaded.
 
 (lsp-register-client
  (make-lsp-client
-  ;; instead of `:new-connection (lsp-stdio-connection lsp-text-executable)` use
-  :new-connection (lsp-stdio-connection (lambda () lsp-text-executable))
+  ;; instead of `:new-connection (lsp-stdio-connection lsp-tex-executable)` use
+  :new-connection (lsp-stdio-connection (lambda () lsp-tex-executable))
   :activation-fn (lsp-activate-on "plaintex" "latex")
   :priority -1
   :server-id 'digestif))


### PR DESCRIPTION
This MR fixes a typo in an example which can be seen here: https://emacs-lsp.github.io/lsp-mode/page/adding-new-language/

The current example reads:
```lisp
(defcustom lsp-tex-executable "digestif"
...

;; instead of `:new-connection (lsp-stdio-connection lsp-text-executable)` use
:new-connection (lsp-stdio-connection (lambda () lsp-text-executable))
```

Muscle memory probably lead `tex` to be written as `text`