### PR TITLE
yield thread while waiting for native json rpc

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3296,7 +3296,9 @@ If NO-WAIT is non-nil send the request as notification."
                                :cancel-token :sync-request)
             (while (not (or resp-error resp-result))
               (if (functionp 'json-rpc-connection)
-                  (catch 'lsp-done (sit-for 0.01))
+                  (catch 'lsp-done
+                    (thread-yield)
+                    (sit-for 0.01))
                 (catch 'lsp-done
                   (accept-process-output
                    nil


### PR DESCRIPTION
sit-for may not yield if there's input pending

it seems to solve https://github.com/emacs-lsp/emacs/issues/12