### PR TITLE
Fix roslyn path (404 error)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -6,7 +6,7 @@
   * Add support for Meson build system. (~meson-mode~).
   * Add support for go to definition for external files (.dll) in CSharp projects for OmniSharp server.
   * Added a new optional ~:action-filter~ argument when defining LSP clients that allows code action requests to be modified before they are sent to the server. This is used by the Haskell language server client to work around an ~lsp-mode~ parsing quirk that incorrectly sends ~null~ values instead of ~false~ in code action requests.
-  * Add support for C# via the [[https://github.com/dotnet/roslyn/tree/main/src/Features/LanguageServer][Roslyn language server]].
+  * Add support for C# via the [[https://github.com/dotnet/roslyn/tree/main/src/LanguageServer][Roslyn language server]].
   * Add basic support for [[https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics][pull diagnostics]] requests.
 
 ** 9.0.0

--- a/clients/lsp-roslyn.el
+++ b/clients/lsp-roslyn.el
@@ -28,7 +28,7 @@
 
 (defgroup lsp-roslyn nil
   "LSP support for the C# programming language, using the Roslyn language server."
-  :link '(url-link "https://github.com/dotnet/roslyn/tree/main/src/Features/LanguageServer")
+  :link '(url-link "https://github.com/dotnet/roslyn/tree/main/src/LanguageServer")
   :group 'lsp-mode
   :package-version '(lsp-mode . "8.0.0"))
 

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -140,7 +140,7 @@
     "common-group-name": "csharp",
     "full-name": "C# (csharp-roslyn)",
     "server-name": "Microsoft.CodeAnalysis.LanguageServer (Roslyn)",
-    "server-url": "https://github.com/dotnet/roslyn/tree/main/src/Features/LanguageServer",
+    "server-url": "https://github.com/dotnet/roslyn/tree/main/src/LanguageServer",
     "installation": "Supports automatic installation via NuGet",
     "lsp-install-server": "csharp-roslyn",
     "debugger": "Yes (netcoredbg)"


### PR DESCRIPTION
fix a path to the language server:

```https://github.com/dotnet/roslyn/tree/main/src/Features/LanguageServer```

on

```https://github.com/dotnet/roslyn/tree/main/src/LanguageServer```