### PR TITLE
Use variable watcher with lsp-defcustom to support local variables.

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8551,16 +8551,24 @@ TBL - a hash table, PATHS is the path to the nested VALUE."
   "Defines `lsp-mode' server property."
   (declare (doc-string 3) (debug (name body))
            (indent defun))
-  (let ((path (plist-get args :lsp-path)))
+  (let ((path (plist-get args :lsp-path))
+        (setter (intern (concat (symbol-name symbol) "--set"))))
     (cl-remf args :lsp-path)
     `(progn
        (lsp-register-custom-settings
         (quote ((,path ,symbol ,(equal ''boolean (plist-get args :type))))))
 
-       (defcustom ,symbol ,standard ,doc
-         :set (lambda (sym val)
-                (lsp--set-custom-property sym val ,path))
-         ,@args))))
+       (defcustom ,symbol ,standard ,doc ,@args)
+
+       ;; Use a variable watcher instead of registering a `defcustom'
+       ;; setter since `hack-local-variables' is not aware of custom
+       ;; setters and won't invoke them.
+
+       (defun ,setter (sym val op _where)
+         (when (eq op 'set)
+           (lsp--set-custom-property sym val ,path)))
+
+       (add-variable-watcher ',symbol #',setter))))
 
 (defun lsp--set-custom-property (sym val path)
   (set sym val)


### PR DESCRIPTION
When custom variables are set locally using `hack-local-variables`, a custom variable's registered setter is not invoked.  To address this, a variable watcher is used instead to cause the setter to be invoked when the variable is updated.

Fixes #4337.