### PR TITLE
lsp-start-plain: fix path that can contain spaces

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -9917,12 +9917,10 @@ In case the major-mode that you are using for "
   (let ((start-plain (make-temp-file "plain" nil ".el")))
     (url-copy-file "https://raw.githubusercontent.com/emacs-lsp/lsp-mode/master/scripts/lsp-start-plain.el"
                    start-plain t)
-    (async-shell-command
-     (format "%s -q -l %s %s"
-             (expand-file-name invocation-name invocation-directory)
-             start-plain
-             (or (buffer-file-name) ""))
-     (generate-new-buffer " *lsp-start-plain*"))))
+    (start-process "lsp-start-plain"
+                   (generate-new-buffer " *lsp-start-plain*")
+                   (expand-file-name invocation-name invocation-directory)
+                    "-q" "-l" start-plain (or (buffer-file-name) ""))))
 
 
 


### PR DESCRIPTION
Using `start-process` instead of `async-shell-command` so that the `command` path is interpreted correctly