### PR TITLE
lsp-graphql: add new defcustom `lsp-graphql-target-file-extensions`

### DIFF
--- a/clients/lsp-graphql.el
+++ b/clients/lsp-graphql.el
@@ -43,13 +43,18 @@
   :risky t
   :group 'lsp-graphql)
 
+(defcustom lsp-graphql-target-file-extensions '("ts" "js" "jsx" "tsx" "vue" "graphql" "graphqls" "gql")
+  "List of target file extensions for the GraphQL language server."
+  :type '(repeat string)
+  :group 'lsp-graphql)
+
 (defun lsp-graphql-activate-p (filename &optional _)
   "Check if the GraphQL language server should be enabled based on FILENAME."
-  (or (string-match-p (rx (one-or-more anything) "."
-                        (or "ts" "js" "jsx" "tsx" "vue" "graphql" "gql")eos)
-        filename)
-    (and (derived-mode-p 'js-mode 'js2-mode 'typescript-mode 'typescript-ts-mode)
-      (not (derived-mode-p 'json-mode)))))
+  (let ((target-extensions (mapconcat 'identity lsp-graphql-target-file-extensions "\\|")))
+    (or (string-match-p (format "\\.%s\\'" target-extensions) filename)
+        (and (derived-mode-p 'js-mode 'js2-mode 'typescript-mode 'typescript-ts-mode)
+             (not (derived-mode-p 'json-mode))))))
+
 
 (lsp-register-client
   (make-lsp-client :new-connection (lsp-stdio-connection (lambda()


### PR DESCRIPTION
## About

- Add new `lsp-graphql-target-file-extensions` customize variable
   - Add `.graphqls` extension to it

## Why

I want to use `lsp-graphql` on the file with `.graphqls` ext.

There was a way to write directly to a list in a function, but I thought it was better to isolate it as a customised variable.


