### PR TITLE
fix LSP Nix docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,8 +108,8 @@ nav:
     - MSSQL: https://emacs-lsp.github.io/lsp-mssql
     - Nginx: page/lsp-nginx.md
     - Nim: page/lsp-nim.md
-    - Nix (nixd-lsp): page/lsp-nix.md
-    - Nix (rnix-lsp): page/lsp-nix.md
+    - Nix (nixd-lsp): page/lsp-nix-nixd.md
+    - Nix (rnix-lsp): page/lsp-nix-rnix.md
     - Nix (nil): page/lsp-nix-nil.md
     - OCaml (ocaml-lsp): page/lsp-ocaml-lsp-server.md
     - OpenSCAD: page/lsp-openscad.md


### PR DESCRIPTION
Both `rnix` and `nixd` point to https://emacs-lsp.github.io/lsp-mode/page/lsp-nix/ right now, my mistake. This should fix it.