### PR TITLE
lsp-roslyn: make it compatibale with emacs-lsp-booster for windows

### DIFF
--- a/clients/lsp-roslyn.el
+++ b/clients/lsp-roslyn.el
@@ -120,7 +120,10 @@ Gotten from https://dev.azure.com/azure-public/vside/_artifacts/feed/vs-impl/NuG
        :sentinel sentinel
        :stderr stderr-buf
        :noquery t
-       :command (list "PowerShell" "-NoProfile" "-ExecutionPolicy" "Bypass" "-Command" lsp-roslyn--stdpipe-path "." lsp-roslyn--pipe-name)))
+       :command (lsp-resolve-final-command
+                 `("PowerShell" "-NoProfile" "-ExecutionPolicy" "Bypass" "-Command"
+                   ,lsp-roslyn--stdpipe-path "."
+                   ,lsp-roslyn--pipe-name))))
      (t (make-network-process
          :name process-name
          :remote lsp-roslyn--pipe-name
@@ -143,12 +146,11 @@ creates another process connecting to the named pipe it specifies."
                            :filter 'lsp-roslyn--parent-process-filter
                            :sentinel sentinel
                            :stderr parent-stderr-buf
-                           :command (append
-                                     (list lsp-roslyn-dotnet-executable
-                                           (lsp-roslyn--get-server-dll-path)
-                                           (format "--logLevel=%s" lsp-roslyn-server-log-level)
-                                           (format "--extensionLogDirectory=%s" lsp-roslyn-server-log-directory))
-                                     lsp-roslyn-server-extra-args)
+                           :command `(,lsp-roslyn-dotnet-executable
+                                      ,(lsp-roslyn--get-server-dll-path)
+                                      ,(format "--logLevel=%s" lsp-roslyn-server-log-level)
+                                      ,(format "--extensionLogDirectory=%s" lsp-roslyn-server-log-directory)
+                                      ,@lsp-roslyn-server-extra-args)
                            :noquery t)))
     (accept-process-output command-process lsp-roslyn-server-timeout-seconds) ; wait for JSON with pipe name to print on stdout, like {"pipeName":"\\\\.\\pipe\\d1b72351"}
     (when (not lsp-roslyn--pipe-name)


### PR DESCRIPTION
The `lsp-roslyn` is using stdio via named pipe redirection using powershell script in Windows and using named pipe for other platforms.
The [`emacs-lsp-booster`](https://github.com/blahgeek/emacs-lsp-booster) only supports `stdio` language server now so at least for Windows, we should make it compatible with `emacs-lsp-booster`.
In this change, we use `lsp-resolve-final-command` as it's the general advised function to trigger the booster process.