### PR TITLE
Autocompletion options for Nix (nixd)

### DIFF
--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -57,11 +57,11 @@
 (lsp-defcustom lsp-nix-nixd-formatting-command nil
   "External formatter command with arguments.
 
-  Example: [ nixpkgs-fmt ]."
+  Example: [ \"nixpkgs-fmt\" ]"
   :type 'lsp-string-vector
   :group 'lsp-nix-nixd
   :lsp-path "nixd.formatting.command"
-  :package-version '(lsp-mode . "9.0.0"))
+  :package-version '(lsp-mode . "9.0.1"))
 
 (lsp-defcustom lsp-nix-nixd-nixpkgs-expr nil
   "This expression will be interpreted as \"nixpkgs\" toplevel
@@ -70,12 +70,11 @@
   Resource Usage: Entries are lazily evaluated, entire nixpkgs takes 200~300MB
   for just \"names\". Package documentation, versions, are evaluated by-need.
 
-  Example:
-  \"import <nixpkgs> { }\""
+  Example: \"import <nixpkgs> { }\""
   :type 'string
   :group 'lsp-nix-nixd
   :lsp-path "nixd.nixpkgs.expr"
-  :package-version '(lsp-mode . "9.0.0"))
+  :package-version '(lsp-mode . "9.0.1"))
 
 (lsp-defcustom lsp-nix-nixd-nixos-options-expr nil
   "Option set for NixOS option completion. If this is omitted, the default
@@ -86,7 +85,7 @@
   :type 'string
   :group 'lsp-nix-nil
   :lsp-path "nixd.options.nixos.expr"
-  :package-version '(lsp-mode . "9.0.0"))
+  :package-version '(lsp-mode . "9.0.1"))
 
 (lsp-defcustom lsp-nix-nixd-home-manager-options-expr nil
   "Option set for home-manager option completion.
@@ -96,12 +95,17 @@
   :type 'string
   :group 'lsp-nix-nil
   :lsp-path "nixd.options.home-manager.expr"
-  :package-version '(lsp-mode . "9.0.0"))
+  :package-version '(lsp-mode . "9.0.1"))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-nix-nixd-server-path))
                   :major-modes '(nix-mode nix-ts-mode)
-                  :server-id 'nixd-lsp
+                  :initialized-fn (lambda (workspace)
+                                    (with-lsp-workspace workspace
+                                      (lsp--set-configuration
+                                       (lsp-configuration-section "nixd"))))
+                  :synchronize-sections '("nixd")
+                  :server-id 'nixd-improved
                   :priority -1))
 
 (defgroup lsp-nix-nil nil

--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -105,7 +105,7 @@
                                       (lsp--set-configuration
                                        (lsp-configuration-section "nixd"))))
                   :synchronize-sections '("nixd")
-                  :server-id 'nixd-improved
+                  :server-id 'nixd-lsp
                   :priority -1))
 
 (defgroup lsp-nix-nil nil

--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -54,6 +54,50 @@
   :type 'string
   :package-version '(lsp-mode . "8.0.0"))
 
+(lsp-defcustom lsp-nix-nixd-formatting-command nil
+  "External formatter command with arguments.
+
+  Example: [ nixpkgs-fmt ]."
+  :type 'lsp-string-vector
+  :group 'lsp-nix-nixd
+  :lsp-path "nixd.formatting.command"
+  :package-version '(lsp-mode . "9.0.0"))
+
+(lsp-defcustom lsp-nix-nixd-nixpkgs-expr nil
+  "This expression will be interpreted as \"nixpkgs\" toplevel
+  Nixd provides package, lib completion/information from it.
+
+  Resource Usage: Entries are lazily evaluated, entire nixpkgs takes 200~300MB
+  for just \"names\". Package documentation, versions, are evaluated by-need.
+
+  Example:
+  \"import <nixpkgs> { }\""
+  :type 'string
+  :group 'lsp-nix-nixd
+  :lsp-path "nixd.nixpkgs.expr"
+  :package-version '(lsp-mode . "9.0.0"))
+
+(lsp-defcustom lsp-nix-nixd-nixos-options-expr nil
+  "Option set for NixOS option completion. If this is omitted, the default
+  search path (<nixpkgs>) will be used.
+
+  Example:
+  \"(builtins.getFlake \"/home/lyc/flakes\").nixosConfigurations.adrastea.options\""
+  :type 'string
+  :group 'lsp-nix-nil
+  :lsp-path "nixd.options.nixos.expr"
+  :package-version '(lsp-mode . "9.0.0"))
+
+(lsp-defcustom lsp-nix-nixd-home-manager-options-expr nil
+  "Option set for home-manager option completion.
+
+  Example:
+  \"(builtins.getFlake \"/home/lyc/flakes\").nixosConfigurations.adrastea.options\""
+  :type 'string
+  :group 'lsp-nix-nil
+  :lsp-path "nixd.options.home-manager.expr"
+  :package-version '(lsp-mode . "9.0.0"))
+
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-nix-nixd-server-path))
                   :major-modes '(nix-mode nix-ts-mode)


### PR DESCRIPTION
This PR adds more comprehensive options for the nixd language server, including those necessary for formatting and completion. As mentioned in #4592, these options were previously absent.

The options added include: 
- `lsp-nix-nixd-nixpkgs-expr`, which provides completion for nixpkgs
- `lsp-nix-nixd-nixos-options-expr`, which provides completion for NixOS options
- `lsp-nix-nixd-home-manager-options-expr`, which provides completion for Home Manager options
- `lsp-nix-nixd-formatting-command`, which sets the formatter used by nixd

An example configuration in Doom: 

```elisp
(after! lsp-mode
  (setq lsp-nix-nixd-formatting-command [ "nixfmt" ]
        lsp-nix-nixd-nixpkgs-expr "import <nixpkgs> { }"
        lsp-nix-nixd-nixos-options-expr "(builtins.getFlake \"/home/breitnw/Documents/code/nixos\").nixosConfigurations.mnd.options"
        lsp-nix-nixd-home-manager-options-expr "(builtins.getFlake \"/home/breitnw/Documents/code/nixos\").homeConfigurations.\"breitnw@mnd\".options"))

(add-hook! 'nix-mode-hook
           (setq company-idle-delay 0.1))
```
