### PR TITLE
feat: Add `lsp-sql-show-tables` command to `lsp-sqls`

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,7 @@
   * Add support for C# via the [[https://github.com/dotnet/roslyn/tree/main/src/LanguageServer][Roslyn language server]].
   * Add basic support for [[https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics][pull diagnostics]] requests.
   * Add ~lsp-flush-delayed-changes-before-next-message~ customization point to enforce throttling document change notifications.
+  * Add ~lsp-sql-show-tables~ command.
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/clients/lsp-sqls.el
+++ b/clients/lsp-sqls.el
@@ -143,6 +143,14 @@ use the current region if set, otherwise the entire buffer."
     "workspace/executeCommand"
     (list :command "showConnections" :timeout lsp-sqls-timeout))))
 
+(defun lsp-sql-show-tables (&optional _command)
+  "Show tables."
+  (interactive)
+  (lsp-sqls--show-results
+   (lsp-request
+    "workspace/executeCommand"
+    (list :command "showTables" :timeout lsp-sqls-timeout))))
+
 (defun lsp-sql-switch-database (&optional _command)
   "Switch database."
   (interactive)
@@ -176,6 +184,7 @@ use the current region if set, otherwise the entire buffer."
                                        ("showDatabases" #'lsp-sql-show-databases)
                                        ("showSchemas" #'lsp-sql-show-schemas)
                                        ("showConnections" #'lsp-sql-show-connections)
+                                       ("showTables" #'lsp-sql-show-tables)
                                        ("switchDatabase" #'lsp-sql-switch-database)
                                        ("switchConnections" #'lsp-sql-switch-connection))
                   :server-id 'sqls


### PR DESCRIPTION
## About

- The `sqls` server is supporting `showTables` command
    - https://github.com/sqls-server/sqls/blob/eb695acda8a928f6633555fedb91b22e6290f0f0/internal/handler/execute_command.go#L29
- I want to add `lsp-sql-show-tables` command using it.

## Screenshot

- `M-x lsp-sql-show-tables`

<img width="847" alt="screenshot" src="https://github.com/user-attachments/assets/06a3ddc2-f659-401d-ad19-aca9a999df10">

