### PR TITLE
Remove unsupported settings in `ruff server`

### DIFF
--- a/clients/lsp-ruff.el
+++ b/clients/lsp-ruff.el
@@ -38,10 +38,10 @@ Previous ruff-lsp should change this to (\"ruff-lsp\")"
   :type '(repeat string)
   :group 'lsp-ruff)
 
-(defcustom lsp-ruff-ruff-args []
+(defcustom lsp-ruff-ruff-args '()
   "Arguments, passed to ruff."
   :risky t
-  :type 'lsp-string-vector
+  :type '(repeat string)
   :group 'lsp-ruff)
 
 (defcustom lsp-ruff-log-level "error"

--- a/clients/lsp-ruff.el
+++ b/clients/lsp-ruff.el
@@ -38,12 +38,6 @@ Previous ruff-lsp should change this to (\"ruff-lsp\")"
   :type '(repeat string)
   :group 'lsp-ruff)
 
-(defcustom lsp-ruff-ruff-path ["ruff"]
-  "Paths to ruff to try, in order."
-  :risky t
-  :type 'lsp-string-vector
-  :group 'lsp-ruff)
-
 (defcustom lsp-ruff-ruff-args []
   "Arguments, passed to ruff."
   :risky t

--- a/clients/lsp-ruff.el
+++ b/clients/lsp-ruff.el
@@ -87,7 +87,7 @@ Previous ruff-lsp should change this to (\"ruff-lsp\")"
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection
-                   (lambda () lsp-ruff-server-command))
+                   (lambda () (append lsp-ruff-server-command lsp-ruff-ruff-args)))
   :activation-fn (lsp-activate-on "python")
   :server-id 'ruff
   :priority -2

--- a/clients/lsp-ruff.el
+++ b/clients/lsp-ruff.el
@@ -101,10 +101,7 @@ Previous ruff-lsp should change this to (\"ruff-lsp\")"
   :initialization-options
   (lambda ()
     (list :settings
-          (list :args lsp-ruff-ruff-args
-                :logLevel lsp-ruff-log-level
-                :path lsp-ruff-ruff-path
-                :interpreter (vector lsp-ruff-python-path)
+          (list :logLevel lsp-ruff-log-level
                 :showNotifications lsp-ruff-show-notifications
                 :organizeImports (lsp-json-bool lsp-ruff-advertize-organize-imports)
                 :fixAll (lsp-json-bool lsp-ruff-advertize-fix-all)


### PR DESCRIPTION
I removed unsupported settings in `ruff server`.
https://docs.astral.sh/ruff/editors/migration/#unsupported-settings

I also changed `lsp-ruff-ruff-args` to be used under `new-connection` function to remove the setting `args`.

related issue: #4451