### PR TITLE
Move common test utilities into a separate file.

### DIFF
--- a/test/lsp-benchmarks.el
+++ b/test/lsp-benchmarks.el
@@ -76,4 +76,4 @@
                  lsp-benchmark-data))
     (garbage-collect)))
 
-(provide 'lsp-benchmarks)
+;;; lsp-benchmarks.el ends here

--- a/test/lsp-clangd-test.el
+++ b/test/lsp-clangd-test.el
@@ -23,7 +23,7 @@
 
 (require 'ert)
 (require 'lsp-clangd)
-(require 'lsp-integration-test)
+(require 'lsp-test-utils)
 
 (ert-deftest lsp-clangd-extract-signature-on-hover ()
   (should (string= (lsp-clients-extract-signature-on-hover

--- a/test/lsp-completion-test.el
+++ b/test/lsp-completion-test.el
@@ -129,5 +129,4 @@
       (should (equal (do-test-trigger-kind t t) 2))) ;; and the session is the same: expect a new trigger-character completion
     ))
 
-(provide 'lsp-completion-test)
 ;;; lsp-completion-test.el ends here

--- a/test/lsp-file-watch-test.el
+++ b/test/lsp-file-watch-test.el
@@ -368,5 +368,4 @@
     (should (null lsp--test-events))
     (should (ht-empty? (lsp-session-watches)))))
 
-(provide 'lsp-file-watch-test)
 ;;; lsp-file-watch-test.el ends here

--- a/test/lsp-integration-test.el
+++ b/test/lsp-integration-test.el
@@ -39,18 +39,6 @@
 
 (defconst lsp-test-location (file-name-directory (or load-file-name buffer-file-name)))
 
-(defun lsp-test--wait-for (form &optional d)
-  (--doto (or d (deferred:new #'identity))
-    (run-with-timer
-     0.001 nil
-     (lambda ()
-       (if-let ((result (eval form)))
-           (deferred:callback-post it result)
-         (lsp-test--wait-for form it))))))
-
-(defmacro lsp-test-wait (form)
-  `(lsp-test--wait-for '(progn ,form)))
-
 (defun lsp-def-request-async (method params &rest args)
   (--doto (deferred:new #'identity)
     (apply #'lsp-request-async method params (-partial #'deferred:callback-post it)
@@ -671,5 +659,4 @@
             (replace-match "foobar")))
         (deferred:sync!))))
 
-(provide 'lsp-integration-test)
 ;;; lsp-integration-test.el ends here

--- a/test/lsp-mode-test.el
+++ b/test/lsp-mode-test.el
@@ -175,5 +175,4 @@
                        "textDocument/hover")))
              2)))
 
-(provide 'lsp-mode-test)
 ;;; lsp-mode-test.el ends here

--- a/test/lsp-protocol-test.el
+++ b/test/lsp-protocol-test.el
@@ -167,5 +167,4 @@
     (lsp-put input :import_for_trait_assoc_item :json-false)
     (should (eq (lsp-get input :import_for_trait_assoc_item) :json-false))))
 
-(provide 'lsp-protocol-test)
 ;;; lsp-protocol-test.el ends here

--- a/test/lsp-test-utils.el
+++ b/test/lsp-test-utils.el
@@ -1,0 +1,42 @@
+;;; lsp-test-utils.el --- unit test utilities -*- lexical-binding: t -*-
+
+;; Copyright (C) emacs-lsp maintainers
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This file contains definitions required by other test units.  Reusable
+;; utilities like functions, macros, and customizables should prefer to be
+;; defined here to avoid having to load a unit test directly, because Emacs
+;; checks for reused ERT test names since 29.1, which may also be caused by
+;; loading the same test unit multiple times.  See also discussion in
+;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=66782
+
+;;; Code:
+
+(defun lsp-test--wait-for (form &optional d)
+  (--doto (or d (deferred:new #'identity))
+    (run-with-timer
+     0.001 nil
+     (lambda ()
+       (if-let ((result (eval form)))
+           (deferred:callback-post it result)
+         (lsp-test--wait-for form it))))))
+
+(defmacro lsp-test-wait (form)
+  `(lsp-test--wait-for '(progn ,form)))
+
+(provide 'lsp-test-utils)
+;;; lsp-test-utils.el ends here


### PR DESCRIPTION
* This avoids loading a ERT test utility directly and causing ERT test redefined error.

* Also drop "provide" from test units to avoid loading an ERT test unit directly.

* More details
  - https://debbugs.gnu.org/cgi/bugreport.cgi?bug=66782
  - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1052939

* It should be encouraged to move more common utility to the lsp-test-utils.el file.  It's not causing immediate issues so not doing this in this PR.