### PR TITLE
Add some C# directories to ignored directories

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -366,6 +366,7 @@ the server has requested that."
     "[/\\\\]\\.metals\\'"
     "[/\\\\]target\\'"
     "[/\\\\]\\.ccls-cache\\'"
+    "[/\\\\]\\.vs\\'"
     "[/\\\\]\\.vscode\\'"
     "[/\\\\]\\.venv\\'"
     "[/\\\\]\\.mypy_cache\\'"
@@ -382,7 +383,9 @@ the server has requested that."
     ;; Bazel
     "[/\\\\]bazel-[^/\\\\]+\\'"
     ;; CSharp
+    "[/\\\\]\\.cache[/\\\\]lsp-csharp\\'"
     "[/\\\\]\\.meta\\'"
+    "[/\\\\]\\.nuget\\'"
     ;; Unity
     "[/\\\\]Library\\'"
     ;; Clojure


### PR DESCRIPTION
This adds some C# directories, that probably should always be excluded, to the ignored list.