### PR TITLE
Add gnu/linux arm64 support in lsp--system-arch

### DIFF
--- a/clients/lsp-lua.el
+++ b/clients/lsp-lua.el
@@ -552,7 +552,8 @@ and `../lib` ,exclude `../lib/temp`.
                    (pcase system-type
                      ('gnu/linux
                       (pcase (lsp-resolve-value lsp--system-arch)
-                        ('x64     "linux-x64")))
+                        ('x64     "linux-x64")
+                        ('arm64   "linux-arm64")))
                      ('darwin
                       (pcase (lsp-resolve-value lsp--system-arch)
                         ('x64     "darwin-x64")

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1501,6 +1501,7 @@ INHERIT-INPUT-METHOD will be proxied to `completing-read' without changes."
                                         (_ 'x64)))
                                      ('gnu/linux
                                        (pcase system-configuration
+                                         ((rx bol "aarch64-") 'arm64)
                                          ((rx bol "x86_64") 'x64)
                                          ((rx bol (| "i386" "i886")) 'x32)))
                                      (_


### PR DESCRIPTION
Currently, only `darwin` (macos) includes aarch64/arm64 as a detected architecture when setting `lsp--system-arch`.

This change adds detection for arm64 on `gnu/linux` system-types, as well as adding an appropriate cond to the mapping in lsp-lua. The only other place this var is used is in lsp-ada, which already accounts for `gnu/linux` + `arm64`.