### PR TITLE
rust-analyzer client: extract signature in hover content

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -28,6 +28,7 @@
 (require 'ht)
 (require 'dash)
 (require 'lsp-semantic-tokens)
+(require 's)
 
 (defgroup lsp-rust nil
   "LSP support for Rust, using Rust Language Server or rust-analyzer."

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1764,6 +1764,16 @@ https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/lsp-extensions.m
   :download-server-fn (lambda (_client callback error-callback _update?)
                         (lsp-package-ensure 'rust-analyzer callback error-callback))))
 
+(cl-defmethod lsp-clients-extract-signature-on-hover (contents (_server-id (eql rust-analyzer)))
+  "Extract first non-comment line from rust-analyzer's hover CONTENTS.
+The first line of the hover contents is usally about memory layout or notable
+traits starting with //, with the actual signature follows."
+  (let* ((lines (s-lines (s-trim (lsp--render-element contents))))
+         (non-comment-lines (--filter (not (s-prefix? "//" it)) lines)))
+    (if non-comment-lines
+        (car non-comment-lines)
+      (car lines))))
+
 (lsp-consistency-check lsp-rust)
 
 (provide 'lsp-rust)


### PR DESCRIPTION
The full hover content from rust-analyzer usually looks like this:

![Screenshot_20240529_232050](https://github.com/emacs-lsp/lsp-mode/assets/1308450/c79383bf-98da-41a1-8887-062fa259e2f9)
![Screenshot_20240529_232031](https://github.com/emacs-lsp/lsp-mode/assets/1308450/1d0e980c-120f-44f4-a13a-cc9b1571951a)

By default, when `lsp-eldoc-render-all` is nil, only the first line (the comment) is show.

This PR implements the extraction method (like clangd) to return the first non-comment line.