### PR TITLE
fix: reduce nix docstring length

### DIFF
--- a/clients/lsp-nix.el
+++ b/clients/lsp-nix.el
@@ -81,7 +81,7 @@
   search path (`<nixpkgs>`) will be used.
 
   Example:
-  `\"(builtins.getFlake \"/home/lyc/flakes\").nixosConfigurations.adrastea.options\"`"
+  `\"(builtins.getFlake \"/home/nb/nix\").nixosConfigurations.mnd.options\"`"
   :type 'string
   :group 'lsp-nix-nixd
   :lsp-path "nixd.options.nixos.expr"
@@ -91,7 +91,7 @@
   "Option set for home-manager option completion.
 
   Example:
-  `\"(builtins.getFlake \"/home/lyc/flakes\").nixosConfigurations.adrastea.options\"`"
+  `\"(builtins.getFlake \"/home/nb/nix\").homeConfigurations.\"nb@mnd\".options\"`"
   :type 'string
   :group 'lsp-nix-nixd
   :lsp-path "nixd.options.home-manager.expr"


### PR DESCRIPTION
As noted in #4594, there were compile warnings in the last PR: 

```
In toplevel form:
lsp-nix.el:79:2: Warning: custom-declare-variable `lsp-nix-nixd-nixos-options-expr' docstring wider than 80 characters
lsp-nix.el:90:2: Warning: custom-declare-variable `lsp-nix-nixd-home-manager-options-expr' docstring wider than 80 characters
```

This PR should fix these warnings. 