### PR TITLE
ci: bump: GitHub Actions setup-cmake and setup-python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Setup cmake
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-      uses: jwlawson/actions-setup-cmake@v1.4
+      uses: jwlawson/actions-setup-cmake@v1.14
       with:
         cmake-version: '3.18.x'
 
@@ -49,7 +49,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
       run: "cmake --version"
       
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.9"
         architecture: "x64"


### PR DESCRIPTION
What
===
I Bump GitHub Actions setup-cmake and setup-python.

Why
===
This may be due to the use of old Actions, or because an unsupported version of Node.js is being used. Numerous warnings are being generated.
Security support has expired, which may cause problems, even though it is only used for CI. In any case, it is best to remove the warnings.