### PR TITLE
Refactoring all-the-icons functions

### DIFF
--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -157,7 +157,8 @@ caching purposes.")
    lsp-headerline-arrow
    (setq lsp-headerline-arrow (let ((all-the-icons-scale-factor 1.0)
                                     (all-the-icons-default-adjust 0))
-                                (lsp-icons-all-the-icons-material-icon
+                                (lsp-icons-all-the-icons-icon
+                                 'material
                                  "chevron_right"
                                  'lsp-headerline-breadcrumb-separator-face
                                  ">"

--- a/lsp-icons.el
+++ b/lsp-icons.el
@@ -32,7 +32,11 @@
   :type 'boolean
   :group 'lsp-icons)
 
-(declare-function all-the-icons-material "ext:all-the-icons" t t)
+(defcustom lsp-modeline-code-action-icons-enable t
+  "If non-nil, icons support is enabled for modeline-code-action"
+  :type 'boolean
+  :group 'lsp-icons)
+
 (declare-function lsp-treemacs-symbol-icon "ext:lsp-treemacs" (kind))
 (declare-function lsp-treemacs-get-icon "ext:lsp-treemacs" (icon-name))
 
@@ -40,6 +44,7 @@
   "Check if icons support is enabled for FEATURE."
   (cond
    ((eq feature 'headerline-breadcrumb) lsp-headerline-breadcrumb-icons-enable)
+   ((eq feature 'modeline-code-action) lsp-modeline-code-action-icons-enable)
    (t t)))
 
 (defun lsp-icons--fix-image-background (image)
@@ -79,16 +84,17 @@ if its enabled."
     (lsp-icons--fix-image-background
      (lsp-treemacs-symbol-icon kind))))
 
-(defun lsp-icons-all-the-icons-material-icon (icon-name face fallback &optional feature)
-  "Get a material icon from all-the-icons by ICON-NAME using FACE.
+(defun lsp-icons-all-the-icons-icon (icon-set icon-name face fallback &optional feature &rest args)
+  "Get icon ICON-NAME from `all-the-icons' ICON-SET using FACE.
+If ARGS is provided, it's a plist passed directly to the `all-the-icons' function.
 Fallback to FALLBACK string if not found or not available.
 FEATURE is the feature that will use the icon which we should check
 if its enabled."
-  (if (and (functionp 'all-the-icons-material)
-           (lsp-icons--enabled-for-feature feature))
-      (all-the-icons-material icon-name
-                              :face face)
-    (propertize fallback 'face face)))
+  (let ((icon-set-fn (intern-soft (concat "all-the-icons-" (symbol-name icon-set)))))
+    (if (and (fboundp icon-set-fn)
+             (lsp-icons--enabled-for-feature feature))
+        (apply icon-set-fn icon-name :face face args)
+      (propertize fallback 'face face))))
 
 (lsp-consistency-check lsp-icons)
 

--- a/lsp-modeline.el
+++ b/lsp-modeline.el
@@ -22,6 +22,7 @@
 ;;; Code:
 
 (require 'lsp-mode)
+(require 'lsp-icons)
 
 (defgroup lsp-modeline nil
   "LSP support for modeline"
@@ -71,7 +72,6 @@
                  (const :tag "All Projects" :global))
   :package-version '(lsp-mode . "6.3"))
 
-(declare-function all-the-icons-octicon "ext:all-the-icons" t t)
 (declare-function lsp-treemacs-errors-list "ext:lsp-treemacs" t)
 
 
@@ -85,14 +85,6 @@
   (if preferred-code-action
       'lsp-modeline-code-actions-preferred-face
     'lsp-modeline-code-actions-face))
-
-(defun lsp-modeline--code-actions-icon (face)
-  "Build the icon for modeline code actions using FACE."
-  (if (require 'all-the-icons nil t)
-      (all-the-icons-octicon "light-bulb"
-                             :face face
-                             :v-adjust -0.0575)
-    (propertize lsp-modeline-code-action-fallback-icon 'face face)))
 
 (defun lsp-modeline--code-action-name (actions preferred-code-action-title)
   "Return the code action name from ACTIONS and PREFERRED-CODE-ACTION-TITLE."
@@ -116,7 +108,13 @@
     (mapconcat
      (lambda (segment)
        (pcase segment
-         ('icon (lsp-modeline--code-actions-icon face))
+         ('icon (lsp-icons-all-the-icons-icon
+                 'octicon
+                 "light-bulb"
+                 face
+                 lsp-modeline-code-action-fallback-icon
+                 'modeline-code-action
+                 :v-adjust -0.0575))
          ('name (propertize (lsp-modeline--code-action-name actions preferred-code-action)
                             'face face))
          ('count (propertize (number-to-string (seq-length actions))


### PR DESCRIPTION
`lsp-modeline--code-actions-icon` isn't guarded by the proper checks for `all-the-icons-octicon` function, which will cause `all-the-icons` to load in the terminal, even though it is not supported. I've also taken the opportunity to refactor the 2 functions that use all-the-icons to use the new `lsp-icons-all-the-icons-icon` function.