### PR TITLE
Generate language server enum settings as const string choices

### DIFF
--- a/scripts/lsp-generate-settings.el
+++ b/scripts/lsp-generate-settings.el
@@ -37,7 +37,8 @@
 ENUM is the value of enum key in vscode manifest."
   (cond
    ((and enum (not (or (equal "boolean" type)
-                       (equal '("boolean") type)))) `(choice (:tag ,@(append enum nil))))
+                       (equal '("boolean") type))))
+    `(choice ,@(mapcar (lambda (e) `(const ,(format "\"%s\"" e))) enum)))
    (t (pcase type
         ("boolean" 'boolean)
         ('("boolean") 'boolean)


### PR DESCRIPTION
Fixes [#4515](https://github.com/emacs-lsp/lsp-mode/issues/4515#issue-2438275163). Relates to [this](https://github.com/emacs-lsp/lsp-haskell/pull/186#issue-2436193990) PR on [lsp-haskell](https://github.com/emacs-lsp/lsp-haskell).