### PR TITLE
suggestion: use `nixd` language server, priority over `rnix`

### DIFF
--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -41,6 +41,23 @@
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-nix-rnix-server-path))
                   :major-modes '(nix-mode)
                   :server-id 'rnix-lsp
+                  :priority -2))
+
+(defgroup lsp-nix-nixd nil
+  "LSP support for Nix, using nixd language server."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/nix-community/nixd"))
+
+(defcustom lsp-nix-nixd-server-path "nixd"
+  "Executable path for the server."
+  :group 'lsp-nix-nixd
+  :type 'string
+  :package-version '(lsp-mode . "8.0.0"))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-nix-nixd-server-path))
+                  :major-modes '(nix-mode)
+                  :server-id 'nixd-lsp
                   :priority -1))
 
 (defgroup lsp-nix-nil nil

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -614,10 +614,18 @@
   },
   {
     "name": "nix",
-    "full-name": "Nix",
+    "full-name": "Nix (nixd language server)",
+    "server-name": "nixd",
+    "server-url": "https://github.com/nix-community/nixd",
+    "installation": "nix profile install github:nixos/nixpkgs#nixd",
+    "debugger": "Not available"
+  },
+  {
+    "name": "nix",
+    "full-name": "Nix (rnix language server)",
     "server-name": "rnix-lsp",
     "server-url": "https://github.com/nix-community/rnix-lsp",
-    "installation": "nix-env -i rnix-lsp",
+    "installation": "nix profile install github:nixos/nixpkgs#rnix-lsp",
     "debugger": "Not available"
   },
   {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
     - MSSQL: https://emacs-lsp.github.io/lsp-mssql
     - Nginx: page/lsp-nginx.md
     - Nim: page/lsp-nim.md
+    - Nix (nixd-lsp): page/lsp-nix.md
     - Nix (rnix-lsp): page/lsp-nix.md
     - Nix (nil): page/lsp-nix-nil.md
     - OCaml (ocaml-lsp): page/lsp-ocaml-lsp-server.md


### PR DESCRIPTION
`nixd` may be more actively maintained than `rnix`
https://github.com/nix-community/nixd
https://github.com/nix-community/rnix-lsp

request: https://github.com/emacs-lsp/lsp-mode/issues/4168

I have tested this very briefly by editing a Nix Flake with Emacs. `nixd` starts fine and `lsp-mode` seems to be fine. `imenu` works.


I manually installed `nixd` https://github.com/nix-community/nixd/blob/main/nixd/docs/user-guide.md
```
nix profile install github:nixos/nixpkgs#nixd
```
I have not tested any `lsp-mode` automated installation of `nixd`