### PR TITLE
fix: correct padding for lsp-modeline-progress

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2147,7 +2147,7 @@ PARAMS - the data sent from WORKSPACE."
           (goto-char (lsp--position-to-point (lsp:range-start selection?))))
         t))))
 
-(defcustom lsp-progress-prefix " ⌛ "
+(defcustom lsp-progress-prefix "⌛ "
   "Progress prefix."
   :group 'lsp-mode
   :type 'string
@@ -2190,7 +2190,7 @@ PARAMS - the data sent from WORKSPACE."
                    "|"))))
             (lsp-workspaces)))))
     (unless (s-blank? progress-status)
-      (concat lsp-progress-prefix progress-status))))
+      (concat lsp-progress-prefix progress-status " "))))
 
 (lsp-defun lsp-on-progress-modeline (workspace (&ProgressParams :token :value
                                                                 (value &as &WorkDoneProgress :kind)))


### PR DESCRIPTION
Hello. This PR fixes the modeline progress status squashing together with mode line item after it. The standard is that modeline items have 1 space of padding to the right.

If you think about it, this makes sense:
"item_A item_B item_C ..."
each item needs exactly 1 space of padding to the right. That way each item doesn't need to know where in the mode line order it is.