### PR TITLE
lsp-rust: report command capabilities

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1761,7 +1761,17 @@ https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/lsp-extensions.m
   :semantic-tokens-faces-overrides `( :discard-default-modifiers t
                                       :modifiers ,(lsp-rust-analyzer--semantic-modifiers))
   :server-id 'rust-analyzer
-  :custom-capabilities `((experimental . ((snippetTextEdit . ,(and lsp-enable-snippet (fboundp 'yas-minor-mode))))))
+  :custom-capabilities `((experimental .
+                                       ((snippetTextEdit . ,(and lsp-enable-snippet (fboundp 'yas-minor-mode)))
+                                        (commands . ((commands .
+                                                               [
+                                                                "rust-analyzer.runSingle"
+                                                                "rust-analyzer.debugSingle"
+                                                                "rust-analyzer.showReferences"
+                                                                ;; "rust-analyzer.gotoLocation"
+                                                                "rust-analyzer.triggerParameterHints"
+                                                                ;; "rust-analyzer.rename"
+                                                                ]))))))
   :download-server-fn (lambda (_client callback error-callback _update?)
                         (lsp-package-ensure 'rust-analyzer callback error-callback))))
 


### PR DESCRIPTION
Since
https://github.com/rust-lang/rust-analyzer/commit/49184a138cb4df11279e81a6233a2b5014715771 rust-analyzer no longer assumes clients implement all remote commands.

Since it gates the lenses it returns based on the known commands in the client, it no longer returns many useful ones.

This PR explicitly lists the available commands, as mapped in the code a few lines above.