### PR TITLE
lsp.el: fix "no lexical binding" warning

### DIFF
--- a/lsp.el
+++ b/lsp.el
@@ -1,4 +1,4 @@
-;; The code was moved into lsp-mode.el. This file is kept only for backward compatibility.
+;; The code was moved into lsp-mode.el. This file is kept only for backward compatibility. -*- lexical-binding: t -*-
 (require 'lsp-mode)
 
 ;; (warn "Replace (require 'lsp) with (require 'lsp-mode)")


### PR DESCRIPTION
Upstream Emacs has enabled warnings for `.el` files with no lexical-binding directive, so this file triggers a:

    In toplevel form:
    lsp.el:1:1: Warning: file has no ‘lexical-binding’ directive on its first line

Fix that.