### PR TITLE
fix: remove direct references to the node_modules directory

### DIFF
--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -790,18 +790,22 @@ name (e.g. `data' variable passed as `data' parameter)."
   (when-let ((workspace (lsp-find-workspace 'ts-ls (buffer-file-name))))
     (eq 'initialized (lsp--workspace-status workspace))))
 
-(defun lsp-clients-typescript-require-resolve ()
+(defun lsp-clients-typescript-require-resolve (&optional dir)
   "Get the location of the typescript.
 Use Node.js require.
 The node_modules directory structure is suspect
 and should be trusted as little as possible.
 If you call require in Node.js,
 it should take into account the various hooks.
-For example, yarn PnP."
-  (let ((output
-         (string-trim-right
-          (shell-command-to-string
-           "node -e \"console.log(require.resolve('typescript'))\""))))
+For example, yarn PnP.
+
+Optional argument DIR specifies the working directory
+to run the command in."
+  (let* ((default-directory (or dir default-directory))
+         (output
+          (string-trim-right
+           (shell-command-to-string
+            "node -e \"console.log(require.resolve('typescript'))\""))))
     (if (string-empty-p output)
         nil
       (f-parent output))))
@@ -811,7 +815,7 @@ For example, yarn PnP."
 because the lsp server may not recognize the tsserver executable file,
 e.g., on Windows."
   (if (memq system-type '(cygwin windows-nt ms-dos))
-      (f-join (f-parent (lsp-package-path 'typescript)) "node_modules" "typescript" "lib")
+      (lsp-clients-typescript-require-resolve (f-parent (lsp-package-path 'typescript)))
     (lsp-package-path 'typescript)))
 
 (defun lsp-clients-typescript-server-path ()

--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -800,7 +800,7 @@ it should take into account the various hooks."
   (let ((output
          (string-trim-right
           (shell-command-to-string
-           "node -e \"console.log(require.resolve('typescript'))\" 2>/dev/null"))))
+           "node -e \"console.log(require.resolve('typescript'))\""))))
     (if (string-empty-p output)
         nil
       (f-parent output))))

--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -790,13 +790,14 @@ name (e.g. `data' variable passed as `data' parameter)."
   (when-let ((workspace (lsp-find-workspace 'ts-ls (buffer-file-name))))
     (eq 'initialized (lsp--workspace-status workspace))))
 
-(defun lsp-clients-typescript-server-path-by-node-require ()
-  "Get the location of the typescript library.
-Use Node.js.
+(defun lsp-clients-typescript-require-resolve ()
+  "Get the location of the typescript.
+Use Node.js require.
 The node_modules directory structure is suspect
 and should be trusted as little as possible.
 If you call require in Node.js,
-it should take into account the various hooks."
+it should take into account the various hooks.
+For example, yarn PnP."
   (let ((output
          (string-trim-right
           (shell-command-to-string
@@ -807,7 +808,7 @@ it should take into account the various hooks."
 
 (defun lsp-clients-typescript-server-path ()
   (if lsp-clients-typescript-prefer-use-project-ts-server
-      (let ((server-path (lsp-clients-typescript-server-path-by-node-require)))
+      (let ((server-path (lsp-clients-typescript-require-resolve)))
         (if (f-exists? server-path)
             server-path
           (lsp-package-path 'typescript)))


### PR DESCRIPTION
Stop reading `node_modules` directly by the file system. The problem with this direct loading is that projects without `node_modules` in the top-level directory will not work at all. For example, when I develop with aws cdk,
I cut off the `cdk` or `infra` directory and create a new `package.json` and put `node_modules` there too, but in that case, the code before this modification will not work at all. I solved this problem by simply inserting an abstraction layer.

Relation.
* [lsp-javascript: supply correct path to tsserver for ts-ls by kiennq · Pull Request #4202 · emacs-lsp/lsp-mode](https://github.com/emacs-lsp/lsp-mode/pull/4202)
* [ts-ls: Wrong lsp-clients-typescript-server-path · Issue #4254 · emacs-lsp/lsp-mode](https://github.com/emacs-lsp/lsp-mode/issues/4254)