### PR TITLE
[Bugfix] Add xref 1.6.3 as a dependency

### DIFF
--- a/docs/lsp-doc.el
+++ b/docs/lsp-doc.el
@@ -1,7 +1,7 @@
 ;;; lsp-doc.el --- LSP doc generator -*- lexical-binding: t; -*-
 
 ;; Keywords: languages, tool
-;; Package-Requires: ((emacs "26.1") (lsp-mode "7.0.1") (emacs "26.1") (dash "2.18.0") (f "0.20.0") (ht "2.3") (spinner "1.7.3") (markdown-mode "2.3") (lv "0"))
+;; Package-Requires: ((emacs "26.1") (lsp-mode "7.0.1") (emacs "26.1") (dash "2.18.0") (f "0.20.0") (ht "2.3") (spinner "1.7.3") (markdown-mode "2.3") (lv "0") (xref "1.6.3"))
 ;; Version: 8.0.0
 
 ;; URL: https://github.com/emacs-lsp/lsp-mode


### PR DESCRIPTION
The `xref-auto-jump` support added in https://github.com/emacs-lsp/lsp-mode/pull/4057 assumes that the `xref-auto-jump-to-first-xref` variable is present.  However, this variable isn't available by default until emacs 28.0 (commit [`1be8bfae6`](https://github.com/emacs-mirror/emacs/commit/1be8bfae6b1f9a0291a0be36fef0417a14657fc3)). For earlier versions of emacs, this requires installing a newer, non-default version version of `xref`.  Since `lsp-mode` supports emacs 26.1 and up, the addition `xref` dependency should be explicitly stated.

Fixes https://github.com/emacs-lsp/lsp-mode/issues/4063.