### PR TITLE
Add html-ts-mode to `lsp-language-id-configuration` alist

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -840,6 +840,7 @@ Changes take effect only when a new session is started."
     (cuda-mode . "cuda")
     (objc-mode . "objective-c")
     (html-mode . "html")
+    (html-ts-mode . "html")
     (sgml-mode . "html")
     (mhtml-mode . "html")
     (mint-mode . "mint")


### PR DESCRIPTION
html-ls is currently not automatically associated with treesit's `html-ts-mode`. This tiny PR just adds it to the `lsp-langauge-id-configuration` alist.