### PR TITLE
lsp-completion-passthrough-try-completion: make it more basic

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -284,7 +284,8 @@ The MARKERS and PREFIX value will be attached to each candidate."
                                                  (setq fuz-queries
                                                        (plist-put fuz-queries start-point s))
                                                  s)))
-                                (label-len (length label)))
+                                (label-len (length label))
+                                (case-fold-search completion-ignore-case))
                            (when (string-match fuz-query label)
                              (put-text-property 0 label-len 'match-data (match-data) label)
                              (plist-put cand
@@ -642,7 +643,8 @@ Others: CANDIDATES"
   "Calculate fuzzy score for STR with query QUERY.
 The return is nil or in range of (0, inf)."
   (-when-let* ((md (cddr (or (get-text-property 0 'match-data str)
-                             (let ((re (lsp-completion--regex-fuz query)))
+                             (let ((re (lsp-completion--regex-fuz query))
+                                   (case-fold-search completion-ignore-case))
                                (when (string-match re str)
                                  (match-data))))))
                (start (pop md))
@@ -755,19 +757,9 @@ The CLEANUP-FN will be called to cleanup."
   "Disable LSP completion support."
   (lsp-completion-mode -1))
 
-(defun lsp-completion-passthrough-try-completion (string table pred point)
-  (let* ((completion-ignore-case t)
-         (try (completion-basic-try-completion string table pred point))
-         (newstr (car try))
-         (newpoint (cdr try))
-         (beforepoint (and try (substring newstr 0 newpoint))))
-    (if (and beforepoint
-             (string-prefix-p
-              beforepoint
-              (try-completion "" table pred)
-              t))
-        try
-      (cons string point))))
+(defun lsp-completion-passthrough-try-completion (string _table _pred point)
+  "Passthrough try function, always return the passed STRING and POINT."
+  (cons string point))
 
 (defun lsp-completion-passthrough-all-completions (_string table pred _point)
   "Passthrough all completions from TABLE with PRED."

--- a/test/lsp-completion-test.el
+++ b/test/lsp-completion-test.el
@@ -36,11 +36,12 @@
 
 (ert-deftest lsp-completion-test-fuz-score ()
   (cl-labels ((do-test (query cands expected)
-                       (should (equal
-                                (sort cands
-                                      (lambda (l r) (> (lsp-completion--fuz-score query l)
-                                                       (lsp-completion--fuz-score query r))))
-                                expected))))
+                (let ((completion-ignore-case t))
+                  (should (equal
+                           (sort cands
+                                 (lambda (l r) (> (or (lsp-completion--fuz-score query l) 0)
+                                                  (or (lsp-completion--fuz-score query r) 0))))
+                           expected)))))
     (do-test "as"
              '("hashCode() : int"
                "asSubclass(Class<U> clazz) : Class<? extends U>")


### PR DESCRIPTION
Make lsp-completion-passthrough-try-completion more basic by just return the passed string and point. It will make the behavior closer to VsCode where the try completion will always be success.
Also respect the `completion-ignore-case` value now when showing the completion candidates.

@dgutov 