### PR TITLE
fix: add pwsh support for zip decompression, zls wrong bin path

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -19,6 +19,7 @@
     longer generated. *This is a breaking change.* (See #4430.)
   * If asm-lsp is installed, lsp-asm won't try to download it to cache store
   * Fix lsp-unzip on windows when unzip was found on the PATH
+  * Fix zlg wrong bin path
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -19,7 +19,7 @@
     longer generated. *This is a breaking change.* (See #4430.)
   * If asm-lsp is installed, lsp-asm won't try to download it to cache store
   * Fix lsp-unzip on windows when unzip was found on the PATH
-  * Fix zlg wrong bin path
+  * Fix zls wrong bin path
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/clients/lsp-zig.el
+++ b/clients/lsp-zig.el
@@ -236,7 +236,7 @@ If `true', replace the text after the cursor."
 This is differ from the variable `lsp-zig-zls-executable'; this is local storage
 and not the global storage."
   (f-join lsp-zig-server-store-path
-          (pcase system-type ('windows-nt "bin/zls.exe") (_ "bin/zls"))))
+          (pcase system-type ('windows-nt "zls.exe") (_ "zls"))))
 
 (lsp-dependency
  'zls

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8469,7 +8469,7 @@ archive (e.g. when the archive has multiple files)"
                                           (executable-find "powershell"))
                                      lsp-ext-powershell-script)
                                     ((executable-find "unzip") lsp-ext-unzip-script)
-                                    ((executable-find "powershell") lsp-ext-pwsh-script)
+                                    ((executable-find "pwsh") lsp-ext-pwsh-script)
                                     (t nil)))
   "The script to unzip."
   :group 'lsp-mode

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8450,7 +8450,11 @@ archive (e.g. when the archive has multiple files)"
 
 ;; unzip
 
-(defconst lsp-ext-pwsh-script "powershell -noprofile -noninteractive \
+(defconst lsp-ext-pwsh-script "pwsh -noprofile -noninteractive \
+-nologo -ex bypass -c Expand-Archive -Path '%s' -DestinationPath '%s'"
+  "Pwsh script to unzip file.")
+
+(defconst lsp-ext-powershell-script "powershell -noprofile -noninteractive \
 -nologo -ex bypass -command Expand-Archive -path '%s' -dest '%s'"
   "Powershell script to unzip file.")
 
@@ -8459,8 +8463,11 @@ archive (e.g. when the archive has multiple files)"
 
 (defcustom lsp-unzip-script (lambda ()
                               (cond ((and (eq system-type 'windows-nt)
-                                          (executable-find "powershell"))
+                                          (executable-find "pwsh"))
                                      lsp-ext-pwsh-script)
+                                    ((and (eq system-type 'windows-nt)
+                                          (executable-find "powershell"))
+                                     lsp-ext-powershell-script)
                                     ((executable-find "unzip") lsp-ext-unzip-script)
                                     ((executable-find "powershell") lsp-ext-pwsh-script)
                                     (t nil)))


### PR DESCRIPTION
The zip decompression of lsp-mode under the windows platform is damaged.

Emacs under windows will have a strange problem when using shell-command to execute bash commands. I have not found the reason to solve it.
Just like this:

```lisp
(shell-command "bash -c 'echo hello && echo kk'")
```
Run it on emacs with Windows, and emacs will report error:

```
/bin/bash: -c: line 1: unexpected EOF while looking for matching `''
```

But this will work fine:

```lisp
(shell-command "bash -c 'echo hello")
```
Then because emacs will give priority to using bash to create the directory and call unzip to perform the decompression operation (if unzip exists)

**Feats**:

- add powershell support for zip decompression
- fix zls path problem
