### PR TITLE
Provide better Ada semantic highlighting defaults.

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -104,6 +104,7 @@
   * Add Autotools support
   * Add Jsonnet support
   * Add support for ~ada-ts-mode~.
+  * Allow customizing Ada semantic token and token modifier faces.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-ada.el
+++ b/clients/lsp-ada.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'lsp-mode)
+(require 'lsp-semantic-tokens)
 
 (defgroup lsp-ada nil
   "Settings for Ada Language Server."
@@ -68,6 +69,31 @@
   :group 'lsp-ada
   :package-version '(lsp-mode "8.0.1"))
 
+(defcustom lsp-ada-semantic-token-face-overrides
+  '(("namespace" . default)
+    ("modifier"  . lsp-face-semhl-keyword))
+  "Semantic token face overrides to be applied."
+  :type '(alist :key-type string
+                :value-type (choice (face  :tag "Face")
+                                    (const :tag "No Face" nil)))
+  :group 'lsp-ada
+  :package-version '(lsp-mode "8.0.1"))
+
+(defcustom lsp-ada-semantic-token-modifier-face-overrides
+  '(("declaration")
+    ("definition")
+    ("implementation")
+    ("static")
+    ("modification")
+    ("documentation")
+    ("defaultLibrary"))
+  "Semantic token modifier face overrides to be applied."
+  :type '(alist :key-type string
+                :value-type (choice (face  :tag "Face")
+                                    (const :tag "No Face" nil)))
+  :group 'lsp-ada
+  :package-version '(lsp-mode "8.0.1"))
+
 (defun lsp-ada--environment ()
   "Add environmental variables if needed."
   (let ((project-root (lsp-workspace-root)))
@@ -96,6 +122,8 @@
                                     (with-lsp-workspace workspace
                                       (lsp--set-configuration
                                        (lsp-configuration-section "ada"))))
+                  :semantic-tokens-faces-overrides `( :types ,lsp-ada-semantic-token-face-overrides
+                                                      :modifiers ,lsp-ada-semantic-token-modifier-face-overrides)
                   :server-id 'ada-ls
                   :synchronize-sections '("ada")
                   :environment-fn 'lsp-ada--environment))


### PR DESCRIPTION
The Ada Language Server provides numerous semantic token modifiers that can be used, but most of the modifiers should not affect the original base token face.  This change provides a mechanism to customize the faces associated with semantic tokens and modifiers that are applied to the buffer, while also providing better defaults for out-of-the-box usage.