### PR TITLE
feat: add `lsp-yaml-schema-extensions`

### DIFF
--- a/clients/lsp-yaml.el
+++ b/clients/lsp-yaml.el
@@ -172,9 +172,9 @@ Limited for performance reasons."
                                         (lsp-package-ensure 'yaml-language-server
                                                             callback error-callback))))
 
-(defcustom lsp-yaml-schema-extensions '(((name . "Kubernetes Built-In")
-                                          (description . "Built-in `yaml-language-server' kubernetes manifest schema definition")
-                                          (url . "kubernetes")
+(defcustom lsp-yaml-schema-extensions '(((name . "Kubernetes v1.30.3")
+                                          (description . "Kubernetes v1.30.3 manifest schema definition")
+                                          (url . "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.3-standalone-strict/all.json")
                                           (fileMatch . ["*-k8s.yaml" "*-k8s.yml"])))
   "List of user defined schemas to be provided in `lsp-yaml--get-supported-schemas' alongside schemas from `lsp-yaml-schema-store-uri'."
   :type  'list

--- a/clients/lsp-yaml.el
+++ b/clients/lsp-yaml.el
@@ -176,7 +176,9 @@ Limited for performance reasons."
                                           (description . "Kubernetes v1.30.3 manifest schema definition")
                                           (url . "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.3-standalone-strict/all.json")
                                           (fileMatch . ["*-k8s.yaml" "*-k8s.yml"])))
-  "List of user defined schemas to be provided in `lsp-yaml--get-supported-schemas' alongside schemas from `lsp-yaml-schema-store-uri'."
+  "User defined schemas that extend default schema store.
+Used in `lsp-yaml--get-supported-schemas' to supplement schemas provided by
+`lsp-yaml-schema-store-uri'."
   :type  'list
   :group 'lsp-yaml
   :package-version '(lsp-mode . "9.0.1"))

--- a/clients/lsp-yaml.el
+++ b/clients/lsp-yaml.el
@@ -172,11 +172,14 @@ Limited for performance reasons."
                                         (lsp-package-ensure 'yaml-language-server
                                                             callback error-callback))))
 
-(defconst lsp-yaml--built-in-kubernetes-schema
-  '((name . "Kubernetes")
-    (description . "Built-in kubernetes manifest schema definition")
-    (url . "kubernetes")
-    (fileMatch . ["*-k8s.yaml" "*-k8s.yml"])))
+(defcustom lsp-yaml-schema-extensions '(((name . "Kubernetes Built-In")
+                                          (description . "Built-in `yaml-language-server' kubernetes manifest schema definition")
+                                          (url . "kubernetes")
+                                          (fileMatch . ["*-k8s.yaml" "*-k8s.yml"])))
+  "List of user defined schemas to be provided in `lsp-yaml--get-supported-schemas' alongside schemas from `lsp-yaml-schema-store-uri'."
+  :type  'list
+  :group 'lsp-yaml
+  :package-version '(lsp-mode . "9.0.1"))
 
 (defun lsp-yaml-download-schema-store-db (&optional force-downloading)
   "Download remote schema store at `lsp-yaml-schema-store-uri' into local cache.
@@ -194,7 +197,7 @@ Set FORCE-DOWNLOADING to non-nil to force re-download the database."
     (lsp-yaml-download-schema-store-db)
     (setq lsp-yaml--schema-store-schemas-alist
           (alist-get 'schemas (json-read-file lsp-yaml-schema-store-local-db))))
-  (seq-concatenate 'list (list lsp-yaml--built-in-kubernetes-schema) lsp-yaml--schema-store-schemas-alist))
+  (seq-concatenate 'list lsp-yaml-schema-extensions lsp-yaml--schema-store-schemas-alist))
 
 (defun lsp-yaml-set-buffer-schema (uri-string)
   "Set yaml schema for the current buffer to URI-STRING."


### PR DESCRIPTION
This commit replaces defconst `lsp-yaml--built-in-kubernetes-schema` with defcustom `lsp-yaml-schema-extensions` to
enable users to extend the dropdown options provided by `lsp-yaml--get-supported-schemas`. This is helpful since users are no longer locked into the yaml-language-server's version of the Kubernetes schema on a per buffer basis. This also enables users to provide more schemas and multiple versions of schemas if need be i.e. multiple versions of the Kubernetes schema, if you work across multiple clusters.