### PR TITLE
Nix Tree-Sitter tweak

### DIFF
--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -39,7 +39,7 @@
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-nix-rnix-server-path))
-                  :major-modes '(nix-mode)
+                  :major-modes '(nix-mode nix-ts-mode)
                   :server-id 'rnix-lsp
                   :priority -1))
 
@@ -79,7 +79,7 @@
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-nix-nil-server-path))
-                  :major-modes '(nix-mode)
+                  :major-modes '(nix-mode nix-ts-mode)
                   :initialized-fn (lambda (workspace)
                     (with-lsp-workspace workspace
                       (lsp--set-configuration

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -408,6 +408,8 @@ the server has requested that."
     "[/\\\\]\\.terraform\\'"
     "[/\\\\]\\.terragrunt-cache\\'"
     ;; nix-direnv
+    "[/\\\\]\\result"
+    "[/\\\\]\\result-bin"
     "[/\\\\]\\.direnv\\'")
   "List of regexps matching directory paths which won't be monitored when
 creating file watches. Customization of this variable is only honored at

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -914,6 +914,7 @@ Changes take effect only when a new session is started."
     (robot-mode . "robot")
     (racket-mode . "racket")
     (nix-mode . "nix")
+    (nix-ts-mode . "Nix")
     (prolog-mode . "prolog")
     (vala-mode . "vala")
     (actionscript-mode . "actionscript")


### PR DESCRIPTION
And drive-by fixup to ignore nix result and result-bin folders, usual outputs for nix builds.