### PR TITLE
Deal with 'workspace/diagnostic/refresh' message

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3707,6 +3707,7 @@ disappearing, unset all the variables related to it."
                                                                    :json-false))))))
                    ,@(when lsp-lens-enable '((codeLens . ((refreshSupport . t)))))
                    ,@(when lsp-inlay-hint-enable '((inlayHint . ((refreshSupport . :json-false)))))
+                   (diagnostics . ((refreshSupport . :json-false)))
                    (fileOperations . ((didCreate . :json-false)
                                       (willCreate . :json-false)
                                       (didRename . t)
@@ -6944,6 +6945,8 @@ server. WORKSPACE is the active workspace."
                       (when (and lsp-lens-enable
                                  (fboundp 'lsp--lens-on-refresh))
                         (lsp--lens-on-refresh workspace))
+                      nil)
+                     ((equal method "workspace/diagnostic/refresh")
                       nil)
                      (t (lsp-warn "Unknown request method: %s" method) nil))))
     ;; Send response to the server.


### PR DESCRIPTION
lsp-mode does not currently support pull diagnostics.

There is a recent change to the spec where the server can notify the client to request diagnostics, when the pull mode is being used.

This is implemented incorrectly in a number of servers, which do not first check the relevant client capability.

Mitigate this problem by
a. Sending client capabilities to day that this is not supported b. Putting a null handler in for the server request message.

Closes #4570