### PR TITLE
Correct global tool commands for fsharpautocomplete and csharp-ls

### DIFF
--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -504,10 +504,10 @@ filename is returned so lsp-mode can display this file."
 
 (defun lsp-csharp--cls-find-executable ()
   (or (when lsp-csharp-csharpls-use-dotnet-tool
-        (-flatten (list "dotnet" (if lsp-csharp-csharpls-use-local-tool (list "tool" "run") "") "csharp-ls")))
-      (executable-find "csharp-ls")
-      ;; NOTE[gastove|2023-02-03] This approach might be remove-able if we
-      ;; standardize on going through the `dotnet' cli.
+        (if lsp-csharp-csharpls-use-local-tool
+            (list "dotnet" "tool" "run" "csharp-ls")
+          (list "csharp-ls")))
+      (executable-find "csharp-ls")      
       (f-join (or (getenv "USERPROFILE") (getenv "HOME"))
               ".dotnet" "tools" "csharp-ls")))
 

--- a/clients/lsp-fsharp.el
+++ b/clients/lsp-fsharp.el
@@ -199,7 +199,9 @@ UPDATE? is t."
 (defun lsp-fsharp--fsac-cmd ()
   "The location of fsautocomplete executable."
   (or (when lsp-fsharp-use-dotnet-tool-for-fsac
-        (list "dotnet" (if lsp-fsharp-use-dotnet-local-tool "" "tool") "run" "fsautocomplete"))
+        (if lsp-fsharp-use-dotnet-local-tool
+            (list "dotnet" "tool" "run" "fsautocomplete")
+          (list "fsautocomplete")))
       (-let [maybe-local-executable (expand-file-name "fsautocomplete" lsp-fsharp-server-install-dir)]
         (when (f-exists-p maybe-local-executable)
           maybe-local-executable))


### PR DESCRIPTION
dotnet global tools are invoked directly by the binary name -- `fsautocomplete`, not `dotnet fsautocomplete` or `dotnet tool run fsautocomplete`, as local tools require. This commit corrects the command formation behavior.

Closes #4491 