### PR TITLE
Fix golangci-lint client on Emacs 27

### DIFF
--- a/clients/lsp-golangci-lint.el
+++ b/clients/lsp-golangci-lint.el
@@ -112,7 +112,7 @@
   "Return the command and args to start golangci-lint-langserver."
   (let ((args (list lsp-golangci-lint-server-path)))
     (when (and (listp lsp-golangci-lint-server-args)
-               (length> lsp-golangci-lint-server-args 0))
+               (> (length lsp-golangci-lint-server-args) 0))
       (setq args (append args lsp-golangci-lint-server-args)))
     (when lsp-golangci-lint-server-debug
       (setq args (append args '("-debug"))))
@@ -138,7 +138,7 @@
                         when condition
                         append (if value (list flag value) (list flag)))))
     (when (and (listp lsp-golangci-lint-run-args)
-               (length> lsp-golangci-lint-run-args 0))
+               (> (length lsp-golangci-lint-run-args) 0))
       (setq args (append args lsp-golangci-lint-run-args)))
     args))
 

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -315,6 +315,7 @@
     "full-name": "golangci-lint",
     "server-name": "golangci-lint-server",
     "server-url": "https://github.com/nametake/golangci-lint-langserver",
+    "installation": "go install github.com/nametake/golangci-lint-langserver@latest",
     "installation-url": "https://github.com/nametake/golangci-lint-langserver#installation",
     "debugger": "Not available"
   },


### PR DESCRIPTION
The `length>` function is not available in Emacs 27.x, so replace it with separate uses of `>` and `length`.

Also add installation command for `golangci-lint-server` to `docs/lsp-clients.json`.