### PR TITLE
Fix client settings cannot be overridden

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8514,7 +8514,7 @@ session workspace folder configuration for the server."
         (funcall initialization-options-or-fn)
       initialization-options-or-fn)))
 
-(defvar lsp-client-settings (make-hash-table)
+(defvar lsp-client-settings (make-hash-table :test 'equal)
   "For internal use, any external users please use
   `lsp-register-custom-settings' function instead")
 

--- a/test/lsp-mode-test.el
+++ b/test/lsp-mode-test.el
@@ -175,4 +175,13 @@
                        "textDocument/hover")))
              2)))
 
+(ert-deftest lsp-test--register-custom-settings-override ()
+  "Test that custom settings can be overridden."
+  (clrhash lsp-client-settings)
+  (lsp-register-custom-settings '(("foo" "original value")))
+  (lsp-register-custom-settings '(("foo" "new value")))
+  (should (equal (gethash "foo" lsp-client-settings) '("new value"))))
+
+
+
 ;;; lsp-mode-test.el ends here


### PR DESCRIPTION
Create hash table with `:test 'equal` so that
`lsp-register-custom-settings` can be called again to override settings.

Resolves #4382