### PR TITLE
Prefer buffer's major mode for rendering strings.

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5516,10 +5516,11 @@ In addition, each can have property:
   "Render STR using `major-mode' corresponding to LANGUAGE.
 When language is nil render as markup if `markdown-mode' is loaded."
   (setq str (s-replace "\r" "" (or str "")))
-  (if-let ((mode (-some (-lambda ((mode . lang))
-                          (when (and (equal lang language) (functionp mode))
-                            mode))
-                        lsp-language-id-configuration)))
+  (if-let* ((modes (-keep (-lambda ((mode . lang))
+                            (when (and (equal lang language) (functionp mode))
+                              mode))
+                          lsp-language-id-configuration))
+            (mode (car (or (member major-mode modes) modes))))
       (lsp--fontlock-with-mode str mode)
     str))
 


### PR DESCRIPTION
Currently, when multiple major modes exist and are available for a language (e.g., c-mode and c-ts-mode), the major mode used to render strings is determined by the ordering of these modes within `lsp-language-id-configuration'.  This ordering doesn't necessarily reflect the preference of the user.

This change alters this behavior by preferring to render strings, whose language matches that of the current buffer, with the same major mode as the buffer.  When the string's language is different from the buffer, the behavior falls back to selecting the first major mode matching the language from `lsp-language-id-configuration'.