### PR TITLE
Bump vscode-eslint extension to 3.0.10 to fix `eslint/probeFailed` on newer configurations

### DIFF
--- a/clients/lsp-eslint.el
+++ b/clients/lsp-eslint.el
@@ -42,7 +42,7 @@
   :group 'lsp-eslint
   :package-version '(lsp-mode . "8.0.0"))
 
-(defcustom lsp-eslint-download-url "https://github.com/emacs-lsp/lsp-server-binaries/blob/master/dbaeumer.vscode-eslint-2.2.2.vsix?raw=true"
+(defcustom lsp-eslint-download-url "https://github.com/emacs-lsp/lsp-server-binaries/blob/master/dbaeumer.vscode-eslint-3.0.10.vsix?raw=true"
   "ESLint language server download url."
   :type 'string
   :group 'lsp-eslint


### PR DESCRIPTION
In repositories that use eslint over `9.0.0` you get errors with `probeFailed` from the eslint LSP server.

Example log: *lsp-log: eslint*

```
[Trace - 05:54:47 PM] Sending response 'workspace/configuration - (2)'. Processing request took 0ms
Params: {
  "jsonrpc": "2.0",
  "id": 2,
  "result": [
    {
      "validate": "probe",
      "packageManager": "npm",
      "codeAction": {
        "disableRuleComment": {
          "enable": true,
          "location": "separateLine"
        },
        "showDocumentation": {
          "enable": true
        }
      },
      "codeActionOnSave": {
        "enable": false,
        "mode": "all"
      },
      "format": true,
      "quiet": false,
      "onIgnoredFiles": "off",
      "options": {},
      "experimental": {},
      "problems": {},
      "timeBudget": {},
      "rulesCustomizations": [],
      "run": "onType",
      "nodePath": null,
      "workingDirectory": null,
      "workspaceFolder": {
        "uri": "file:///Users/ovistoica/workspace/mindle",
        "name": "mindle"
      }
    }
  ]
}


[Trace - 05:54:47 PM] Received notification 'window/logMessage'.
Params: {
  "message": "ESLint library loaded from: /Users/ovistoica/workspace/mindle/node_modules/eslint/lib/api.js",
  "type": 3
}


[Trace - 05:54:48 PM] Received request 'eslint/probeFailed - (3).
Params: {
  "textDocument": {
    "uri": "file:///Users/ovistoica/workspace/mindle/drizzle.config.ts"
  }
}


[Trace - 05:54:48 PM] Sending response 'eslint/probeFailed - (3)'. Processing request took 1ms
Params: {
  "jsonrpc": "2.0",
  "id": 3,
  "result": "LSP :: ESLint is not configured correctly. Please ensure your eslintrc is set up for the languages you are using."
}
```

It took me a while to understand why this was happening, and I found that the vscode-eslint version from my local VSCode didn't have this issue, so I tried using that `eslintServer` and the issue wasn't there anymore.

Config used for local VSCode `eslintServer.js`
```elisp
(use-package lsp-eslint
  :demand t
  :after lsp-mode
  :config
  (setq lsp-eslint-server-command `("node"
                                    "~/.vscode/extensions/dbaeumer.vscode-eslint-3.0.10/server/out/eslintServer.js"
                                    "--stdio")))
```

This PR addresses this issue and makes `lsp-eslint` compatible with latest eslint version provided users reinstall their eslint server

Here's the PR from `lsp-server-binaries` to upload the latest vscode-eslint version: https://github.com/emacs-lsp/lsp-server-binaries/pull/3

Why is this happening? AFAIU, there are breaking changes between eslint 8.* and 9.* so if eslint config has rules that are only valid in 9.*, the probing fails. I think this is related: https://eslint.org/docs/latest/use/configure/migration-guide