### PR TITLE
Fix #4501: Auto adjust stale diagnostic ranges on document changes

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -8,6 +8,7 @@
   * Added a new optional ~:action-filter~ argument when defining LSP clients that allows code action requests to be modified before they are sent to the server. This is used by the Haskell language server client to work around an ~lsp-mode~ parsing quirk that incorrectly sends ~null~ values instead of ~false~ in code action requests.
   * Add support for C# via the [[https://github.com/dotnet/roslyn/tree/main/src/LanguageServer][Roslyn language server]].
   * Add basic support for [[https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics][pull diagnostics]] requests.
+  * Improve positions of stale diagnostics on a changed buffer via overlays.
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -154,7 +154,7 @@ CALLBACK is the status callback passed by Flycheck."
 
   (remove-hook 'lsp-on-idle-hook #'lsp-diagnostics--flycheck-buffer t)
 
-  (->> (lsp--get-buffer-diagnostics)
+  (->> (lsp--get-buffer-diagnostics t)
        (-map (-lambda ((&Diagnostic :message :severity? :tags? :code? :source?
                                     :range (&Range :start (start &as &Position
                                                                  :line      start-line

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2375,11 +2375,9 @@ This is only executed if the server supports pull diagnostics."
                         (start-pos (lsp--position-to-point
                                     (lsp-get range :start)))
                         (end-pos (lsp--position-to-point
-                                  (lsp-get range :end))))
-              (puthash
-               diagnostic
-               (make-overlay start-pos end-pos)
-               result)))
+                                  (lsp-get range :end)))
+                        (overlay (make-overlay start-pos end-pos)))
+              (puthash diagnostic overlay result)))
           diagnostics)
     result))
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3182,6 +3182,10 @@ and end-of-string meta-characters."
 
   ;; `diagnostic-overlay-map' is a hashmap of hashmaps providing each file with
   ;; a map from a diagnostic to an overlay that anchors its range in the buffer.
+  ;; These overlays help to readjust diagnostic ranges on document changes
+  ;; before an update from the server comes.
+  ;; Whenever a diagnostic is discarded, you should also remove the overlay
+  ;; to avoid slowing down Emacs.
   (diagnostic-overlay-map (make-hash-table :test 'equal))
 
   ;; contains all the workDone progress tokens that have been created

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2394,10 +2394,9 @@ Depends on KIND being a \\='full\\=' update."
       (lsp--clear-diagnostic-overlays workspace path)
       (if (seq-empty-p diagnostics?)
           (remhash path workspace-diagnostics)
-        (progn
-          (puthash path (append diagnostics? nil) workspace-diagnostics)
-          (puthash path (lsp--make-overlays-for-diagnostics diagnostics?)
-                   (lsp--workspace-diagnostic-overlay-map workspace))))
+        (puthash path (append diagnostics? nil) workspace-diagnostics)
+        (puthash path (lsp--make-overlays-for-diagnostics diagnostics?)
+                 (lsp--workspace-diagnostic-overlay-map workspace)))
       (run-hooks 'lsp-diagnostics-updated-hook)))
     ((equal kind "unchanged") t)
     (t (lsp--error "Unknown pull diagnostic result kind '%s'" kind))))
@@ -2422,10 +2421,9 @@ WORKSPACE is the workspace that contains the diagnostics."
     (lsp--clear-diagnostic-overlays workspace file)
     (if (seq-empty-p diagnostics)
         (remhash file workspace-diagnostics)
-      (progn
-        (puthash file (append diagnostics nil) workspace-diagnostics)
-        (puthash file (lsp--make-overlays-for-diagnostics diagnostics)
-                 (lsp--workspace-diagnostic-overlay-map workspace))))
+      (puthash file (append diagnostics nil) workspace-diagnostics)
+      (puthash file (lsp--make-overlays-for-diagnostics diagnostics)
+               (lsp--workspace-diagnostic-overlay-map workspace)))
 
     (run-hooks 'lsp-diagnostics-updated-hook)))
 

--- a/test/lsp-mock-server-test.el
+++ b/test/lsp-mock-server-test.el
@@ -208,6 +208,7 @@ If after TIMEOUT seconds CONDITION does not become non-nil
 raise `error' with \"Timeout wiaitng for\" + TIMEOUT-DESC (string).
 BODY is implicitly wrapped in `progn'.
 Once last form of BODY evaluates to non-nil, return its result."
+  (declare (indent 2))
   `(lsp-test--sync-wait-for
     ,timeout ,(concat "Timeout waiting for " timeout-desc) (lambda () ,@body)))
 
@@ -216,17 +217,19 @@ Once last form of BODY evaluates to non-nil, return its result."
   (seq-filter (lambda (ovl) (null (overlay-get ovl 'pulse-delete)))
               (overlays-in (point-min) (point-max))))
 
-(defun lsp-mock--run-with-mock-server (diags-provider test-body)
+(defun lsp-mock--run-with-mock-server (sample-file diags-provider test-body)
   "Run TEST-BODY function with mock LSP client connected to the mock server.
 
 This is an environment function that configures lsp-mode, mock lsp-client,
-opens the `lsp-test-sample-file' and starts the mock server."
+opens the SAMPLE-FILE and starts the mock server.
+It sets DIAGS-PROVIDER as the diagnostics provider for the test,
+which should be a value valid for `lsp-diagnostics-provider'."
   (let ((lsp-clients (lsp-ht)) ; clear all clients
         (lsp-diagnostics-provider diags-provider) ; focus on LSP itself, not its UI integration
         (lsp-restart 'ignore) ; Avoid restarting the server or prompting user on a crash
         (lsp-enable-snippet nil) ; Avoid warning that lsp-yasnippet is not intalled
         (lsp-warn-no-matched-clients nil) ; Mute warning LSP can't figure out src lang
-        (workspace-root (file-name-directory lsp-test-sample-file))
+        (workspace-root (file-name-directory sample-file))
         (initial-server-count (lsp-test-total-folder-count))
         (initial-overlay-count nil))
     (register-mock-client) ; register mock client as the one an only lsp client
@@ -240,7 +243,7 @@ opens the `lsp-test-sample-file' and starts the mock server."
       (defvar xref-auto-jump-to-first-definition nil))
 
     (lsp-workspace-folders-add workspace-root)
-    (let* ((buf (find-file-noselect lsp-test-sample-file)))
+    (let* ((buf (find-file-noselect sample-file)))
       (unwind-protect
           (progn
             (with-timeout (5 (error "Timeout running a test with mock server"))
@@ -269,43 +272,49 @@ opens the `lsp-test-sample-file' and starts the mock server."
     (lsp-test-sync-wait 5 "LSP mock server to stop"
                         (= initial-server-count (lsp-test-total-folder-count)))))
 
-(defmacro lsp-mock-run-with-mock-server (&rest test-body)
+(defmacro lsp-mock-run-with-mock-server (sample-file diags-provider &rest test-body)
   "Evaluate TEST-BODY in the context of a mock client connected to mock server.
 
-Opens the `lsp-test-sample-file' and initiates the LSP session.
+Opens the SAMPLE-FILE and initiates the LSP session.
+It sets DIAGS-PROVIDER as the diagnostics provider for the test,
+which should be a value valid for `lsp-diagnostics-provider'.
 TEST-BODY can interact with the mock server."
-  `(lsp-mock--run-with-mock-server :flycheck (lambda () ,@test-body)))
+  (declare (indent 2))
+  `(lsp-mock--run-with-mock-server
+    ,sample-file
+    ,diags-provider
+    (lambda () ,@test-body)))
 
 (ert-deftest lsp-mock-server-reports-diagnostics ()
-  (lsp-mock-run-with-mock-server
-   (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 0))
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
-   (lsp-test-sync-wait
-    4 "lsp mode to get the diagnostic"
-    (should (lsp-workspaces))
-    (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
-   (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
-                  (lsp-test-range-make (buffer-string)
-                                       "line 1 unique word broming + common"
-                                       "                   ^^^^^^^         ")))))
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 0))
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+    (lsp-test-sync-wait
+     4 "lsp mode to get the diagnostic"
+     (should (lsp-workspaces))
+     (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
+    (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
+                   (lsp-test-range-make (buffer-string)
+                                        "line 1 unique word broming + common"
+                                        "                   ^^^^^^^         ")))))
 
 (ert-deftest lsp-mock-server-crashes ()
   "Test that the mock server crashes when instructed so."
   (let ((initial-serv-count (lsp-test-total-folder-count)))
     (when-let ((buffer (get-buffer "*mock-server::stderr*")))
       (kill-buffer buffer))
-    (lsp-mock-run-with-mock-server
-     (should (eq (lsp-test-total-folder-count) (1+ initial-serv-count)))
-     (lsp-test-crash-server-with-message "crashed by command")
-     (lsp-test-sync-wait
-      4 "LSP server to crash by command"
-      (eq initial-serv-count (lsp-test-total-folder-count)))
-     (let ((buffer (get-buffer "*mock-server::stderr*")))
-       (should buffer)
-       (with-current-buffer buffer
-         (goto-char (point-min))
-         (should (search-forward "crashed by command"))
-         (goto-char (point-max)))))))
+    (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+      (should (eq (lsp-test-total-folder-count) (1+ initial-serv-count)))
+      (lsp-test-crash-server-with-message "crashed by command")
+      (lsp-test-sync-wait
+       4 "LSP server to crash by command"
+       (eq initial-serv-count (lsp-test-total-folder-count)))
+      (let ((buffer (get-buffer "*mock-server::stderr*")))
+        (should buffer)
+        (with-current-buffer buffer
+          (goto-char (point-min))
+          (should (search-forward "crashed by command"))
+          (goto-char (point-max)))))))
 
 (defun lsp-mock-get-first-diagnostic-line ()
   "Get the line number of the first diagnostic on `lsp-test-sample-file'."
@@ -318,37 +327,37 @@ TEST-BODY can interact with the mock server."
 
 (ert-deftest lsp-mock-server-updates-diagnostics ()
   "Test that mock server can update diagnostics and lsp-mode reflects that."
-  (lsp-mock-run-with-mock-server
-   ;; There are no diagnostics at first
-   (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 0))
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    ;; There are no diagnostics at first
+    (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 0))
 
-   ;; Server found diagnostic
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
-   (lsp-test-sync-wait
-    4 "LSP mode to receive initial diagnostic"
-    (should (lsp-workspaces))
-    (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
+    ;; Server found diagnostic
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+    (lsp-test-sync-wait
+     4 "LSP mode to receive initial diagnostic"
+     (should (lsp-workspaces))
+     (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
 
-   ;; The diagnostic is properly received
-   (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
-                  (lsp-test-range-make (buffer-string)
-                                       "line 1 unique word broming + common"
-                                       "                   ^^^^^^^         ")))
+    ;; The diagnostic is properly received
+    (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
+                   (lsp-test-range-make (buffer-string)
+                                        "line 1 unique word broming + common"
+                                        "                   ^^^^^^^         ")))
 
-   ;; Server found a different diagnostic
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "fegam")
-   (let ((old-line (lsp-mock-get-first-diagnostic-line)))
-     (lsp-test-sync-wait
-      4 "LSP to receive updated diagnostic"
-      (should (lsp-workspaces))
-      (not (equal old-line (lsp-mock-get-first-diagnostic-line)))))
+    ;; Server found a different diagnostic
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "fegam")
+    (let ((old-line (lsp-mock-get-first-diagnostic-line)))
+      (lsp-test-sync-wait
+       4 "LSP to receive updated diagnostic"
+       (should (lsp-workspaces))
+       (not (equal old-line (lsp-mock-get-first-diagnostic-line)))))
 
-   ;; The new diagnostics is properly displayed instead of the old one
-   (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
-   (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
-                  (lsp-test-range-make (buffer-string)
-                                       "Line 0 unique word fegam and common"
-                                       "                   ^^^^^           ")))))
+    ;; The new diagnostics is properly displayed instead of the old one
+    (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
+    (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
+                   (lsp-test-range-make (buffer-string)
+                                        "Line 0 unique word fegam and common"
+                                        "                   ^^^^^           ")))))
 
 (ert-deftest lsp-mock-server-updates-diags-with-delay ()
   "Test demonstrating delay in the diagnostics update.
@@ -357,95 +366,95 @@ If server takes noticeable time to update diagnostics after a
 document change, and `lsp-diagnostic-clean-after-change' is
 nil (default), diagnostic ranges will be off until server
 publishes the update. This test demonstrates this behavior."
-  (lsp-mock-run-with-mock-server
-   ;; There are no diagnostics at first
-   (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 0))
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    ;; There are no diagnostics at first
+    (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 0))
 
-   ;; Server found diagnostic
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
-   (lsp-test-sync-wait
-    4 "LSP mode to receive initial diagnostic"
-    (should (lsp-workspaces))
-    (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
+    ;; Server found diagnostic
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+    (lsp-test-sync-wait
+     4 "LSP mode to receive initial diagnostic"
+     (should (lsp-workspaces))
+     (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
 
-   ;; The diagnostic is properly received
-   (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
-                  (lsp-test-range-make (buffer-string)
-                                       "line 1 unique word broming + common"
-                                       "                   ^^^^^^^         ")))
+    ;; The diagnostic is properly received
+    (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
+                   (lsp-test-range-make (buffer-string)
+                                        "line 1 unique word broming + common"
+                                        "                   ^^^^^^^         ")))
 
-   ;; Change the text: remove the first line
-   (goto-char (point-min))
-   (kill-line 1)
-   (should (string-equal (buffer-string)
-                         "line 1 unique word broming + common
+    ;; Change the text: remove the first line
+    (goto-char (point-min))
+    (kill-line 1)
+    (should (string-equal (buffer-string)
+                          "line 1 unique word broming + common
 line 2 unique word normalw common here
 line 3 words here and here
 "))
-   ;; Give it some time to update
-   (sleep-for 0.5)
-   ;; The diagnostic is not updated and now points to a wrong line
-   (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
-                  (lsp-test-range-make (buffer-string)
-                                       "line 2 unique word normalw common here"
-                                       "                   ^^^^^^^            ")))
+    ;; Give it some time to update
+    (sleep-for 0.5)
+    ;; The diagnostic is not updated and now points to a wrong line
+    (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
+                   (lsp-test-range-make (buffer-string)
+                                        "line 2 unique word normalw common here"
+                                        "                   ^^^^^^^            ")))
 
-   ;; Server sent an update
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+    ;; Server sent an update
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
 
-   (let ((old-line (lsp-mock-get-first-diagnostic-line)))
-     (lsp-test-sync-wait 4 "LSP mode to receive updated diagnostics"
-                         (should (lsp-workspaces))
-                         (not (equal old-line (lsp-mock-get-first-diagnostic-line)))))
+    (let ((old-line (lsp-mock-get-first-diagnostic-line)))
+      (lsp-test-sync-wait 4 "LSP mode to receive updated diagnostics"
+                          (should (lsp-workspaces))
+                          (not (equal old-line (lsp-mock-get-first-diagnostic-line)))))
 
-   ;; Now the diagnostic is correct again
-   (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
-                  (lsp-test-range-make (buffer-string)
-                                       "line 1 unique word broming + common"
-                                       "                   ^^^^^^^         ")))))
+    ;; Now the diagnostic is correct again
+    (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
+                   (lsp-test-range-make (buffer-string)
+                                        "line 1 unique word broming + common"
+                                        "                   ^^^^^^^         ")))))
 
 (ert-deftest lsp-mock-server-updates-diags-clears-up ()
   "Test ensuring diagnostics are cleared after a change."
   (let ((lsp-diagnostic-clean-after-change t))
-  (lsp-mock-run-with-mock-server
-   ;; There are no diagnostics at first
-   (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 0))
+    (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+      ;; There are no diagnostics at first
+      (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 0))
 
-   ;; Server found diagnostic
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
-   (lsp-test-sync-wait
-    4 "LSP mode to receive initial diagnostics"
-    (should (lsp-workspaces))
-    (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
+      ;; Server found diagnostic
+      (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+      (lsp-test-sync-wait
+       4 "LSP mode to receive initial diagnostics"
+       (should (lsp-workspaces))
+       (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
 
-   ;; The diagnostic is properly received
-   (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
-                  (lsp-test-range-make (buffer-string)
-                                       "line 1 unique word broming + common"
-                                       "                   ^^^^^^^         ")))
+      ;; The diagnostic is properly received
+      (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
+                     (lsp-test-range-make (buffer-string)
+                                          "line 1 unique word broming + common"
+                                          "                   ^^^^^^^         ")))
 
-   ;; Change the text: remove the first line
-   (goto-char (point-min))
-   (kill-line 1)
+      ;; Change the text: remove the first line
+      (goto-char (point-min))
+      (kill-line 1)
 
-   ;; After a short while, diagnostics are cleared up
-   (lsp-test-sync-wait 4 "LSP mode to clear up diagnostics"
-                       (should (lsp-workspaces))
-                       (null (gethash lsp-test-sample-file (lsp-diagnostics t))))
+      ;; After a short while, diagnostics are cleared up
+      (lsp-test-sync-wait 4 "LSP mode to clear up diagnostics"
+                          (should (lsp-workspaces))
+                          (null (gethash lsp-test-sample-file (lsp-diagnostics t))))
 
-   ;; Server sent an update
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+      ;; Server sent an update
+      (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
 
-   (let ((old-line (lsp-mock-get-first-diagnostic-line)))
-     (lsp-test-sync-wait 4 "LSP mode to get updated diagnostics"
-                         (should (lsp-workspaces))
-                         (not (equal old-line (lsp-mock-get-first-diagnostic-line)))))
+      (let ((old-line (lsp-mock-get-first-diagnostic-line)))
+        (lsp-test-sync-wait 4 "LSP mode to get updated diagnostics"
+                            (should (lsp-workspaces))
+                            (not (equal old-line (lsp-mock-get-first-diagnostic-line)))))
 
-   ;; Now the diagnostic is correct again
-   (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
-                  (lsp-test-range-make (buffer-string)
-                                       "line 1 unique word broming + common"
-                                       "                   ^^^^^^^         "))))))
+      ;; Now the diagnostic is correct again
+      (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
+                     (lsp-test-range-make (buffer-string)
+                                          "line 1 unique word broming + common"
+                                          "                   ^^^^^^^         "))))))
 
 (defun lsp-test-xref-loc-to-range (xref-loc)
   "Convert XREF-LOC to a range p-list.
@@ -475,60 +484,60 @@ Scan CONTENTS for all occurences of WORD and compose a list of references."
   (let* (found-xrefs
          (xref-show-xrefs-function (lambda (fetcher &rest _params)
                                      (setq found-xrefs (funcall fetcher)))))
-    (lsp-mock-run-with-mock-server
-     (lsp-test-schedule-response "textDocument/references"
-                                 (lsp-test-make-references
-                                  lsp-test-sample-file (buffer-string) "unique"))
-     (lsp-find-references)
-     (should found-xrefs)
-     (should (eq (length found-xrefs) 3))
-     (should (equal (lsp-test-xref-loc-to-range (nth 0 found-xrefs))
-                    (lsp-test-range-make (buffer-string)
-                                         "Line 0 unique word fegam and common"
-                                         "       ^^^^^^                      ")))
-     (should (equal (lsp-test-xref-loc-to-range (nth 1 found-xrefs))
-                    (lsp-test-range-make (buffer-string)
-                                         "line 1 unique word broming + common"
-                                         "       ^^^^^^                      ")))
-     (should (equal (lsp-test-xref-loc-to-range (nth 2 found-xrefs))
-                    (lsp-test-range-make (buffer-string)
-                                         "line 2 unique word normalw common here"
-                                         "       ^^^^^^                         "))))))
+    (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+      (lsp-test-schedule-response "textDocument/references"
+                                  (lsp-test-make-references
+                                   lsp-test-sample-file (buffer-string) "unique"))
+      (lsp-find-references)
+      (should found-xrefs)
+      (should (eq (length found-xrefs) 3))
+      (should (equal (lsp-test-xref-loc-to-range (nth 0 found-xrefs))
+                     (lsp-test-range-make (buffer-string)
+                                          "Line 0 unique word fegam and common"
+                                          "       ^^^^^^                      ")))
+      (should (equal (lsp-test-xref-loc-to-range (nth 1 found-xrefs))
+                     (lsp-test-range-make (buffer-string)
+                                          "line 1 unique word broming + common"
+                                          "       ^^^^^^                      ")))
+      (should (equal (lsp-test-xref-loc-to-range (nth 2 found-xrefs))
+                     (lsp-test-range-make (buffer-string)
+                                          "line 2 unique word normalw common here"
+                                          "       ^^^^^^                         "))))))
 
 (ert-deftest lsp-mock-server-provides-folding-ranges ()
   "Test ensuring that lsp-mode accepts correct locations for folding ranges."
-  (lsp-mock-run-with-mock-server
-   (lsp-test-schedule-response
-    "textDocument/foldingRange"
-    [(:kind "region" :startLine 0 :startCharacter 10 :endLine 1)
-     (:kind "region" :startLine 1 :startCharacter 5 :endLine 2)])
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    (lsp-test-schedule-response
+     "textDocument/foldingRange"
+     [(:kind "region" :startLine 0 :startCharacter 10 :endLine 1)
+      (:kind "region" :startLine 1 :startCharacter 5 :endLine 2)])
 
-   (let ((folding-ranges (lsp--get-folding-ranges)))
-     (should (eq (length folding-ranges) 2))
-     ;; LSP line numbers are 0-based, Emacs line numbers are 1-based
-     ;; henace the +1
-     (should (equal (line-number-at-pos
-                     (lsp--folding-range-beg (nth 0 folding-ranges)))
-                    1))
-     (should (equal (line-number-at-pos
-                     (lsp--folding-range-end (nth 0 folding-ranges)))
-                    2))
-     (should (equal (line-number-at-pos
-                     (lsp--folding-range-beg (nth 1 folding-ranges)))
-                    2))
-     (should (equal (line-number-at-pos
-                     (lsp--folding-range-end (nth 1 folding-ranges)))
-                    3)))))
+    (let ((folding-ranges (lsp--get-folding-ranges)))
+      (should (eq (length folding-ranges) 2))
+      ;; LSP line numbers are 0-based, Emacs line numbers are 1-based
+      ;; henace the +1
+      (should (equal (line-number-at-pos
+                      (lsp--folding-range-beg (nth 0 folding-ranges)))
+                     1))
+      (should (equal (line-number-at-pos
+                      (lsp--folding-range-end (nth 0 folding-ranges)))
+                     2))
+      (should (equal (line-number-at-pos
+                      (lsp--folding-range-beg (nth 1 folding-ranges)))
+                     2))
+      (should (equal (line-number-at-pos
+                      (lsp--folding-range-end (nth 1 folding-ranges)))
+                     3)))))
 
 (ert-deftest lsp-mock-server-lsp-caches-folding-ranges ()
   "Test ensuring that lsp-mode accepts correct locations for folding ranges."
-  (lsp-mock-run-with-mock-server
-   (should (eq (lsp--get-folding-ranges) nil))
-   (lsp-test-schedule-response
-    "textDocument/foldingRange"
-    [(:kind "region" :startLine 0 :startCharacter 10 :endLine 1)])
-   ;; Folding ranges are cached from the first request
-   (should (eq (lsp--get-folding-ranges) nil))))
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    (should (eq (lsp--get-folding-ranges) nil))
+    (lsp-test-schedule-response
+     "textDocument/foldingRange"
+     [(:kind "region" :startLine 0 :startCharacter 10 :endLine 1)])
+    ;; Folding ranges are cached from the first request
+    (should (eq (lsp--get-folding-ranges) nil))))
 
 (defun lsp-test-all-overlays (tag)
   "Return all overlays tagged TAG in the current buffer."
@@ -592,38 +601,38 @@ TEST-FN is a function to call with the temporary window."
 
 (ert-deftest lsp-mock-server-provides-symbol-highlights ()
   "Test ensuring that lsp-mode accepts correct locations for highlights."
-  (lsp-mock-run-with-mock-server
-   (lsp-test-schedule-response
-    "textDocument/documentHighlight"
-    (lsp-test-make-highlights (buffer-string) "here"))
-   ;; The highlight overlays are created only if visible in a window
-   (lsp-mock-with-temp-window
-    (current-buffer)
-    (lambda ()
-      (lsp-document-highlight)
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    (lsp-test-schedule-response
+     "textDocument/documentHighlight"
+     (lsp-test-make-highlights (buffer-string) "here"))
+    ;; The highlight overlays are created only if visible in a window
+    (lsp-mock-with-temp-window
+     (current-buffer)
+     (lambda ()
+       (lsp-document-highlight)
 
-      (let ((highlights (lsp-test-sort-ranges
-                         (lsp-test-sync-wait
-                          4 "LSP mode to receive highlights"
-                          (should (lsp-workspaces))
-                          (lsp-test-all-overlays-as-ranges 'lsp-highlight)))))
-        (message "%s" highlights)
-        (should (eq (length highlights) 3))
-        (should (equal (nth 0 highlights)
-                       (lsp-test-range-make (buffer-string)
-                                            "line 2 unique word normalw common here"
-                                            "                                  ^^^^")))
-        (should (equal (nth 1 highlights)
-                       (lsp-test-range-make (buffer-string)
-                                            "line 3 words here and here"
-                                            "             ^^^^         ")))
-        (should (equal (nth 2 highlights)
-                       (lsp-test-range-make (buffer-string)
-                                            "line 3 words here and here"
-                                            "                      ^^^^"))))
-      ;; Remove highlights
-      (lsp-test-schedule-response "textDocument/documentHighlight" [])
-      (lsp-document-highlight)))))
+       (let ((highlights (lsp-test-sort-ranges
+                          (lsp-test-sync-wait
+                           4 "LSP mode to receive highlights"
+                           (should (lsp-workspaces))
+                           (lsp-test-all-overlays-as-ranges 'lsp-highlight)))))
+         (message "%s" highlights)
+         (should (eq (length highlights) 3))
+         (should (equal (nth 0 highlights)
+                        (lsp-test-range-make (buffer-string)
+                                             "line 2 unique word normalw common here"
+                                             "                                  ^^^^")))
+         (should (equal (nth 1 highlights)
+                        (lsp-test-range-make (buffer-string)
+                                             "line 3 words here and here"
+                                             "             ^^^^         ")))
+         (should (equal (nth 2 highlights)
+                        (lsp-test-range-make (buffer-string)
+                                             "line 3 words here and here"
+                                             "                      ^^^^"))))
+       ;; Remove highlights
+       (lsp-test-schedule-response "textDocument/documentHighlight" [])
+       (lsp-document-highlight)))))
 
 (defun lsp-test-index-to-pos (idx)
   "Convert 0-based integer IDX to a position in the corrent buffer.
@@ -712,18 +721,18 @@ and insertion must not contain a line break."
 
 (ert-deftest lsp-mock-server-formats-with-edits ()
   "Test ensuring that lsp-mode requests and applies formatting correctly."
-  (lsp-mock-run-with-mock-server
-   (lsp-test-schedule-response
-    "textDocument/formatting"
-    (lsp-test-make-edits
-     "Line 0 ###### word fegam and common
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    (lsp-test-schedule-response
+     "textDocument/formatting"
+     (lsp-test-make-edits
+      "Line 0 ###### word fegam and common
 line 1 unique <double>word ######### common
 line 2 unique word #ormalw common here
 line 3 words here and here
 "))
-   (lsp-format-buffer)
-   (should (equal (buffer-string)
-                  "Line 0  word fegam and common
+    (lsp-format-buffer)
+    (should (equal (buffer-string)
+                   "Line 0  word fegam and common
 line 1 unique doubleword  common
 line 2 unique word ormalw common here
 line 3 words here and here
@@ -731,25 +740,25 @@ line 3 words here and here
 
 (ert-deftest lsp-mock-server-suggests-action-with-simple-changes ()
   "Test ensuring that lsp-mode applies code action simple edits correctly."
-  (lsp-mock-run-with-mock-server
-   (lsp-test-schedule-response
-    "textDocument/codeAction"
-    (vconcat (list `(:title "Some edits"
-                     :kind "quickfix"
-                     :isPreferred t
-                     :edit
-                     (:changes
-                      ((,(concat "file://" lsp-test-sample-file)
-                        .
-                        ,(lsp-test-make-edits
-                          "Line 0 unique word ######### common
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    (lsp-test-schedule-response
+     "textDocument/codeAction"
+     (vconcat (list `(:title "Some edits"
+                      :kind "quickfix"
+                      :isPreferred t
+                      :edit
+                      (:changes
+                       ((,(concat "file://" lsp-test-sample-file)
+                         .
+                         ,(lsp-test-make-edits
+                           "Line 0 unique word ######### common
 line # unique word broming + common
 line # unique word normalw common here
 line #<81> words here and here
 "))))))))
-   (lsp-execute-code-action-by-kind "quickfix")
-   (should (equal (buffer-string)
-                  "Line 0 unique word  common
+    (lsp-execute-code-action-by-kind "quickfix")
+    (should (equal (buffer-string)
+                   "Line 0 unique word  common
 line  unique word broming + common
 line  unique word normalw common here
 line 81 words here and here
@@ -757,29 +766,29 @@ line 81 words here and here
 
 (ert-deftest lsp-mock-server-suggests-action-with-doc-changes ()
   "Test ensuring that lsp-mode applies code action document edits correctly."
-  (lsp-mock-run-with-mock-server
-   (let ((docChanges
-          (vconcat (list `(:textDocument
-                           (:version 0 ; document was never changed
-                            :uri ,(concat "file://" lsp-test-sample-file))
-                           :edits
-                           ,(lsp-test-make-edits
-                             "Line 0 ########### ######### common
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    (let ((docChanges
+           (vconcat (list `(:textDocument
+                            (:version 0 ; document was never changed
+                             :uri ,(concat "file://" lsp-test-sample-file))
+                            :edits
+                            ,(lsp-test-make-edits
+                              "Line 0 ########### ######### common
 line 1<00> unique word broming + common
 line # ###### word normalw common here
 line #<81> words here and here
 "))))))
-     (lsp-test-schedule-response
-      "textDocument/codeAction"
-      (vconcat (list `(:title "Some edits"
-                       :kind "quickfix"
-                       :isPreferred t
-                       :edit
-                       (:changes #s(hash-table data ()) ; empty obj
-                        :documentChanges ,docChanges)))))
-     (lsp-execute-code-action-by-kind "quickfix")
-     (should (equal (buffer-string)
-                    "Line 0   common
+      (lsp-test-schedule-response
+       "textDocument/codeAction"
+       (vconcat (list `(:title "Some edits"
+                        :kind "quickfix"
+                        :isPreferred t
+                        :edit
+                        (:changes #s(hash-table data ()) ; empty obj
+                         :documentChanges ,docChanges)))))
+      (lsp-execute-code-action-by-kind "quickfix")
+      (should (equal (buffer-string)
+                     "Line 0   common
 line 100 unique word broming + common
 line   word normalw common here
 line 81 words here and here
@@ -787,21 +796,21 @@ line 81 words here and here
 
 (ert-deftest lsp-mock-doc-changes-wrong-version ()
   "Test ensuring that lsp-mode applies code action document edits correctly."
-  (lsp-mock-run-with-mock-server
-   (let ((docChanges
-          (vconcat (list `(:textDocument
-                           (:version 1 ; This version does not exist
-                            :uri ,(concat "file://" lsp-test-sample-file))
-                           :edits [])))))
-     (lsp-test-schedule-response
-      "textDocument/codeAction"
-      (vconcat (list `(:title "Some edits"
-                       :kind "quickfix"
-                       :isPreferred t
-                       :edit
-                       (:changes #s(hash-table data ()) ; empty obj
-                        :documentChanges ,docChanges)))))
-     (should-error (lsp-execute-code-action-by-kind "quickfix")))))
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    (let ((docChanges
+           (vconcat (list `(:textDocument
+                            (:version 1 ; This version does not exist
+                             :uri ,(concat "file://" lsp-test-sample-file))
+                            :edits [])))))
+      (lsp-test-schedule-response
+       "textDocument/codeAction"
+       (vconcat (list `(:title "Some edits"
+                        :kind "quickfix"
+                        :isPreferred t
+                        :edit
+                        (:changes #s(hash-table data ()) ; empty obj
+                         :documentChanges ,docChanges)))))
+      (should-error (lsp-execute-code-action-by-kind "quickfix")))))
 
 ;; Some actions are executed partially by the server:
 ;; after the user selects the action, lsp-mode sends a request
@@ -811,25 +820,25 @@ line 81 words here and here
 ;; This test simulates only the last bit.
 (ert-deftest lsp-mock-server-request-edits ()
   "Test ensuring that lsp-mode honors server's request for edits."
-  (lsp-mock-run-with-mock-server
-   (let ((initial-content (buffer-string)))
-     (lsp-test-send-command-to-mock-server
-      (format "(princ (json-rpc-string '(:id 1 :method \"workspace/applyEdit\"
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    (let ((initial-content (buffer-string)))
+      (lsp-test-send-command-to-mock-server
+       (format "(princ (json-rpc-string '(:id 1 :method \"workspace/applyEdit\"
                                       :params (:edit
                                                (:changes
                                                 ((%S . %S)))))))"
-              (concat "file://" lsp-test-sample-file)
-              (lsp-test-make-edits
-               "#### <8>0 unique word fegam and common
+               (concat "file://" lsp-test-sample-file)
+               (lsp-test-make-edits
+                "#### <8>0 unique word fegam and common
 line 1 unique word broming + common
 line 2 unique word normalw common here
 line 3 words here and here
 ")))
-     (lsp-test-sync-wait 4 "LSP mode changes code"
-                         (should (lsp-workspaces))
-                         (not (equal initial-content (buffer-string))))
-     (should (equal (buffer-string)
-                    " 80 unique word fegam and common
+      (lsp-test-sync-wait 4 "LSP mode changes code"
+                          (should (lsp-workspaces))
+                          (not (equal initial-content (buffer-string))))
+      (should (equal (buffer-string)
+                     " 80 unique word fegam and common
 line 1 unique word broming + common
 line 2 unique word normalw common here
 line 3 words here and here
@@ -837,71 +846,71 @@ line 3 words here and here
 
 (ert-deftest lsp-mock-server-no-declaration-found ()
   "Test checking that lsp-mode reports when server returns no declaration."
-  (lsp-mock-run-with-mock-server
-   (should (string-match-p "not found" (lsp-find-declaration)))))
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    (should (string-match-p "not found" (lsp-find-declaration)))))
 
 (ert-deftest lsp-mock-server-goto-declaration ()
   "Test checking that lsp-mode can follow the symbol declaration."
-  (lsp-mock-run-with-mock-server
-   (let ((decl-range (lsp-test-range-make
-                      (buffer-string)
-                      "line 1 unique word broming + common"
-                      "                   ^^^^^^^         ")))
-     (lsp-test-schedule-response
-      "textDocument/declaration"
-      (vconcat (list `(:uri ,(concat "file://" lsp-test-sample-file)
-                       :range ,(lsp-test-full-range decl-range)))))
-     (lsp-find-declaration)
-     ;; 1+ to convert 0-based LSP line number to 1-based Emacs line number
-     (should (equal (1+ (plist-get decl-range :line)) (line-number-at-pos)))
-     (should (equal (plist-get decl-range :from) (current-column))))))
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    (let ((decl-range (lsp-test-range-make
+                       (buffer-string)
+                       "line 1 unique word broming + common"
+                       "                   ^^^^^^^         ")))
+      (lsp-test-schedule-response
+       "textDocument/declaration"
+       (vconcat (list `(:uri ,(concat "file://" lsp-test-sample-file)
+                        :range ,(lsp-test-full-range decl-range)))))
+      (lsp-find-declaration)
+      ;; 1+ to convert 0-based LSP line number to 1-based Emacs line number
+      (should (equal (1+ (plist-get decl-range :line)) (line-number-at-pos)))
+      (should (equal (plist-get decl-range :from) (current-column))))))
 
 (ert-deftest lsp-mock-server-goto-definition ()
   "Test checking that lsp-mode can follow the symbol definition."
-  (lsp-mock-run-with-mock-server
-   (let ((decl-range (lsp-test-range-make
-                      (buffer-string)
-                      "line 3 words here and here"
-                      "     ^^^^^^^              ")))
-     (lsp-test-schedule-response
-      "textDocument/definition"
-      (vconcat (list `(:uri ,(concat "file://" lsp-test-sample-file)
-                       :range ,(lsp-test-full-range decl-range)))))
-     (lsp-find-definition)
-     ;; 1+ to convert 0-based LSP line number to 1-based Emacs line number
-     (should (equal (1+ (plist-get decl-range :line)) (line-number-at-pos)))
-     (should (equal (plist-get decl-range :from) (current-column))))))
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    (let ((decl-range (lsp-test-range-make
+                       (buffer-string)
+                       "line 3 words here and here"
+                       "     ^^^^^^^              ")))
+      (lsp-test-schedule-response
+       "textDocument/definition"
+       (vconcat (list `(:uri ,(concat "file://" lsp-test-sample-file)
+                        :range ,(lsp-test-full-range decl-range)))))
+      (lsp-find-definition)
+      ;; 1+ to convert 0-based LSP line number to 1-based Emacs line number
+      (should (equal (1+ (plist-get decl-range :line)) (line-number-at-pos)))
+      (should (equal (plist-get decl-range :from) (current-column))))))
 
 (ert-deftest lsp-mock-server-provides-inlay-hints ()
   "lsp-mode accepts inlay hints from the server and displays them."
   (let ((lsp-inlay-hint-enable t)
         (hint-line 2)
         (hint-col 10))
-    (lsp-mock-run-with-mock-server
-     (lsp-mock-with-temp-window
-      (current-buffer)
-      (lambda ()
-        (lsp-test-schedule-response
-         "textDocument/inlayHint"
-         (vconcat (list `(:kind 2
-                          :position (:line ,hint-line :character ,hint-col)
-                          :paddingLeft ()
-                          :label "my hint"))))
-        ;; Lsp will update inlay hints on idling
-        (run-hooks 'lsp-on-idle-hook)
-        (lsp-test-sync-wait 4 "LSP mode inserts inlay hints"
-                            (should (lsp-workspaces))
-                            (lsp-test-all-overlays 'lsp-inlay-hint))
-        (let ((hints (lsp-test-all-overlays 'lsp-inlay-hint)))
-          (should (eq (length hints) 1))
-          (should (equal (overlay-get (car hints) 'before-string) "my hint"))
-          (goto-char (overlay-start (car hints)))
+    (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+      (lsp-mock-with-temp-window
+       (current-buffer)
+       (lambda ()
+         (lsp-test-schedule-response
+          "textDocument/inlayHint"
+          (vconcat (list `(:kind 2
+                           :position (:line ,hint-line :character ,hint-col)
+                           :paddingLeft ()
+                           :label "my hint"))))
+         ;; Lsp will update inlay hints on idling
+         (run-hooks 'lsp-on-idle-hook)
+         (lsp-test-sync-wait 4 "LSP mode inserts inlay hints"
+                             (should (lsp-workspaces))
+                             (lsp-test-all-overlays 'lsp-inlay-hint))
+         (let ((hints (lsp-test-all-overlays 'lsp-inlay-hint)))
+           (should (eq (length hints) 1))
+           (should (equal (overlay-get (car hints) 'before-string) "my hint"))
+           (goto-char (overlay-start (car hints)))
                                         ; 1+ to convert 0-based LSP line number to 1-based Emacs line number
-          (should (equal (line-number-at-pos) (1+ hint-line)))
-          (should (equal (current-column) hint-col)))
-        ;; Disable inlay hints to remove overlays
-        (lsp-test-schedule-response "textDocument/inlayHint" [])
-        (run-hooks 'lsp-on-idle-hook))))))
+           (should (equal (line-number-at-pos) (1+ hint-line)))
+           (should (equal (current-column) hint-col)))
+         ;; Disable inlay hints to remove overlays
+         (lsp-test-schedule-response "textDocument/inlayHint" [])
+         (run-hooks 'lsp-on-idle-hook))))))
 
 (ert-deftest lsp-mock-server-provides-code-lens ()
   "lsp-mode accepts code lenses from the server and displays them."
@@ -912,17 +921,17 @@ line 3 words here and here
                               :end (:line ,line :character 1))
                       :command (:title "My command"
                                 :command "myCommand")))))
-    (lsp-mock-run-with-mock-server
-     (lsp-test-sync-wait 4 "LSP server inserts lenses"
-                         (lsp-test-all-overlays 'lsp-lens))
-     (let ((lenses (lsp-test-all-overlays 'lsp-lens)))
-       (should (eq (length lenses) 1))
-       (should (string-match-p "My command"
-                               (overlay-get (car lenses) 'after-string)))
-       (goto-char (overlay-start (car lenses)))
-       (should (equal (line-number-at-pos) (- line 1))))
-     ;; Remove lens overlays
-     (lsp-lens-hide))))
+    (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+      (lsp-test-sync-wait 4 "LSP server inserts lenses"
+                          (lsp-test-all-overlays 'lsp-lens))
+      (let ((lenses (lsp-test-all-overlays 'lsp-lens)))
+        (should (eq (length lenses) 1))
+        (should (string-match-p "My command"
+                                (overlay-get (car lenses) 'after-string)))
+        (goto-char (overlay-start (car lenses)))
+        (should (equal (line-number-at-pos) (- line 1))))
+      ;; Remove lens overlays
+      (lsp-lens-hide))))
 
 (defun lsp-test-overlay-ranges (tag)
   "Return all overlays tagged TAG in the current buffer as ranges."
@@ -945,46 +954,46 @@ line 3 words here and here
 
 (ert-deftest lsp-mock-server-flycheck-updates-diagnostics ()
   "Test that mock server can update diagnostics and lsp-mode reflects that."
-  (lsp-mock-run-with-mock-server
-   ;; There are no diagnostics at first
-   (should (null (lsp-test-flycheck-diags)))
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    ;; There are no diagnostics at first
+    (should (null (lsp-test-flycheck-diags)))
 
-   ;; Server found a diagnostic
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+    ;; Server found a diagnostic
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
 
-   ;; For some reason, flycheck refuses to call lsp-diagnostics--flycheck-start
-   (lsp-test-sync-wait 4 "Flycheck inserts diagnostics"
-                       (should (lsp-workspaces))
-                       (flycheck-buffer)
-                       (eq (length (lsp-test-flycheck-diags)) 1))
+    ;; For some reason, flycheck refuses to call lsp-diagnostics--flycheck-start
+    (lsp-test-sync-wait 4 "Flycheck inserts diagnostics"
+                        (should (lsp-workspaces))
+                        (flycheck-buffer)
+                        (eq (length (lsp-test-flycheck-diags)) 1))
 
-   ;; The diagnostic is properly received
-   (should (equal (car (lsp-test-flycheck-diags))
-                  (lsp-test-range-make (buffer-string)
-                                       "line 1 unique word broming + common"
-                                       "                   ^^^^^^^         ")))
+    ;; The diagnostic is properly received
+    (should (equal (car (lsp-test-flycheck-diags))
+                   (lsp-test-range-make (buffer-string)
+                                        "line 1 unique word broming + common"
+                                        "                   ^^^^^^^         ")))
 
 
-   ;; Server found a different diagnostic
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "fegam")
-   (let ((old-line (lsp-mock-get-first-diagnostic-line)))
-     (lsp-test-sync-wait 3 "Flycheck diags change"
-                         (should (lsp-workspaces))
-                         (flycheck-buffer)
-                         (not (equal old-line (lsp-mock-get-first-diagnostic-line)))))
+    ;; Server found a different diagnostic
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "fegam")
+    (let ((old-line (lsp-mock-get-first-diagnostic-line)))
+      (lsp-test-sync-wait 3 "Flycheck diags change"
+                          (should (lsp-workspaces))
+                          (flycheck-buffer)
+                          (not (equal old-line (lsp-mock-get-first-diagnostic-line)))))
 
-   ;; The new diagnostics is properly displayed instead of the old one
-   (should (eq (length (lsp-test-flycheck-diags)) 1))
-   (should (equal (car (lsp-test-flycheck-diags))
-                  (lsp-test-range-make (buffer-string)
-                                       "Line 0 unique word fegam and common"
-                                       "                   ^^^^^           ")))
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "nonexistent")
+    ;; The new diagnostics is properly displayed instead of the old one
+    (should (eq (length (lsp-test-flycheck-diags)) 1))
+    (should (equal (car (lsp-test-flycheck-diags))
+                   (lsp-test-range-make (buffer-string)
+                                        "Line 0 unique word fegam and common"
+                                        "                   ^^^^^           ")))
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "nonexistent")
 
-   (lsp-test-sync-wait 3 "Flycheck diags dissipate"
-                       (should (lsp-workspaces))
-                       (flycheck-buffer)
-                       (null (lsp-test-flycheck-diags)))))
+    (lsp-test-sync-wait 3 "Flycheck diags dissipate"
+                        (should (lsp-workspaces))
+                        (flycheck-buffer)
+                        (null (lsp-test-flycheck-diags)))))
 
 (ert-deftest lsp-mock-server-flycheck-updates-diags-with-delay ()
   "Test demonstrating delay in the diagnostics update.
@@ -993,62 +1002,62 @@ If server takes noticeable time to update diagnostics after a
 document change, and `lsp-diagnostic-clean-after-change' is
 nil (default), diagnostic ranges will be off until server
 publishes the update. This test demonstrates this behavior."
-  (lsp-mock-run-with-mock-server
-   ;; There are no diagnostics at first
-   (should (null (lsp-test-flycheck-diags)))
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flycheck
+    ;; There are no diagnostics at first
+    (should (null (lsp-test-flycheck-diags)))
 
-   ;; Server found diagnostic
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
-   (lsp-test-sync-wait
-    4 "LSP mode to receive initial diagnostic"
-    (should (lsp-workspaces))
-    (flycheck-buffer)
-    (eq (length (lsp-test-flycheck-diags)) 1))
+    ;; Server found diagnostic
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+    (lsp-test-sync-wait
+     4 "LSP mode to receive initial diagnostic"
+     (should (lsp-workspaces))
+     (flycheck-buffer)
+     (eq (length (lsp-test-flycheck-diags)) 1))
 
-   ;; The diagnostic is properly received
-   (should (equal (car (lsp-test-flycheck-diags))
-                  (lsp-test-range-make (buffer-string)
-                                       "line 1 unique word broming + common"
-                                       "                   ^^^^^^^         ")))
+    ;; The diagnostic is properly received
+    (should (equal (car (lsp-test-flycheck-diags))
+                   (lsp-test-range-make (buffer-string)
+                                        "line 1 unique word broming + common"
+                                        "                   ^^^^^^^         ")))
 
-   ;; Change the text: remove the first line
-   (goto-char (point-min))
-   (kill-line 1)
-   (should (string-equal (buffer-string)
-                         "line 1 unique word broming + common
+    ;; Change the text: remove the first line
+    (goto-char (point-min))
+    (kill-line 1)
+    (should (string-equal (buffer-string)
+                          "line 1 unique word broming + common
 line 2 unique word normalw common here
 line 3 words here and here
 "))
-   ;; Give it some time to update
-   (sleep-for 0.5)
-   (flycheck-buffer)
-   ;; The diagnostic is not updated and now points to a wrong line
-   (should (equal (car (lsp-test-flycheck-diags))
-                  (lsp-test-range-make (buffer-string)
-                                       "line 2 unique word normalw common here"
-                                       "                   ^^^^^^^            ")))
+    ;; Give it some time to update
+    (sleep-for 0.5)
+    (flycheck-buffer)
+    ;; The diagnostic is not updated and now points to a wrong line
+    (should (equal (car (lsp-test-flycheck-diags))
+                   (lsp-test-range-make (buffer-string)
+                                        "line 2 unique word normalw common here"
+                                        "                   ^^^^^^^            ")))
 
-   ;; Server sent an update
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+    ;; Server sent an update
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
 
-   (let ((old-line (lsp-mock-get-first-diagnostic-line)))
-     (lsp-test-sync-wait 4 "LSP mode to receive updated diagnostics"
-                         (should (lsp-workspaces))
-                         (not (equal old-line (lsp-mock-get-first-diagnostic-line)))))
-   (flycheck-buffer)
+    (let ((old-line (lsp-mock-get-first-diagnostic-line)))
+      (lsp-test-sync-wait 4 "LSP mode to receive updated diagnostics"
+                          (should (lsp-workspaces))
+                          (not (equal old-line (lsp-mock-get-first-diagnostic-line)))))
+    (flycheck-buffer)
 
-   ;; Now the diagnostic is correct again
-   (should (equal (car (lsp-test-flycheck-diags))
-                  (lsp-test-range-make (buffer-string)
-                                       "line 1 unique word broming + common"
-                                       "                   ^^^^^^^         ")))
+    ;; Now the diagnostic is correct again
+    (should (equal (car (lsp-test-flycheck-diags))
+                   (lsp-test-range-make (buffer-string)
+                                        "line 1 unique word broming + common"
+                                        "                   ^^^^^^^         ")))
 
-   ;; Remove diagnostics
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "nonexistent")
-   (lsp-test-sync-wait 3 "Flycheck diags dissipate"
-                       (should (lsp-workspaces))
-                       (flycheck-buffer)
-                       (null (lsp-test-flycheck-diags)))))
+    ;; Remove diagnostics
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "nonexistent")
+    (lsp-test-sync-wait 3 "Flycheck diags dissipate"
+                        (should (lsp-workspaces))
+                        (flycheck-buffer)
+                        (null (lsp-test-flycheck-diags)))))
 
 (defun lsp-test-flymake-diags ()
   "Get all diags displayed by flymake."
@@ -1065,66 +1074,92 @@ off until server publishes the update. However, flymake keeps the
 overlays it created until an update comes, and overlays are
 automatically adjusted on every edit, so diagnostic ranges remain
 correct."
-  (lsp-mock--run-with-mock-server
-   :flymake
-   (lambda ()
-     ;; There are no diagnostics at first
-     (should (null (lsp-test-flymake-diags)))
+  (lsp-mock-run-with-mock-server lsp-test-sample-file :flymake
+    ;; There are no diagnostics at first
+    (should (null (lsp-test-flymake-diags)))
 
-     ;; Server found diagnostic
-     (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
-     (lsp-test-sync-wait
-      4 "LSP mode to receive initial diagnostic"
-      (should (lsp-workspaces))
-      (flymake-start)
-      (eq (length (lsp-test-flymake-diags)) 1))
+    ;; Server found diagnostic
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+    (lsp-test-sync-wait
+     4 "LSP mode to receive initial diagnostic"
+     (should (lsp-workspaces))
+     (flymake-start)
+     (eq (length (lsp-test-flymake-diags)) 1))
 
-     ;; The diagnostic is properly received
-     (should (equal (car (lsp-test-flymake-diags))
-                    (lsp-test-range-make (buffer-string)
-                                         "line 1 unique word broming + common"
-                                         "                   ^^^^^^^         ")))
-     ;; Change the text: remove the first line
-     (goto-char (point-min))
-     (kill-line 1)
-     (should (string-equal (buffer-string)
-                           "line 1 unique word broming + common
+    ;; The diagnostic is properly received
+    (should (equal (car (lsp-test-flymake-diags))
+                   (lsp-test-range-make (buffer-string)
+                                        "line 1 unique word broming + common"
+                                        "                   ^^^^^^^         ")))
+    ;; Change the text: remove the first line
+    (goto-char (point-min))
+    (kill-line 1)
+    (should (string-equal (buffer-string)
+                          "line 1 unique word broming + common
 line 2 unique word normalw common here
 line 3 words here and here
 "))
-     ;; Give it some time to update
-     (sleep-for 0.5)
-     (flymake-start)
-     ;; Unlike flycheck, flymake keeps the old diagnostics as overlays until it
-     ;; gets an update. So the range of the diagnostic is preserved properly.
-     (should (equal (car (lsp-test-flymake-diags))
-                    (lsp-test-range-make (buffer-string)
-                                         "line 1 unique word broming + common"
-                                         "                   ^^^^^^^         ")))
+    ;; Give it some time to update
+    (sleep-for 0.5)
+    (flymake-start)
+    ;; Unlike flycheck, flymake keeps the old diagnostics as overlays until it
+    ;; gets an update. So the range of the diagnostic is preserved properly.
+    (should (equal (car (lsp-test-flymake-diags))
+                   (lsp-test-range-make (buffer-string)
+                                        "line 1 unique word broming + common"
+                                        "                   ^^^^^^^         ")))
 
-     ;; Server sent an update
-     (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+    ;; Server sent an update
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
 
-     (let ((old-line (lsp-mock-get-first-diagnostic-line)))
-       (lsp-test-sync-wait 4 "LSP mode to receive updated diagnostics"
-                           (should (lsp-workspaces))
-                           (not (equal old-line (lsp-mock-get-first-diagnostic-line)))))
-     (flymake-start)
+    (let ((old-line (lsp-mock-get-first-diagnostic-line)))
+      (lsp-test-sync-wait 4 "LSP mode to receive updated diagnostics"
+                          (should (lsp-workspaces))
+                          (not (equal old-line (lsp-mock-get-first-diagnostic-line)))))
+    (flymake-start)
 
-     ;; Upon reception, flymake replaces the old overlays with the
-     ;; new ones placed on the reported position, which happend to
-     ;; be the same.
-     (should (equal (car (lsp-test-flymake-diags))
-                    (lsp-test-range-make (buffer-string)
-                                         "line 1 unique word broming + common"
-                                         "                   ^^^^^^^         ")))
+    ;; Upon reception, flymake replaces the old overlays with the
+    ;; new ones placed on the reported position, which happend to
+    ;; be the same.
+    (should (equal (car (lsp-test-flymake-diags))
+                   (lsp-test-range-make (buffer-string)
+                                        "line 1 unique word broming + common"
+                                        "                   ^^^^^^^         ")))
 
-     ;; Remove diagnostics
-     (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "nonexistent")
-     (lsp-test-sync-wait 3 "Flymake diags dissipate"
-                         (should (lsp-workspaces))
-                         (flymake-start)
-                         (null (lsp-test-flymake-diags))))))
+    ;; Remove diagnostics
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "nonexistent")
+    (lsp-test-sync-wait 3 "Flymake diags dissipate"
+                        (should (lsp-workspaces))
+                        (flymake-start)
+                        (null (lsp-test-flymake-diags)))))
+
+(defun lsp-mock-edit-org-buffer ()
+  "Edit the org buffer: remove 2 lines and undent code block."
+  ;; Change the text: remove the first line in the org doc itself
+  (goto-char (point-min))
+  (kill-line 1)
+  ;; And in the code block
+  (search-forward "Line 0 unique")
+  (goto-char (line-beginning-position))
+  (kill-line 1)
+  ;; And unindent the block by 2 characters
+  (forward-line -1)
+  (dotimes (_ 5) ;; 3 lines in the code block + begin_src + end_src lines
+    (goto-char (line-beginning-position))
+    (kill-forward-chars 2)
+    (forward-line 1))
+  (forward-line -1)
+  (should (string-equal (buffer-string)
+                        "
+** Header to a section with some indentation
+     language =prog= will resolve into the =prog-mode= - mode for the mock LSP server
+   #+begin_src prog :tangle \"sample.txt\"
+   line 1 unique word broming + common
+   line 2 unique word normalw common here
+   line 3 words here and here
+   #+end_src
+")))
+
 
 
 ;;; lsp-mock-server-test.el ends here

--- a/test/lsp-mock-server-test.el
+++ b/test/lsp-mock-server-test.el
@@ -296,7 +296,9 @@ TEST-BODY can interact with the mock server."
     (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
                    (lsp-test-range-make (buffer-string)
                                         "line 1 unique word broming + common"
-                                        "                   ^^^^^^^         ")))))
+                                        "                   ^^^^^^^         ")))
+    ;; Clean up diagnostics
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "non-existing")))
 
 (ert-deftest lsp-mock-server-crashes ()
   "Test that the mock server crashes when instructed so."
@@ -357,7 +359,9 @@ TEST-BODY can interact with the mock server."
     (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
                    (lsp-test-range-make (buffer-string)
                                         "Line 0 unique word fegam and common"
-                                        "                   ^^^^^           ")))))
+                                        "                   ^^^^^           ")))
+    ;; Clean up diagnostics
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "non-existing")))
 
 (ert-deftest lsp-mock-server-updates-diags-with-delay ()
   "Test demonstrating delay in the diagnostics update.
@@ -411,7 +415,9 @@ line 3 words here and here
     (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
                    (lsp-test-range-make (buffer-string)
                                         "line 1 unique word broming + common"
-                                        "                   ^^^^^^^         ")))))
+                                        "                   ^^^^^^^         ")))
+    ;; Clean up diagnostics
+    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "non-existing")))
 
 (ert-deftest lsp-mock-server-updates-diags-clears-up ()
   "Test ensuring diagnostics are cleared after a change."
@@ -454,7 +460,9 @@ line 3 words here and here
       (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
                      (lsp-test-range-make (buffer-string)
                                           "line 1 unique word broming + common"
-                                          "                   ^^^^^^^         "))))))
+                                          "                   ^^^^^^^         ")))
+      ;; Clean up diagnostics
+      (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "non-existing"))))
 
 (defun lsp-test-xref-loc-to-range (xref-loc)
   "Convert XREF-LOC to a range p-list.
@@ -616,7 +624,6 @@ TEST-FN is a function to call with the temporary window."
                            4 "LSP mode to receive highlights"
                            (should (lsp-workspaces))
                            (lsp-test-all-overlays-as-ranges 'lsp-highlight)))))
-         (message "%s" highlights)
          (should (eq (length highlights) 3))
          (should (equal (nth 0 highlights)
                         (lsp-test-range-make (buffer-string)

--- a/test/mock-lsp-server.el
+++ b/test/mock-lsp-server.el
@@ -142,9 +142,7 @@ Key is the method, and value is the `result' field in the response.")
 This function is useful for external commands,
 allowing control over the server responses.
 
-You can schedule only one response for a method for the entire session."
-  (when (gethash method scheduled-responses)
-    (error "Response for method %s is already scheduled" method))
+You can schedule only one response for a method at a time."
   (puthash method result scheduled-responses))
 
 (defun get-method (input)


### PR DESCRIPTION
To keep the diagnostic ranges actual after document edits and before LSP sends an update (can take multiple seconds or even minutes for SonarLint C++ analysis), allocate an overlay for each diagnostic and use it as the reference for its range.
This change works well together with #4512, which spares the LSP server from playing catch-up with the user modifications.

`lsp-diagnostics` and `lsp--get-buffer-diagnostics` now have an additional optional argument: `update-ranges?` that refreshes the diagnostic ranges.

This fixes #4501.