### PR TITLE
Add interactive function for viewing WGSL syntax tree

### DIFF
--- a/clients/lsp-wgsl.el
+++ b/clients/lsp-wgsl.el
@@ -149,6 +149,23 @@
          (font-lock-mode))
        (switch-to-buffer buffer)))))
 
+(defun lsp-wgsl-syntax-tree ()
+  "Gets the syntax tree of the current buffer."
+  (interactive)
+  (lsp-request-async
+   "wgsl-analyzer/syntaxTree"
+   (list :textDocument (list :uri (lsp--buffer-uri))
+         :range (if (use-region-p)
+                    (lsp--region-to-range (region-beginning) (region-end))
+                  (lsp--region-to-range (point-min) (point-max))))
+   (lambda (syntax-tree)
+     (let ((buffer (get-buffer-create (format "*WGSL-syntax-tree %s*" (lsp--buffer-uri)))))
+       (with-current-buffer buffer
+         (setq-local buffer-read-only nil)
+         (erase-buffer)
+         (insert syntax-tree)
+         (read-only-mode))
+       (switch-to-buffer buffer)))))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection


### PR DESCRIPTION
When implementing the WGSL support the first time, I was not familiar with the syntax tree functionality and what it could be used for. Seems like other language servers like rust-analyzer has the same functionality and presents it in plain text to the user. Doing the same for wgsl. 


This implements support for the custom `wgsl-analyzer/syntaxTree` operation that wgsl-analyzer supports. 