### PR TITLE
fix: use xref-make-match instead of xref-make

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5159,11 +5159,12 @@ identifier and the position respectively."
                             (max (min end-char len) 0)
                             'xref-match t line)
     ;; LINE is nil when FILENAME is not being current visited by any buffer.
-    (xref-make (or line filename)
+    (xref-make-match (or line filename)
                (xref-make-file-location
                 filename
                 (lsp-translate-line (1+ start-line))
-                (lsp-translate-column start-char)))))
+                (lsp-translate-column start-char))
+               (- end-char start-char))))
 
 (defun lsp--location-uri (loc)
   (if (lsp-location? loc)


### PR DESCRIPTION
This allows us to use xref-query-replace-in-results, when exporting to an xref buffer via embark for instance, since it needs xref-match-length to be defined.

Fixes: https://github.com/emacs-lsp/lsp-mode/issues/2997