### PR TITLE
Add missing major-modes declaration for lsp-wgsl

### DIFF
--- a/clients/lsp-wgsl.el
+++ b/clients/lsp-wgsl.el
@@ -185,6 +185,7 @@
                                       ;; https://github.com/wgsl-analyzer/wgsl-analyzer/issues/77
                                       (lsp--set-configuration '())))
                   :request-handlers (lsp-ht ("wgsl-analyzer/requestConfiguration" #'lsp-wgsl--send-configuration))
+                  :major-modes '(wgsl-mode)
                   :activation-fn (lsp-activate-on "wgsl")
                   :download-server-fn (lambda (_client callback error-callback _update?)
                                         (lsp-package-ensure 'wgsl-analyzer


### PR DESCRIPTION
Seems like the major-mode declaration is missing for wgsl. First time installing lsp-wgsl from melpa instead of local evaluation (eval buffer etc.), so let's blame that for me not noticing sooner 😛 

Got the following error when trying it directly from lsp-mode in melpa:
```text
LSP :: There are no language servers supporting current mode `wgsl-mode' registered with `lsp-mode'.
This issue might be caused by:
1. The language you are trying to use does not have built-in support in `lsp-mode'. You must install the required support manually. Examples of this are `lsp-java' or `lsp-metals'.
2. The language server that you expect to run is not configured to run for major mode `wgsl-mode'. You may check that by checking the `:major-modes' that are passed to `lsp-register-client'.
3. `lsp-mode' doesn't have any integration for the language behind `wgsl-mode'. Refer to https://emacs-lsp.github.io/lsp-mode/page/languages and https://langserver.org/ .
4. You are over `tramp'. In this case follow https://emacs-lsp.github.io/lsp-mode/page/remote/.
5. You have disabled the `lsp-mode' clients for that file. (Check `lsp-enabled-clients' and `lsp-disabled-clients').
You can customize `lsp-warn-no-matched-clients' to disable this message.
```