### PR TITLE
Add envrc-file-mode support to lsp-bash

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,7 +15,7 @@
   * Add support for clojure-ts-mode in clojure-lsp client
   * terraform-ls now supports prefill required fields and the ability to validate on save.
   * Ignore =.terraform= and =.terragrunt-cache= directories
-  * ~lsp-bash~ now supports ~bash-ts-mode~ and ~ebuild-mode~
+  * ~lsp-bash~ now supports ~bash-ts-mode~, ~ebuild-mode~ and ~envrc-file-mode~
   * ~lsp-ruby-syntax-tree~, ~lsp-solargraph~, ~lsp-sorbet~, ~lsp-steep~, and ~lsp-typeprof~ now support ~ruby-ts-mode~
   * Drop support for emacs 26.1 and 26.2
   * Added support for ~textDocument/linkedEditingRange~ via

--- a/clients/lsp-bash.el
+++ b/clients/lsp-bash.el
@@ -68,13 +68,13 @@ See instructions at https://marketplace.visualstudio.com/items?itemName=mads-har
   "Check whether `sh-shell' is sh or bash.
 
 This prevents the Bash server from being turned on in zsh files."
-  (and (memq major-mode '(sh-mode bash-ts-mode ebuild-mode))
+  (and (memq major-mode '(sh-mode bash-ts-mode ebuild-mode envrc-file-mode))
        (memq sh-shell '(sh bash))))
 
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection #'lsp-bash--bash-ls-server-command)
-  :major-modes '(sh-mode bash-ts-mode ebuild-mode)
+  :major-modes '(sh-mode bash-ts-mode ebuild-mode envrc-file-mode)
   :priority -1
   :activation-fn #'lsp-bash-check-sh-shell
   :environment-fn (lambda ()

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -799,6 +799,7 @@ Changes take effect only when a new session is started."
     (bash-ts-mode . "shellscript")
     (ebuild-mode . "shellscript")
     (pkgbuild-mode . "shellscript")
+    (envrc-file-mode . "shellscript")
     (scala-mode . "scala")
     (scala-ts-mode . "scala")
     (julia-mode . "julia")


### PR DESCRIPTION
`envrc-file-mode` is a major mode derived from `sh-mode`. It comes with the [envrc package](https://github.com/purcell/envrc) and it is used to edit `.envrc` project file.