### PR TITLE
fix: nixd option groups and documentation page

### DIFF
--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -83,7 +83,7 @@
   Example:
   \"(builtins.getFlake \"/home/lyc/flakes\").nixosConfigurations.adrastea.options\""
   :type 'string
-  :group 'lsp-nix-nil
+  :group 'lsp-nix-nixd
   :lsp-path "nixd.options.nixos.expr"
   :package-version '(lsp-mode . "9.0.1"))
 
@@ -93,7 +93,7 @@
   Example:
   \"(builtins.getFlake \"/home/lyc/flakes\").nixosConfigurations.adrastea.options\""
   :type 'string
-  :group 'lsp-nix-nil
+  :group 'lsp-nix-nixd
   :lsp-path "nixd.options.home-manager.expr"
   :package-version '(lsp-mode . "9.0.1"))
 

--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -57,11 +57,11 @@
 (lsp-defcustom lsp-nix-nixd-formatting-command nil
   "External formatter command with arguments.
 
-  Example: [ nixpkgs-fmt ]."
+  Example: [ \"nixpkgs-fmt\" ]"
   :type 'lsp-string-vector
   :group 'lsp-nix-nixd
   :lsp-path "nixd.formatting.command"
-  :package-version '(lsp-mode . "9.0.0"))
+  :package-version '(lsp-mode . "9.0.1"))
 
 (lsp-defcustom lsp-nix-nixd-nixpkgs-expr nil
   "This expression will be interpreted as \"nixpkgs\" toplevel
@@ -70,12 +70,11 @@
   Resource Usage: Entries are lazily evaluated, entire nixpkgs takes 200~300MB
   for just \"names\". Package documentation, versions, are evaluated by-need.
 
-  Example:
-  \"import <nixpkgs> { }\""
+  Example: \"import <nixpkgs> { }\""
   :type 'string
   :group 'lsp-nix-nixd
   :lsp-path "nixd.nixpkgs.expr"
-  :package-version '(lsp-mode . "9.0.0"))
+  :package-version '(lsp-mode . "9.0.1"))
 
 (lsp-defcustom lsp-nix-nixd-nixos-options-expr nil
   "Option set for NixOS option completion. If this is omitted, the default
@@ -86,7 +85,7 @@
   :type 'string
   :group 'lsp-nix-nil
   :lsp-path "nixd.options.nixos.expr"
-  :package-version '(lsp-mode . "9.0.0"))
+  :package-version '(lsp-mode . "9.0.1"))
 
 (lsp-defcustom lsp-nix-nixd-home-manager-options-expr nil
   "Option set for home-manager option completion.
@@ -96,12 +95,17 @@
   :type 'string
   :group 'lsp-nix-nil
   :lsp-path "nixd.options.home-manager.expr"
-  :package-version '(lsp-mode . "9.0.0"))
+  :package-version '(lsp-mode . "9.0.1"))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-nix-nixd-server-path))
                   :major-modes '(nix-mode nix-ts-mode)
-                  :server-id 'nixd-lsp
+                  :initialized-fn (lambda (workspace)
+                                    (with-lsp-workspace workspace
+                                      (lsp--set-configuration
+                                       (lsp-configuration-section "nixd"))))
+                  :synchronize-sections '("nixd")
+                  :server-id 'nixd-improved
                   :priority -1))
 
 (defgroup lsp-nix-nil nil

--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -57,7 +57,7 @@
 (lsp-defcustom lsp-nix-nixd-formatting-command nil
   "External formatter command with arguments.
 
-  Example: [ \"nixpkgs-fmt\" ]"
+  Example: `[\"nixpkgs-fmt\"]`"
   :type 'lsp-string-vector
   :group 'lsp-nix-nixd
   :lsp-path "nixd.formatting.command"
@@ -70,7 +70,7 @@
   Resource Usage: Entries are lazily evaluated, entire nixpkgs takes 200~300MB
   for just \"names\". Package documentation, versions, are evaluated by-need.
 
-  Example: \"import <nixpkgs> { }\""
+  Example: `\"import <nixpkgs> { }\"`"
   :type 'string
   :group 'lsp-nix-nixd
   :lsp-path "nixd.nixpkgs.expr"
@@ -78,10 +78,10 @@
 
 (lsp-defcustom lsp-nix-nixd-nixos-options-expr nil
   "Option set for NixOS option completion. If this is omitted, the default
-  search path (<nixpkgs>) will be used.
+  search path (`<nixpkgs>`) will be used.
 
   Example:
-  \"(builtins.getFlake \"/home/lyc/flakes\").nixosConfigurations.adrastea.options\""
+  `\"(builtins.getFlake \"/home/lyc/flakes\").nixosConfigurations.adrastea.options\"`"
   :type 'string
   :group 'lsp-nix-nixd
   :lsp-path "nixd.options.nixos.expr"
@@ -91,7 +91,7 @@
   "Option set for home-manager option completion.
 
   Example:
-  \"(builtins.getFlake \"/home/lyc/flakes\").nixosConfigurations.adrastea.options\""
+  `\"(builtins.getFlake \"/home/lyc/flakes\").nixosConfigurations.adrastea.options\"`"
   :type 'string
   :group 'lsp-nix-nixd
   :lsp-path "nixd.options.home-manager.expr"

--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -105,7 +105,7 @@
                                       (lsp--set-configuration
                                        (lsp-configuration-section "nixd"))))
                   :synchronize-sections '("nixd")
-                  :server-id 'nixd-improved
+                  :server-id 'nixd-lsp
                   :priority -1))
 
 (defgroup lsp-nix-nil nil

--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -54,6 +54,50 @@
   :type 'string
   :package-version '(lsp-mode . "8.0.0"))
 
+(lsp-defcustom lsp-nix-nixd-formatting-command nil
+  "External formatter command with arguments.
+
+  Example: [ nixpkgs-fmt ]."
+  :type 'lsp-string-vector
+  :group 'lsp-nix-nixd
+  :lsp-path "nixd.formatting.command"
+  :package-version '(lsp-mode . "9.0.0"))
+
+(lsp-defcustom lsp-nix-nixd-nixpkgs-expr nil
+  "This expression will be interpreted as \"nixpkgs\" toplevel
+  Nixd provides package, lib completion/information from it.
+
+  Resource Usage: Entries are lazily evaluated, entire nixpkgs takes 200~300MB
+  for just \"names\". Package documentation, versions, are evaluated by-need.
+
+  Example:
+  \"import <nixpkgs> { }\""
+  :type 'string
+  :group 'lsp-nix-nixd
+  :lsp-path "nixd.nixpkgs.expr"
+  :package-version '(lsp-mode . "9.0.0"))
+
+(lsp-defcustom lsp-nix-nixd-nixos-options-expr nil
+  "Option set for NixOS option completion. If this is omitted, the default
+  search path (<nixpkgs>) will be used.
+
+  Example:
+  \"(builtins.getFlake \"/home/lyc/flakes\").nixosConfigurations.adrastea.options\""
+  :type 'string
+  :group 'lsp-nix-nil
+  :lsp-path "nixd.options.nixos.expr"
+  :package-version '(lsp-mode . "9.0.0"))
+
+(lsp-defcustom lsp-nix-nixd-home-manager-options-expr nil
+  "Option set for home-manager option completion.
+
+  Example:
+  \"(builtins.getFlake \"/home/lyc/flakes\").nixosConfigurations.adrastea.options\""
+  :type 'string
+  :group 'lsp-nix-nil
+  :lsp-path "nixd.options.home-manager.expr"
+  :package-version '(lsp-mode . "9.0.0"))
+
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-nix-nixd-server-path))
                   :major-modes '(nix-mode nix-ts-mode)

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -710,7 +710,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "nix",
+    "name": "nix-nixd",
     "full-name": "Nix (nixd language server)",
     "server-name": "nixd",
     "server-url": "https://github.com/nix-community/nixd",
@@ -718,7 +718,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "nix",
+    "name": "nix-rnix",
     "full-name": "Nix (rnix language server)",
     "server-name": "rnix-lsp",
     "server-url": "https://github.com/nix-community/rnix-lsp",


### PR DESCRIPTION
My last PR (#4593) seemed to cause some documentation issues, since a few of the options were assigned to `'lsp-nix-nil` instead of `'lsp-nix-nixd`. Also, lsp-clients.json listed both nixd and rnix under a "nix" page, when they should be split into pages named "nix-nixd" and "nix-rnix", respectively. 