### PR TITLE
Provide a unified (lsp-interface INTERFACE ...) pcase form

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -14,7 +14,9 @@
   * Change ~ruff-lsp~ to ~ruff~ for python lsp client. All ~ruff-lsp~ customizable variable change to ~ruff~. Lsp server command now is ~["ruff" "server"]~ instead of ~["ruff-lsp"]~.
   * Add futhark support
   * Optimize overlay creation by checking window visibility first
-
+  * Replace the per-interface ~(INTERFACE ...)~ pcase forms with a single,
+    unified ~(lsp-interface INTERFACE ...)~ form. The per-interface forms are no
+    longer generated. *This is a breaking change.* (See #4430.)
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -575,8 +575,8 @@ Others: CANDIDATES"
           (apply #'delete-region markers)
           (insert prefix)
           (pcase text-edit?
-            ((TextEdit) (lsp--apply-text-edit text-edit?))
-            ((InsertReplaceEdit :insert :replace :new-text)
+            ((lsp-interface TextEdit) (lsp--apply-text-edit text-edit?))
+            ((lsp-interface InsertReplaceEdit :insert :replace :new-text)
              (lsp--apply-text-edit
               (lsp-make-text-edit
                :new-text new-text

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5245,11 +5245,11 @@ identifier and the position respectively."
 type Location, LocationLink, Location[] or LocationLink[]."
   (setq locations
         (pcase locations
-          ((seq (or (Location)
-                    (LocationLink)))
+          ((seq (or (lsp-interface Location)
+                    (lsp-interface LocationLink)))
            (append locations nil))
-          ((or (Location)
-               (LocationLink))
+          ((or (lsp-interface Location)
+               (lsp-interface LocationLink))
            (list locations))))
 
   (cl-labels ((get-xrefs-in-file
@@ -5616,9 +5616,9 @@ When language is nil render as markup if `markdown-mode' is loaded."
   (let ((inhibit-message t))
     (or
      (pcase content
-       ((MarkedString :value :language)
+       ((lsp-interface MarkedString :value :language)
         (lsp--render-string value language))
-       ((MarkupContent :value :kind)
+       ((lsp-interface MarkupContent :value :kind)
         (lsp--render-string value kind))
        ;; plain string
        ((pred stringp) (lsp--render-string content "markdown"))
@@ -6408,11 +6408,11 @@ perform the request synchronously."
   (-mapcat
    (-lambda (sym)
      (pcase-exhaustive sym
-       ((DocumentSymbol :name :children? :selection-range (Range :start))
+       ((lsp-interface DocumentSymbol :name :children? :selection-range (lsp-interface Range :start))
         (cons (cons (concat path name)
                     (lsp--position-to-point start))
               (lsp--xref-elements-index children? (concat path name " / "))))
-       ((SymbolInformation :name :location (Location :range (Range :start)))
+       ((lsp-interface SymbolInformation :name :location (lsp-interface Location :range (lsp-interface Range :start)))
         (list (cons (concat path name)
                     (lsp--position-to-point start))))))
    symbols))

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -225,6 +225,12 @@ Allowed params: %s" interface (reverse (-map #'cl-first params)))
                                              output-bindings)
                                        (setf current-list (cddr current-list))))))
                                  output-bindings))))
+                    ;; These per-interface `pcase' forms are deprecated. Prefer
+                    ;; the new (lsp-interface INTERFACE ...) form defined below.
+                    ;; (See emacs-lsp/lsp-mode#4430.)
+                    ;;
+                    ;; TODO: Remove this `pcase-defmacro' in the next major
+                    ;; version.
                     `(pcase-defmacro ,interface (&rest property-bindings)
                        `(lsp-interface ,',interface ,@property-bindings))
                     (-mapcat (-lambda ((label . name))

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -255,12 +255,16 @@ Allowed params: %s" interface (reverse (-map #'cl-first params)))
          (cl-list* 'progn))))
 
 (pcase-defmacro lsp-interface (interface &rest property-bindings)
-  "If EXPVAL is an instance of the LSP interface INTERFACE, destructure its
-properties.
+  "If EXPVAL is an instance of INTERFACE, destructure it by matching its
+properties. EXPVAL should be a plist or hash table depending on the variable
+`lsp-use-plists'.
 
-Each :PROPERTY key may be followed by an optional PATTERN, which is a `pcase'
-pattern to apply to the property value. Otherwise, PROPERTY is bound to the
-property value.
+INTERFACE should be an LSP interface defined with `lsp-interface'. This form
+will not match if any of INTERFACE's required fields are missing in EXPVAL.
+
+Each :PROPERTY keyword matches a field in EXPVAL. The keyword may be followed by
+an optional PATTERN, which is a `pcase' pattern to apply to the field's value.
+Otherwise, PROPERTY is let-bound to the field's value.
 
 \(fn INTERFACE [:PROPERTY [PATTERN]]...)"
   (cl-check-type interface symbol)

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -225,14 +225,6 @@ Allowed params: %s" interface (reverse (-map #'cl-first params)))
                                              output-bindings)
                                        (setf current-list (cddr current-list))))))
                                  output-bindings))))
-                    ;; These per-interface `pcase' forms are deprecated. Prefer
-                    ;; the new (lsp-interface INTERFACE ...) form defined below.
-                    ;; (See emacs-lsp/lsp-mode#4430.)
-                    ;;
-                    ;; TODO: Remove this `pcase-defmacro' in the next major
-                    ;; version.
-                    `(pcase-defmacro ,interface (&rest property-bindings)
-                       `(lsp-interface ,',interface ,@property-bindings))
                     (-mapcat (-lambda ((label . name))
                                (list
                                 `(defun ,(intern (format "lsp:%s-%s"

--- a/test/lsp-protocol-test.el
+++ b/test/lsp-protocol-test.el
@@ -81,28 +81,34 @@
                                      (lsp-make-my-position :line 30 :character 40 :camelCase nil)
                                      :specialProperty 42)))
     (should (pcase particular-range
-              ((MyRange :start (MyPosition :line start-line :character start-char :camel-case start-camelcase)
-                        :end  (MyPosition :line end-line :character end-char :camel-case end-camelCase))
+              ((lsp-interface MyRange
+                              :start (lsp-interface MyPosition
+                                                    :line start-line :character start-char :camel-case start-camelcase)
+                              :end (lsp-interface MyPosition
+                                                  :line end-line :character end-char :camel-case end-camelCase))
                t)
               (_ nil)))
 
     (should (pcase particular-extended-range
-              ((MyExtendedRange)
+              ((lsp-interface MyExtendedRange)
                t)
               (_ nil)))
 
     ;; a subclass can be matched by a pattern for a parent class
     (should (pcase particular-extended-range
-              ((MyRange :start (MyPosition :line start-line :character start-char :camel-case start-camelcase)
-                        :end  (MyPosition :line end-line :character end-char :camel-case end-camelCase))
+              ((lsp-interface MyRange
+                              :start (lsp-interface MyPosition
+                                                    :line start-line :character start-char :camel-case start-camelcase)
+                              :end  (lsp-interface MyPosition
+                                                   :line end-line :character end-char :camel-case end-camelCase))
                t)
               (_ nil)))
 
     ;; the new patterns should be able to be used with existing ones
     (should (pcase (list particular-range
                          particular-extended-range)
-              ((seq (MyRange)
-                    (MyExtendedRange))
+              ((seq (lsp-interface MyRange)
+                    (lsp-interface MyExtendedRange))
                t)
               (_ nil)))
 
@@ -110,8 +116,8 @@
     ;; not in the order specified by the inner patterns
     (should-not (pcase (list particular-range
                              particular-extended-range)
-                  ((seq (MyExtendedRange)
-                        (MyRange))
+                  ((seq (lsp-interface MyExtendedRange)
+                        (lsp-interface MyRange))
                    t)
                   (_ nil)))
 
@@ -122,8 +128,11 @@
     ;; and the second instance is an equality check against the other
     ;; :character value, which is different.
     (should-not (pcase particular-range
-                  ((MyRange :start (MyPosition :line start-line :character :camel-case start-camelcase)
-                            :end  (MyPosition :line end-line :character :camel-case end-camelCase))
+                  ((lsp-interface MyRange
+                                  :start (lsp-interface MyPosition
+                                                        :line start-line :character :camel-case start-camelcase)
+                                  :end  (lsp-interface MyPosition
+                                                       :line end-line :character :camel-case end-camelCase))
                    t)
                   (_ nil)))
 
@@ -131,7 +140,7 @@
     ;; should still match if the required stuff matches. Missing
     ;; optional properties are bound to nil.
     (should (pcase particular-range
-              ((MyRange :start (MyPosition :optional?))
+              ((lsp-interface MyRange :start (lsp-interface MyPosition :optional?))
                (null optional?))
               (_ nil)))
 
@@ -139,23 +148,23 @@
     ;; the interface, even if the expr-val has all the types specified
     ;; by the interface. This is a programmer error.
     (should-error (pcase particular-range
-                    ((MyRange :something-unrelated)
+                    ((lsp-interface MyRange :something-unrelated)
                      t)
                     (_ nil)))
 
     ;; we do not use camelCase at this stage. This is a programmer error.
     (should-error (pcase particular-range
-                    ((MyRange :start (MyPosition :camelCase))
+                    ((lsp-interface MyRange :start (lsp-interface MyPosition :camelCase))
                      t)
                     (_ nil)))
     (should (pcase particular-range
-              ((MyRange :start (MyPosition :camel-case))
+              ((lsp-interface MyRange :start (lsp-interface MyPosition :camel-case))
                t)
               (_ nil)))
 
     ;; :end is missing, so we should fail to match the interface.
     (should-not (pcase (lsp-make-my-range :start (lsp-make-my-position :line 10 :character 20 :camelCase nil))
-                  ((MyRange)
+                  ((lsp-interface MyRange)
                    t)
                   (_ nil)))))
 


### PR DESCRIPTION
This pull request provides a new unified pcase form `(lsp-interface INTERFACE ...)` to replace the old per-interface `(INTERFACE ...)` forms&mdash;the latter have been removed. **This is a breaking change.**

I've turned the old `pcase-defmacro`s generated by `lsp-interface` into helper functions, which the new pcase form delegates to.

This change addresses a few issues, which are detailed in #4430. In short:

* The existing forms aren't namespaced.
* The lsp-mode package adds hundreds of forms, which each add several lines to pcase's generated docstring, adding up to over 1000 lines.
* Starting in Emacs 31, the number of forms added by lsp-mode causes a noticeable slowdown when loading the interactive help for pcase.

Fixes #4430 