### PR TITLE
lsp-html - update to new version of custom data and add new configuration options

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,6 +1,6 @@
 * Changelog
 ** Unreleased 8.0.1
-  * Add new configuration options for lsp-html. Now able to toggle documentation hovers.
+  * Add new configuration options for lsp-html. Now able to toggle documentation hovers. Custom data is no longer experimental, and is now a vector.
   * Add support for RPM spec files
   * Add support for installing lsp dependencies via Cargo.
   * Fix tramp support issues (see [[https://github.com/emacs-lsp/lsp-mode/pull/4204][#4204]])

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 8.0.1
+  * Add new configuration options for lsp-html. Now able to toggle documentation hovers.
   * Add support for RPM spec files
   * Add support for installing lsp dependencies via Cargo.
   * Fix tramp support issues (see [[https://github.com/emacs-lsp/lsp-mode/pull/4204][#4204]])

--- a/clients/lsp-html.el
+++ b/clients/lsp-html.el
@@ -33,7 +33,8 @@
 
 (defcustom lsp-html-custom-data []
   "A list of JSON file paths that define custom tags, properties and other HTML
-syntax constructs. Only workspace folder setting will be read."
+syntax constructs. Only workspace folder setting will be read.
+All json file paths should be relative to your workspace folder."
   :type 'lsp-repeatable-vector
   :group 'lsp-html
   :package-version '(lsp-mode . "8.0.1"))

--- a/clients/lsp-html.el
+++ b/clients/lsp-html.el
@@ -23,7 +23,6 @@
 ;;; Code:
 
 (require 'lsp-mode)
-(require 'f)
 
 (defgroup lsp-html nil
   "LSP support for HTML, using vscode's built-in language server."
@@ -189,7 +188,7 @@ styles."
 
 ;; Caveat: uri seems to be sent as a single length vector.
 (defun lsp-html--get-content (_workspace files callback)
-  "Helper function for getting the content of a URI when the language server requests it."
+  "Helper function for getting the content of a URI/filename."
   (let* ((filename (aref files 0))
          (uri (f-join (lsp-workspace-root) filename))
          (file-content (f-read-text uri)))

--- a/clients/lsp-html.el
+++ b/clients/lsp-html.el
@@ -137,6 +137,18 @@ styles."
   :group 'lsp-html
   :package-version '(lsp-mode . "6.1"))
 
+(defcustom lsp-html-hover-documentation t
+  "Whether to show documentation strings on hover or not."
+  :type 'boolean
+  :group 'lsp-html
+  :package-version '(lsp-mode . "8.0.1"))
+
+(defcustom lsp-html-hover-references t
+  "Whether to show MDN references in documentation popups."
+  :type 'boolean
+  :group 'lsp-html
+  :package-version '(lsp-mode . "8.0.1"))
+
 (defcustom lsp-html-trace-server "off"
   "Traces the communication between VS Code and the HTML language server."
   :type '(choice
@@ -163,6 +175,8 @@ styles."
    ("html.format.unformatted" lsp-html-format-unformatted)
    ("html.format.wrapLineLength" lsp-html-format-wrap-line-length)
    ("html.format.enable" lsp-html-format-enable t)
+   ("html.hover.documentation" lsp-html-hover-documentation t)
+   ("html.hover.references" lsp-html-hover-references t)
    ("html.experimental.customData" lsp-html-experimental-custom-data)))
 
 (defcustom lsp-html-server-command-args '("--stdio")


### PR DESCRIPTION
# Updating custom data
I could not get custom data to work on my machine with a simple option/property/setting. From reading the vscode html tools source code, it seems that this extension uses the property internally in the same way we do here (read diffs in this PR). In summary:
- Send the data paths to the language server in the initialization options field.
- Handle a request for the content of these files in the client code.


When the content of these files have been sent to the server, it seems to work perfectly. I can complete, view hover information and more. I used various projects, like [the example project from the vscode team](https://github.com/microsoft/vscode-custom-data/tree/main/samples/helloworld). I added an extra custom data definition with some bogus to make it more interesting:
```json
{
  "version": 1.1,
  "tags": [
    {
      "name": "dafuq",
      "description": "The super cool new tag for the cool kids",
      "attributes": [
        { "name": "isThisShit" },
        {
          "name": "test",
          "values": [
            {
              "name": "is-working"
            }
          ]
        }
      ]
    }
  ]
}

```

<img width="579" alt="image" src="https://github.com/emacs-lsp/lsp-mode/assets/5732795/416ee942-dae5-4b2d-b804-b1b917d619f9">
<img width="579" alt="image" src="https://github.com/emacs-lsp/lsp-mode/assets/5732795/83bbf6e9-01c6-4fba-8bb5-37acba768417">
<img width="579" alt="image" src="https://github.com/emacs-lsp/lsp-mode/assets/5732795/5336553e-41d2-45b1-8c3c-fa6eb57baa22">


Completion of attributes also works perfectly. I just have to be sure to activate yas-minor-mode (or similar templating system). 


Fixes #4327
(probably)

# New configuration options
Added `lsp-html-hover-documentation` and `lsp-html-hover-references`, which are both on by default (even if not set from the language server side). I think it makes sense to be able to set these, especially on older machines where I try to get more performance out of turning off features. 