### PR TITLE
lsp-asm: if executable is found there's no need to install it

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -17,6 +17,7 @@
   * Replace the per-interface ~(INTERFACE ...)~ pcase forms with a single,
     unified ~(lsp-interface INTERFACE ...)~ form. The per-interface forms are no
     longer generated. *This is a breaking change.* (See #4430.)
+  * If asm-lsp is installed, lsp-asm won't try to download it to cache store
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/clients/lsp-asm.el
+++ b/clients/lsp-asm.el
@@ -81,7 +81,8 @@ Will update if UPDATE? is t."
  (make-lsp-client
   :new-connection (lsp-stdio-connection
                    #'lsp-asm--server-command
-                   (lambda () (f-exists? lsp-asm-store-path)))
+                   (lambda () (or (executable-find "asm-lsp")
+                                  (f-exists? lsp-asm-store-path))))
   :major-modes lsp-asm-active-modes
   :priority -1
   :server-id 'asm-lsp


### PR DESCRIPTION
This PR fixes the problem in which `lsp-asm` tries to install `asm-lsp` even when it's already installed through other means and available on path.