### PR TITLE
Remove trailing whitespace from `lsp-describe-thing-at-point'

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5405,7 +5405,10 @@ If EXCLUDE-DECLARATION is non-nil, request the server to include declarations."
             (delay-mode-hooks
               (lsp-help-mode)
               (with-help-window lsp-help-buf-name
-                (insert (string-trim-right (lsp--render-on-hover-content contents t)))))
+                (insert
+		 (mapconcat 'string-trim-right
+			    (split-string (lsp--render-on-hover-content contents t) "\n")
+			    "\n"))))
             (run-mode-hooks)))
       (lsp--info "No content at point."))))
 


### PR DESCRIPTION
When calling `lsp-describe-thing-at-point' trailing whitespace can leak into the help buffer. Depending on the face settings, this whitespace can be visibile.

Instead of removing trailing whitespace at the end of the buffer, do so on a line-by-line basis.

Fixes #4572