### PR TITLE
Fix credo language server command issues

### DIFF
--- a/clients/lsp-credo.el
+++ b/clients/lsp-credo.el
@@ -41,7 +41,7 @@
   :group 'lsp-credo
   :package-version '(lsp-mode . "8.0.1"))
 
-(defcustom lsp-credo-version "0.1.2"
+(defcustom lsp-credo-version "0.3.0"
   "Credo language server version to download.
 It has to be set before `lsp-credo.el' is loaded and it has to
 be available here: https://github.com/elixir-tools/credo-language-server/releases."

--- a/clients/lsp-credo.el
+++ b/clients/lsp-credo.el
@@ -70,10 +70,7 @@ be available here: https://github.com/elixir-tools/credo-language-server/release
 (lsp-dependency
  'credo-language-server
  `(:download :url lsp-credo-download-url
-             :store-path ,(f-join lsp-server-install-dir
-                                  "credo-language-server"
-                                  "credo-language-server")
-             :binary-path lsp-credo-binary-path
+             :store-path lsp-credo-binary-path
              :set-executable? t))
 
 (lsp-register-client

--- a/clients/lsp-credo.el
+++ b/clients/lsp-credo.el
@@ -32,7 +32,10 @@
   :link '(url-link "https://github.com/elixir-tools/credo-language-server")
   :package-version '(lsp-mode . "8.0.1"))
 
-(defcustom lsp-credo-command '("credo-language-server" "--stdio=true")
+(defcustom lsp-credo-command
+  `(,(f-join lsp-server-install-dir "credo-language-server"
+            "credo-language-server")
+    "--stdio=true")
   "The command that starts credo-language-server."
   :type '(repeat :tag "List of string values" string)
   :group 'lsp-credo
@@ -75,7 +78,12 @@ be available here: https://github.com/elixir-tools/credo-language-server/release
 
 (lsp-register-client
  (make-lsp-client
-  :new-connection (lsp-stdio-connection lsp-credo-command)
+  :new-connection (lsp-stdio-connection
+                   (lambda ()
+                     `(,(or (executable-find
+                             (cl-first lsp-credo-command))
+                            (lsp-package-path 'credo-language-server))
+                       ,@(cl-rest lsp-credo-command))))
   :activation-fn (lsp-activate-on "elixir")
   :priority -1
   :add-on? t


### PR DESCRIPTION
The download did not work and command was incomplete. This fixes both. The minimum version also gets bumped to 3.0 as the new stable version. 