### PR TITLE
docs: fix `lsp-sqls-workspace-config-path` behavior

### DIFF
--- a/docs/manual-language-docs/lsp-sqls.md
+++ b/docs/manual-language-docs/lsp-sqls.md
@@ -14,7 +14,10 @@ root_file: docs/manual-language-docs/lsp-sqls.md
 
 ```
 
-Alternatively, you can leave `lsp-sqls-workspace-config-path` to the default "workspace" value, and put a json file in `<project>/.sqls/config.json` containing
+## Storing Configuration in `<project>/.sqls/config.json`
+
+Alternatively, you can store your configuration in the project root at `<project>/.sqls/config.json`:
+
 ```
 {
   "sqls": {
@@ -29,4 +32,29 @@ Alternatively, you can leave `lsp-sqls-workspace-config-path` to the default "wo
 }
 ```
 
-Now lsp should start in sql-mode buffers, and you can pick a server connection with `M-x lsp-execute-code-action` and "Switch Connections" (or directly with `M-x lsp-sql-switch-connection`). You can change database with `M-x lsp-execute-code-action` and "Switch Database" (or `M-x lsp-sql-switch-database`).
+In this case, you need to set `lsp-sqls-workspace-config-path` to "root":
+
+```emacs-lisp
+(setq lsp-sqls-workspace-config-path "root")
+```
+
+## Storing Configuration in the Current Directory
+
+If you want to configure it for the current directory, you can create a `.sqls/config.json` file:
+
+```
+.sqls/config.json
+target.sql
+```
+
+For this setup, ensure that `lsp-sqls-workspace-config-path` is set to "workspace":
+
+```emacs-lisp
+(setq lsp-sqls-workspace-config-path "workspace")
+```
+
+# Switching Connections and Databases
+
+Now, lsp should start in sql-mode buffers. You can choose a server connection using `M-x lsp-execute-code-action` and then selecting "Switch Connections", or directly with `M-x lsp-sql-switch-connection`.
+
+To change the database, use `M-x lsp-execute-code-action` and select "Switch Database" (or `M-x lsp-sql-switch-database`).


### PR DESCRIPTION
## About

The current `lsp-sql` documentation does not match the actual behavior.

> Alternatively, you can leave lsp-sqls-workspace-config-path to the default "workspace" value, and put a json file in <project>/.sqls/config.json containing

This is incorrect. The current behavior is to define "root" instead of "workspace."

## Codes

https://github.com/emacs-lsp/lsp-mode/blob/c36b95be6625dac5a37d3874a1a738e0c84ac39f/clients/lsp-sqls.el#L72-L79

## Notes

I am not a native English speaker. Please let me know if there are any unnatural phrases in this pull request.