### PR TITLE
lsp-xml: Update JAR download URL

### DIFF
--- a/clients/lsp-xml.el
+++ b/clients/lsp-xml.el
@@ -287,9 +287,9 @@ The value for `enabled' can be always, never or onValidSchema."
   ("xml.catalogs" lsp-xml-catalogs)
   ("xml.trace.server" lsp-xml-trace-server)))
 
-(defconst lsp-xml-jar-version "0.21.0")
+(defconst lsp-xml-jar-version "0.27.0")
 
-(defconst lsp-xml-jar-name (format "org.eclipse.lemminx-%s-uber.jar" lsp-xml-jar-version))
+(defconst lsp-xml-jar-name (format "org.eclipse.lemminx-uber.jar" lsp-xml-jar-version))
 
 (defcustom lsp-xml-jar-file (f-join lsp-server-install-dir "xmlls" lsp-xml-jar-name)
   "Xml server jar command."
@@ -300,7 +300,7 @@ The value for `enabled' can be always, never or onValidSchema."
 
 (defcustom lsp-xml-jar-download-url
   (format
-   "https://repo.eclipse.org/content/repositories/lemminx-releases/org/eclipse/lemminx/org.eclipse.lemminx/%s/%s"
+   "https://download.eclipse.org/lemminx/releases/%s/%s"
    lsp-xml-jar-version
    lsp-xml-jar-name)
   "Automatic download url for lsp-xml."

--- a/clients/lsp-xml.el
+++ b/clients/lsp-xml.el
@@ -289,7 +289,7 @@ The value for `enabled' can be always, never or onValidSchema."
 
 (defconst lsp-xml-jar-version "0.27.0")
 
-(defconst lsp-xml-jar-name (format "org.eclipse.lemminx-uber.jar" lsp-xml-jar-version))
+(defconst lsp-xml-jar-name "org.eclipse.lemminx-uber.jar")
 
 (defcustom lsp-xml-jar-file (f-join lsp-server-install-dir "xmlls" lsp-xml-jar-name)
   "Xml server jar command."


### PR DESCRIPTION
It appears that the download URL for the lemminx JAR has changed. The existing URL fetches a page with a 403 Forbidden error, and therefore the downloaded JAR file is corrupt.

This PR:

- Updates the download URL 
- Updates the JAR version to the up-to-date release (0.27.0)