### PR TITLE
ci: The version of actions/labeler is fixed at 4

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,7 +6,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
Until now, the main had been specified, so it was automatically raised to the latest version, 5. And as a link, the structure of the configuration file has changed significantly in v5. [Release v5.0.0 · actions/labeler](https://github.com/actions/labeler/releases/tag/v5.0.0) I think it would be preferable to update the file accordingly, but since I am not familiar with the previous structure and I don't think it is healthy for CI to always fail, I will fix it at 4 for the time being. We will consider moving to v5 later.