### PR TITLE
Fix project root discovery when project features aren't loaded.

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3933,10 +3933,11 @@ If any filters, checks if it applies for PATH."
 (defun lsp--suggest-project-root ()
   "Get project root."
   (or
-   (when (featurep 'projectile) (condition-case nil
-                                    (projectile-project-root)
-                                  (error nil)))
-   (when (featurep 'project)
+   (when (fboundp 'projectile-project-root)
+     (condition-case nil
+         (projectile-project-root)
+       (error nil)))
+   (when (fboundp 'project-current)
      (when-let ((project (project-current)))
        (if (fboundp 'project-root)
            (project-root project)


### PR DESCRIPTION
It's possible for the corresponding project package (i.e., projectile or project) to not be loaded yet but there to exist autoloads for the functions.  In that situation, using `featurep` to check for the existence of the package will fail.  Therefore, `fboundp` is used instead to check for the existence (possibly an autoload) of the needed functions.