### PR TITLE
Correctly clean up lsp--update-signature-help-hook

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4120,7 +4120,8 @@ yet."
     (cond
      ((and (or (equal lsp-signature-auto-activate t)
                (memq :on-trigger-char lsp-signature-auto-activate))
-           signature-help-handler)
+           signature-help-handler
+           (not cleanup?))
       (add-hook 'post-self-insert-hook signature-help-handler nil t))
 
      ((or cleanup?


### PR DESCRIPTION
lsp--update-signature-help-hook is not correctly removed when lsp-managed-mode is disabled.

Steps to reproduce:
open https://git.sr.ht/~davidcode/emacs-lsp-problem, and then try to disable lsp-mode and lsp-managed-mode

check the value of the variable post-self-insert-hook.


verified this change by running lsp-managed-mode (to turn it on and off) with the applied changes, and the post hook is no longer visible.


This has a real impact, as it pops up documentation strings, even after LSP mode is turned off.

Paired with David Howard on finding this issue.