### PR TITLE
docs: add missing `lsp-bufls` to list

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
     - AWK: page/lsp-awk.md
     - Bash: page/lsp-bash.md
     - Beancount: page/lsp-beancount.md
+    - Buf/Protocol Buffers: page/lsp-bufls.md
     - Camel: page/lsp-camel.md
     - C++ (ccls): page/lsp-ccls.md
     - C++ (clangd): page/lsp-clangd.md


### PR DESCRIPTION
## About

The `lsp-bufls` page exists but is not indexed.

### page

https://emacs-lsp.github.io/lsp-mode/page/lsp-bufls/

### current list

<img width="245" alt="スクリーンショット 2024-10-05 12 46 07" src="https://github.com/user-attachments/assets/dc97eaa5-484f-4d92-9644-86fde5ca09ad">
