### PR TITLE
clojure: Add support for clojure-ts derived modes

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -106,6 +106,7 @@
   * Add support for ~ada-ts-mode~.
   * Allow customizing Ada semantic token and token modifier faces.
   * Add Hylang support.
+  * Add support for clojure-ts derived modes.
 ** Release 8.0.0
   * Add ~lsp-clients-angular-node-get-prefix-command~ to get the Angular server from another location which is still has ~/lib/node_modules~ in it.
   * Set ~lsp-clients-angular-language-server-command~ after the first connection to speed up subsequent connections.

--- a/clients/lsp-clojure.el
+++ b/clients/lsp-clojure.el
@@ -570,7 +570,8 @@ Focus on it if IGNORE-FOCUS? is nil."
   :new-connection (lsp-stdio-connection
                    #'lsp-clojure--build-command
                    #'lsp-clojure--build-command)
-  :major-modes '(clojure-mode clojurec-mode clojurescript-mode clojure-ts-mode)
+  :major-modes '(clojure-mode clojurec-mode clojurescript-mode
+                 clojure-ts-mode clojure-ts-clojurec-mode clojure-ts-clojurescript-mode)
   :library-folders-fn (lambda (_workspace) lsp-clojure-library-dirs)
   :uri-handlers (lsp-ht ("jar" #'lsp-clojure--file-in-jar))
   :action-handlers (lsp-ht ("code-lens-references" #'lsp-clojure--show-references))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -814,6 +814,8 @@ Changes take effect only when a new session is started."
     (clojurec-mode . "clojure")
     (clojurescript-mode . "clojurescript")
     (clojure-ts-mode . "clojure")
+    (clojure-ts-clojurec-mode . "clojure")
+    (clojure-ts-clojurescript-mode . "clojurescript")
     (java-mode . "java")
     (java-ts-mode . "java")
     (jdee-mode . "java")


### PR DESCRIPTION

- Follow up PR for https://github.com/emacs-lsp/lsp-mode/pull/4002
- See below for derived mode names
https://github.com/clojure-emacs/clojure-ts-mode/blob/928c8316c8bb7d0c7a3e93c2e0b9663668645647/clojure-ts-mode.el#L864