### PR TITLE
Fix typo in for digestify/LaTeX-mode

### DIFF
--- a/clients/lsp-tex.el
+++ b/clients/lsp-tex.el
@@ -46,7 +46,7 @@
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection lsp-clients-digestif-executable)
-                  :major-modes '(plain-tex-mode latex-mode context-mode texinfo-mode LaTex-mode)
+                  :major-modes '(plain-tex-mode latex-mode context-mode texinfo-mode LaTeX-mode)
                   :priority (if (eq lsp-tex-server 'digestif) 1 -1)
                   :server-id 'digestif))
 


### PR DESCRIPTION
As I pointed out [here](https://github.com/emacs-lsp/lsp-mode/pull/4466/files/2eba80a8db9c2c8d0528ebd1e3076d05e86007c7), this typo is preventing digestify from working in `LaTeX-mode`.

I have tested on my local machine that it works with at least two of my latex projects.