### PR TITLE
Fix logic for rust-analyzer.checkOnSave.features setting inheritance

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,7 @@
   * Add support for C# via the [[https://github.com/dotnet/roslyn/tree/main/src/LanguageServer][Roslyn language server]].
   * Add basic support for [[https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics][pull diagnostics]] requests.
   * Add ~lsp-flush-delayed-changes-before-next-message~ customization point to enforce throttling document change notifications.
+  * Fix bug in ~rust-analyzer.check.features~ configuration via ~lsp-rust-checkonsave-features~ Emacs setting: we were defaulting to ~[]~, but ~rust-analyzer~ defaults to inheriting the value from ~rust-analyzer.cargo.features~. The bug resulted in code hidden behind features not getting type checked when those features were enabled by setting ~rust-analyzer.cargo.features~ via the ~lsp-rust-features~ Emacs setting.
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.


### PR DESCRIPTION
# Problem addressed by this PR

The rust-analyzer inherits the setting of [`rust-analyzer.checkOnSave.features`](https://rust-analyzer.github.io/manual.html#rust-analyzer.check.features) from [`rust-analyzer.cargo.features`](https://rust-analyzer.github.io/manual.html#rust-analyzer.cargo.features) by default, but the elisp code here was incorrectly defaulting the former to the empty list, regardless of the value of the latter. The effect was that `rust-analyzer.cargo.features` disabled warnings about "inactive code", without actually turning on type checking of that code!

Besides fixing the bug, by distinguishing between "unset" (`null` in the rust-analyzer docs) and "set to the empty list" (`[]` in the rust-analyzer docs), this PR also improves the docs, by mentioning the documented rust-analyzer settings that correspond to the Elisp variables here, which should help with discoverability of these settings (I had a hard time finding them).

# Example of the bug

Create a simple Rust project with a `Cargo.toml` like this:

```toml
[package]
name = "example"
version = "0.1.0"
edition = "2021"

[features]
foo = []

[dependencies]
```

And a `src/main.rs` like this:

```rust
fn main() {
    #[cfg(feature = "foo")]
    foo();
}

#[cfg(feature = "foo")]
fn foo() {
    // Type error:
    let x = 1 + "2";
    println!("{}", x);
}
```

If you open `main.rs` in Emacs with `rust-analyzer` enabled, you will see that that `foo` function definition and usage are inactive, because the `"foo"` feature is not enabled:

![defaults](https://github.com/user-attachments/assets/716beb53-e756-422f-b003-ee1abea21c3e)

However, if you enable the `"foo"` feature in lsp by setting the `lsp-rust-features` variable with

```sh
M-: (setq lsp-rust-features ["foo"]) RET
M-x lsp-restart-workspace RET
```

then you will see that the `foo` function definition and usage are no longer
marked as inactive, but the type error is not highlighted:

![before-fix](https://github.com/user-attachments/assets/19515fdf-327a-4b2e-a0eb-dfb913368f85)

After the fix in this PR, you instead see the type error highlighted:

![after-fix](https://github.com/user-attachments/assets/c7ed6912-e002-4eed-aaed-92b21acb3732)

The old behavior can be recovered by setting `lsp-rust-analyzer-checkonsave-features` to `[]`, but that's no longer the default.