### PR TITLE
Update urls for the groovy-language-server

### DIFF
--- a/clients/lsp-groovy.el
+++ b/clients/lsp-groovy.el
@@ -30,7 +30,7 @@
 (defgroup lsp-groovy nil
   "LSP support for Groovy, using groovy-language-server."
   :group 'lsp-mode
-  :link '(url-link "https://github.com/prominic/groovy-language-server"))
+  :link '(url-link "https://github.com/GroovyLanguageServer/groovy-language-server"))
 
 (defcustom lsp-groovy-server-file (f-join lsp-server-install-dir "groovy-language-server-all.jar")
   "JAR file path for groovy-language-server-all.jar."

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -395,8 +395,8 @@
     "name": "groovy",
     "full-name": "Groovy",
     "server-name": "groovy-language-server",
-    "server-url": "https://github.com/prominic/groovy-language-server",
-    "installation-url": "https://github.com/prominic/groovy-language-server#build",
+    "server-url": "https://github.com/GroovyLanguageServer/groovy-language-server",
+    "installation-url": "https://github.com/GroovyLanguageServer/groovy-language-server#build",
     "debugger": "Not available"
   },
   {


### PR DESCRIPTION
The urls associated with the groovy language server are outdated, to be fair they still redirect to the language server's new home under the GroovyLanguageServer org/user, but figured it's nice to update 👍 