### PR TITLE
Added AUCTeX LaTeX-mode as a Latex mode

### DIFF
--- a/clients/lsp-tex.el
+++ b/clients/lsp-tex.el
@@ -46,7 +46,7 @@
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection lsp-clients-digestif-executable)
-                  :major-modes '(plain-tex-mode latex-mode context-mode texinfo-mode)
+                  :major-modes '(plain-tex-mode latex-mode context-mode texinfo-mode LaTex-mode)
                   :priority (if (eq lsp-tex-server 'digestif) 1 -1)
                   :server-id 'digestif))
 
@@ -58,7 +58,7 @@
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection lsp-clients-texlab-executable)
-                  :major-modes '(plain-tex-mode latex-mode)
+                  :major-modes '(plain-tex-mode latex-mode LaTeX-mode)
                   :priority (if (eq lsp-tex-server 'texlab) 1 -1)
                   :server-id 'texlab))
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -915,6 +915,7 @@ Changes take effect only when a new session is started."
     (context-mode . "context")
     (cypher-mode . "cypher")
     (latex-mode . "latex")
+    (LaTeX-mode . "latex")
     (v-mode . "v")
     (vhdl-mode . "vhdl")
     (vhdl-ts-mode . "vhdl")


### PR DESCRIPTION
AUCTeX uses a different major mode for editing .tex files (LaTeX-mode).

Before, lsp-mode would not recognize LaTeX-mode as a major mode equivalent to latex-mode; and thus texlab would never be executed. 

I should point out that I added the LaTeX-mode to digestif list of modes; despite not using digestif. 

Would love to get some feedback. 
Thanks in advance!
 
PS: Should I update the change-log as stated in the guidelines?


Fixes: #4467 