### PR TITLE
fix(lsp-mode.el): add langid match for meson

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -801,6 +801,7 @@ Changes take effect only when a new session is started."
     ("^go\\.mod\\'" . "go.mod")
     ("^settings\\.json$" . "jsonc")
     ("^yang\\.settings$" . "jsonc")
+    ("^meson\\(_options\\.txt\\|\\.\\(build\\|format\\)\\)\\'" . "meson")
     (ada-mode . "ada")
     (ada-ts-mode . "ada")
     (gpr-mode . "gpr")
@@ -967,6 +968,7 @@ Changes take effect only when a new session is started."
     (protobuf-mode . "protobuf")
     (nushell-mode . "nushell")
     (nushell-ts-mode . "nushell")
+    (meson-mode . "meson")
     (yang-mode . "yang"))
   "Language id configuration.")
 


### PR DESCRIPTION
Should have done this in #4442, but I forgor.

- ~~[ ] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)~~ Not applicable.

- ~~[ ] I updated documentation if applicable (`docs` folder)~~ Not applicable.
