### PR TITLE
Add buf/protobuf support via bufls

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -98,6 +98,7 @@
   * Add Move language server support.
   * Add mdx support using [[https://github.com/mdx-js/mdx-analyzer/tree/main/packages/language-server][mdx-language-server]]
   * Add golangci-lint add-on client using [[https://github.com/nametake/golangci-lint-langserver][golangci-lint-langserver]]
+  * Add buf/protobuf support via [[https://github.com/bufbuild/buf-language-server][bufls]]
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-bufls.el
+++ b/clients/lsp-bufls.el
@@ -1,0 +1,69 @@
+;;; lsp-bufls.el --- bufls-langserver Client settings -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2023  Jim Myhrberg
+
+;; Author: Jim Myhrberg
+;; Keywords: lsp, protobuf, buf, bufls
+
+;; This file is not part of GNU Emacs
+
+;;; License:
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; lsp-bufls client
+
+;;; Code:
+
+(require 'lsp-mode)
+(require 'lsp-go)
+
+(defgroup lsp-bufls nil
+  "Configuration options for lsp-bufls."
+  :group 'lsp-mode
+  :link '(url-lint "https://github.com/bufbuild/buf-language-server")
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-bufls-args nil
+  "Arguments to pass to bufls serve."
+  :type '(repeat string)
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-bufls-path "bufls"
+  "Command to run bufls."
+  :type 'string
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defun lsp-bufls-server--stdio-command ()
+  "Return the command and args to start bufls-langserver."
+  (let ((args (list lsp-bufls-path "serve")))
+    (when (and (listp lsp-bufls-args)
+               (> (length lsp-bufls-args) 0))
+      (setq args (append args lsp-bufls-args)))
+    args))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   #'lsp-bufls-server--stdio-command)
+                  :activation-fn (lsp-activate-on "protobuf")
+                  :language-id "protobuf"
+                  :priority 0
+                  :server-id 'bufls))
+
+(lsp-consistency-check lsp-bufls)
+
+(provide 'lsp-bufls)
+;;; lsp-bufls.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -71,6 +71,15 @@
     "debugger": "Not available"
   },
   {
+    "name": "bufls",
+    "full-name": "buf-language-server",
+    "server-name": "bufls",
+    "server-url": "https://github.com/bufbuild/buf-language-server",
+    "installation": "go install github.com/bufbuild/buf-language-server/cmd/bufls@latest",
+    "installation-url": "https://github.com/bufbuild/buf-language-server#usage",
+    "debugger": "Not available"
+  },
+  {
     "name": "camel",
     "full-name": "CAMEL",
     "server-name": "camells",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -175,7 +175,7 @@ As defined by the Language Server Protocol 3.16."
 
 (defcustom lsp-client-packages
   '( ccls lsp-actionscript lsp-ada lsp-angular lsp-ansible lsp-awk lsp-astro lsp-bash
-     lsp-beancount lsp-clangd lsp-clojure lsp-cmake lsp-credo lsp-crystal lsp-csharp lsp-css
+     lsp-beancount lsp-bufls lsp-clangd lsp-clojure lsp-cmake lsp-credo lsp-crystal lsp-csharp lsp-css
      lsp-cypher lsp-d lsp-dart lsp-dhall lsp-docker lsp-dockerfile lsp-elm lsp-elixir lsp-emmet
      lsp-erlang lsp-eslint lsp-fortran lsp-fsharp lsp-gdscript lsp-go lsp-golangci-lint lsp-gleam
      lsp-glsl lsp-graphql lsp-hack lsp-grammarly lsp-groovy lsp-haskell lsp-haxe
@@ -937,7 +937,8 @@ Changes take effect only when a new session is started."
     (shader-mode . "shaderlab")
     (wgsl-mode . "wgsl")
     (jq-mode . "jq")
-    (jq-ts-mode . "jq"))
+    (jq-ts-mode . "jq")
+    (protobuf-mode . "protobuf"))
   "Language id configuration.")
 
 (defvar lsp--last-active-workspaces nil


### PR DESCRIPTION
While [`bufls`](https://github.com/bufbuild/buf-language-server) is pretty basic, it's still pretty nice to have the basic features it currently provides available when working on protobuf files. And hopefully it will only get better over time.

I have personally been using this client for around 2 months without issue, and generally find it quite useful.

Here's a link to it in the vendor directory of my Emacs config:
https://github.com/jimeh/.emacs.d/blob/v0.8.46/vendor/lsp-bufls/lsp-bufls.el

I'm more than happy to address any feedback :)