### PR TITLE
Add additional `%%%%` to fix doom-modeline presentation of percentage progress

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2164,8 +2164,8 @@ PARAMS - the data sent from WORKSPACE."
                    (-lambda ((&WorkDoneProgressBegin :message? :title :percentage?))
                      (concat (if percentage?
                                  (if (numberp percentage?)
-                                     (format "%.0f%%%% " percentage?)
-                                   (format "%s%%%% " percentage?))
+                                     (format "%.0f%%%%%%%% " percentage?)
+                                   (format "%s%%%%%%%% " percentage?))
                                "")
                              (or message? title)))
                    (ht-values tokens)


### PR DESCRIPTION
Without these additional %%%%s I see no %-sign or trailing space before the message in progress-status

![2024-02-25_10-33](https://github.com/emacs-lsp/lsp-mode/assets/22691943/8f84b779-7a43-4607-ac57-13f8231544c6)

With the additional %%%%, I get e.g. <nn>% <message> as expected.

![2024-02-25_10-36](https://github.com/emacs-lsp/lsp-mode/assets/22691943/1e990af9-654b-4023-8843-be4efc84664d)

The issue appears confined to the `lsp--progress-status` function and not any presentation logic downstream of it, since it is the `progress-status` value that is faulty. 