### PR TITLE
(docs) Update the `sqls` URL to match the current organization

### DIFF
--- a/clients/lsp-sqls.el
+++ b/clients/lsp-sqls.el
@@ -29,7 +29,7 @@
 (defgroup lsp-sqls nil
   "LSP support for SQL, using sqls."
   :group 'lsp-mode
-  :link '(url-link "https://github.com/lighttiger2505/sqls")
+  :link '(url-link "https://github.com/sqls-server/sqls")
   :package-version `(lsp-mode . "7.0"))
 
 (defcustom lsp-sqls-server "sqls"

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -1029,8 +1029,8 @@
     "name": "sqls",
     "full-name": "SQL (sqls)",
     "server-name": "sqls",
-    "server-url": "https://github.com/lighttiger2505/sqls",
-    "installation": "go install github.com/lighttiger2505/sqls@latest",
+    "server-url": "https://github.com/sqls-server/sqls",
+    "installation": "go install github.com/sqls-server/sqls@latest",
     "debugger": "Not available"
   },
   {


### PR DESCRIPTION
## About

The [`sqls` document](https://emacs-lsp.github.io/lsp-mode/page/lsp-sqls/) said:

> Installation
> go install github.com/lighttiger2505/sqls@latest

But it failed like this:

```sh
$ go install github.com/lighttiger2505/sqls@latest
go: github.com/lighttiger2505/sqls@latest: version constraints conflict:
        github.com/lighttiger2505/sqls@v0.2.28: parsing go.mod:
        module declares its path as: github.com/sqls-server/sqls
                but was required as: github.com/lighttiger2505/sqls
```

`sqls-server/sqls` is successful:

```sh
$ go install github.com/sqls-server/sqls@latest
```