### PR TITLE
add site-packages and .pyenv to file watch ignored directories

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -372,6 +372,8 @@ the server has requested that."
     "[/\\\\]\\.build\\'"
     ;; Python
     "[/\\\\]__pycache__\\'"
+    "[/\\\\]site-packages\\'"
+    "[/\\\\].pyenv\\'"
     ;; Autotools output
     "[/\\\\]\\.deps\\'"
     "[/\\\\]build-aux\\'"


### PR DESCRIPTION
Both folders are commonly large and should be ignored.
Fixes #4585 