### PR TITLE
Add new client for Buf/Protocol Buffers

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -20,6 +20,7 @@
   * If asm-lsp is installed, lsp-asm won't try to download it to cache store
   * Fix lsp-unzip on windows when unzip was found on the PATH
   * Fix zls wrong bin path
+  * Add support for buf CLI ([[https://github.com/bufbuild/buf/releases/tag/v1.43.0][beta]])
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/clients/lsp-bufls.el
+++ b/clients/lsp-bufls.el
@@ -31,8 +31,9 @@
 (require 'lsp-mode)
 (require 'lsp-go)
 
+;; Buf Language Server
 (defgroup lsp-bufls nil
-  "Configuration options for lsp-bufls."
+  "Configuration options for Buf Language Server."
   :group 'lsp-mode
   :link '(url-lint "https://github.com/bufbuild/buf-language-server")
   :package-version '(lsp-mode . "9.0.0"))
@@ -62,6 +63,41 @@
                   :language-id "protobuf"
                   :priority 0
                   :server-id 'bufls))
+
+;; Buf CLI
+(defgroup lsp-buf nil
+  "Configuration options for buf CLI."
+  :group 'lsp-mode
+  :link '(url-lint "https://github.com/bufbuild/buf")
+  :package-version '(lsp-mode . "9.0.0"))
+
+(defcustom lsp-buf-args `("beta" "lsp")
+  "Arguments to pass to buf CLI."
+  :type '(repeat string)
+  :group 'lsp-buf
+  :package-version '(lsp-mode . "9.0.0"))
+
+(defcustom lsp-buf-path "buf"
+  "Command to run buf CLI."
+  :type 'string
+  :group 'lsp-buf
+  :package-version '(lsp-mode . "9.0.0"))
+
+(defun lsp-buf--stdio-command ()
+  "Return the command and args to start buf CLI LSP server."
+  (let ((args (list lsp-buf-path)))
+    (when (and (listp lsp-buf-args)
+               (> (length lsp-buf-args) 0))
+      (setq args (append args lsp-buf-args)))
+    args))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   #'lsp-buf--stdio-command)
+                  :activation-fn (lsp-activate-on "protobuf")
+                  :language-id "protobuf"
+                  :priority -1
+                  :server-id 'buf))
 
 (lsp-consistency-check lsp-bufls)
 

--- a/clients/lsp-bufls.el
+++ b/clients/lsp-bufls.el
@@ -61,7 +61,7 @@
                                    #'lsp-bufls-server--stdio-command)
                   :activation-fn (lsp-activate-on "protobuf")
                   :language-id "protobuf"
-                  :priority 0
+                  :priority -1
                   :server-id 'bufls))
 
 ;; Buf CLI
@@ -96,7 +96,7 @@
                                    #'lsp-buf--stdio-command)
                   :activation-fn (lsp-activate-on "protobuf")
                   :language-id "protobuf"
-                  :priority -1
+                  :priority 0
                   :server-id 'buf))
 
 (lsp-consistency-check lsp-bufls)

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -90,6 +90,15 @@
     "debugger": "Not available"
   },
   {
+    "name": "buf",
+    "full-name": "buf CLI (Beta)",
+    "server-name": "buf",
+    "server-url": "https://github.com/bufbuild/buf",
+    "installation": "npm install -g @bufbuild/buf",
+    "installation-url": "https://buf.build/docs/installation",
+    "debugger": "Not available"
+  },
+  {
     "name": "bufls",
     "full-name": "buf-language-server",
     "server-name": "bufls",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,8 @@ nav:
     - AWK: page/lsp-awk.md
     - Bash: page/lsp-bash.md
     - Beancount: page/lsp-beancount.md
-    - Buf/Protocol Buffers: page/lsp-bufls.md
+    - Buf/Protocol Buffers (Buf CLI): page/lsp-buf.md
+    - Buf/Protocol Buffers (Buf Language Server): page/lsp-bufls.md
     - Camel: page/lsp-camel.md
     - C++ (ccls): page/lsp-ccls.md
     - C++ (clangd): page/lsp-clangd.md


### PR DESCRIPTION
## About

Current `lsp-bufls` using the [Buf Language Server](https://github.com/bufbuild/buf-language-server). But that LSP server was already archived project.
The `buf` CLI was supported LSP server from [v1.43.0](https://github.com/bufbuild/buf/releases/tag/v1.43.0). So I want to try to use it.

It's a first time to add new client for me. please let me know if I need anything else.