### PR TITLE
Bump elixir-ls version to v0.19.0

### DIFF
--- a/clients/lsp-elixir.el
+++ b/clients/lsp-elixir.el
@@ -105,7 +105,7 @@ Leave as default to let `executable-find' search for it."
   :type '(repeat string)
   :package-version '(lsp-mode . "8.0.0"))
 
-(defcustom lsp-elixir-ls-version "v0.16.0"
+(defcustom lsp-elixir-ls-version "v0.20.0"
   "Elixir-Ls version to download.
 It has to be set before `lsp-elixir.el' is loaded and it has to
 be available here: https://github.com/elixir-lsp/elixir-ls/releases/"
@@ -116,7 +116,7 @@ be available here: https://github.com/elixir-lsp/elixir-ls/releases/"
 (defcustom lsp-elixir-ls-download-url
   (format "https://github.com/elixir-lsp/elixir-ls/releases/download/%1$s/elixir-ls-%1$s.zip"
           lsp-elixir-ls-version)
-  "Automatic download url for elixir-ls"
+  "Automatic download url for elixir-ls."
   :type 'string
   :group 'lsp-elixir
   :package-version '(lsp-mode . "8.0.1"))


### PR DESCRIPTION
There are quite a few stability improvements and better support for Elixir 1.16 in the new version.