### PR TITLE
Add option to install language servers using Cargo

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 8.0.1
+  * Add support for installing lsp dependencies via Cargo.
   * Fix tramp support issues (see [[https://github.com/emacs-lsp/lsp-mode/pull/4204][#4204]])
   * Add Cypher support.
   * Add Mojo 🔥 support

--- a/clients/lsp-wgsl.el
+++ b/clients/lsp-wgsl.el
@@ -167,10 +167,18 @@
          (read-only-mode))
        (switch-to-buffer buffer)))))
 
+
+(lsp-dependency 'wgsl-analyzer
+                '(:system lsp-wgsl-server-command)
+                '(:cargo :package "wgsl_analyzer"
+                         :path "wgsl_analyzer"
+                         :git "https://github.com/wgsl-analyzer/wgsl-analyzer"))
+
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection
                                    (lambda ()
-                                     lsp-wgsl-server-command))
+                                     (or (lsp-package-path 'wgsl-analyzer)
+                                         lsp-wgsl-server-command)))
                   :initialized-fn (lambda (workspace)
                                     (with-lsp-workspace workspace
                                       ;; wgsl-analyzer handles configuration in a VERY non-standard way
@@ -178,6 +186,9 @@
                                       (lsp--set-configuration '())))
                   :request-handlers (lsp-ht ("wgsl-analyzer/requestConfiguration" #'lsp-wgsl--send-configuration))
                   :activation-fn (lsp-activate-on "wgsl")
+                  :download-server-fn (lambda (_client callback error-callback _update?)
+                                        (lsp-package-ensure 'wgsl-analyzer
+                                                            callback error-callback))
                   :priority -1
                   :server-id 'wgsl-analyzer))
 


### PR DESCRIPTION
More and more software is developed with Rust, and it is not irregular these days that some language servers are distributed with Cargo. Adding the option to install automatically using Cargo makes a lot of sense in my view. Added a quick example for WGSL where we also install directly from a git repo. Some of the code is obviously inspired by the NPM package installation.

Also added a filter on `nil` values in  `lsp-async-start-process`. In my view, this makes the function more robust, and we can do handling like in the cargo logic (e.g, only sending git options when they are given).


Probably not perfect, so looking forward to hearing about possible improvements 🙂 Feel free to discard if this is not something that is wanted for lsp-mode. I understand if this is out of scope, though I find it really handy to have 🙂 