### PR TITLE
Bump the magik language server to 0.8.2

### DIFF
--- a/clients/lsp-magik.el
+++ b/clients/lsp-magik.el
@@ -34,7 +34,7 @@
   :tag "Lsp Magik"
   :package-version '(lsp-mode . "8.0.1"))
 
-(defcustom lsp-magik-version "0.8.1"
+(defcustom lsp-magik-version "0.8.2"
   "Version of LSP server."
   :type `string
   :group `lsp-magik


### PR DESCRIPTION
Bump the magik language server to 0.8.2.

Release: https://github.com/StevenLooman/magik-tools/releases/tag/0.8.2 Change log: 
https://github.com/StevenLooman/magik-tools/blob/cb457a34cb37b890a8ce73154b09d9e08628b039/CHANGES.md?plain=1#L5