### PR TITLE
feat: add TypeSpec tsp-server support

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -22,6 +22,7 @@
   * Fix zls wrong bin path
   * Add support for buf CLI ([[https://github.com/bufbuild/buf/releases/tag/v1.43.0][beta]])
   * Add fennel support
+  * Add TypeSpec support
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/clients/lsp-typespec.el
+++ b/clients/lsp-typespec.el
@@ -29,7 +29,7 @@
 
 (defgroup lsp-typespec nil
   "LSP support for Typespec."
-  :link '(url-link "https://github.com/jeremymeng/typespec-lsp")
+  :link '(url-link "https://github.com/microsoft/typespec/blob/9c95ccda8c84c7c6afa24b2f4b21cf1ecbe680dd/packages/compiler/cmd/tsp-server.js")
   :group 'lsp-mode
   :tag "Lsp Typespec")
 

--- a/clients/lsp-typespec.el
+++ b/clients/lsp-typespec.el
@@ -1,0 +1,87 @@
+;;; lsp-typespec.el --- Typespec Client settings -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024  jeremy.ymeng@gmail.com
+
+;; Author: Jeremy Meng  <jeremy.ymeng@gmail.com>
+;; Keywords: languages,tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; lsp-typespec client
+
+;;; Code:
+
+(require 'lsp-mode)
+(require 'lsp-semantic-tokens)
+
+(defgroup lsp-typespec nil
+  "LSP support for Typespec."
+  :link '(url-link "https://github.com/jeremymeng/typespec-lsp")
+  :group 'lsp-mode
+  :tag "Lsp Typespec")
+
+(defcustom lsp-typespec-custom-server-command nil
+  "The typespec-lisp server command."
+  :group 'lsp-typespec
+  :risky t
+  :type '(repeat string))
+
+(lsp-dependency
+ 'typespec-lsp
+ '(:npm :package "@typespec/compiler"
+        :path "tsp-server")
+ '(:system "tsp-server"))
+
+(defun lsp-typespec--server-executable-path ()
+  "Return the typespec-lsp server command."
+  (or
+   (when-let ((workspace-folder (lsp-find-session-folder (lsp-session) default-directory)))
+     (let ((tsp-server-local-path (f-join workspace-folder "node_modules" ".bin"
+                                      (if (eq system-type 'windows-nt) "tsp-server.cmd" "tsp-server"))))
+       (when (f-exists? tsp-server-local-path)
+         tsp-server-local-path)))
+   (executable-find "tsp-server")
+   (lsp-package-path 'tsp-server)
+   "tsp-server"))
+
+(lsp-register-client
+ (make-lsp-client
+  :semantic-tokens-faces-overrides '(:types (("docCommentTag" . font-lock-keyword-face)
+                                             ("event" . default)))
+  :new-connection (lsp-stdio-connection `(,(lsp-typespec--server-executable-path) "--stdio"))
+  :activation-fn (lsp-activate-on "typespec")
+  :major-modes '(typespec-mode)
+  :server-id 'typespec-lsp))
+
+(lsp-consistency-check lsp-typespec)
+
+(defun lsp-typespec-semantic-tokens-refresh (&rest _)
+  "Force refresh semantic tokens."
+  (when-let ((workspace (and lsp-semantic-tokens-enable
+                             (lsp-find-workspace 'typespec-lsp (buffer-file-name)))))
+    (--each (lsp--workspace-buffers workspace)
+      (when (lsp-buffer-live-p it)
+        (lsp-with-current-buffer it
+          (lsp-semantic-tokens--enable))))))
+
+(with-eval-after-load 'typespec
+  (when lsp-semantic-tokens-enable
+    ;; refresh tokens
+    (add-hook 'typespec-mode-hook #'lsp-typespec-semantic-tokens-refresh)))
+
+(provide 'lsp-typespec)
+;;; lsp-typespec.el ends here
+

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -497,6 +497,15 @@
     "debugger": "Yes (Firefox/Chrome)"
   },
   {
+    "name": "typespec",
+    "full-name": "TypeSpec",
+    "server-name": "tsp server",
+    "server-url": https://github.com/microsoft/typespec/tree/main/packages/compiler",
+    "installation": "npm i -g @typespec/compiler",
+    "lsp-install-server": "@typespec/compiler",
+    "debugger": "Yes (Firefox/Chrome)"
+  },
+  {
     "name": "deno",
     "common-group-name": "javascript",
     "full-name": "Javascript/Typescript (deno)",

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -500,7 +500,7 @@
     "name": "typespec",
     "full-name": "TypeSpec",
     "server-name": "tsp server",
-    "server-url": https://github.com/microsoft/typespec/tree/main/packages/compiler",
+    "server-url": "https://github.com/microsoft/typespec/tree/main/packages/compiler",
     "installation": "npm i -g @typespec/compiler",
     "lsp-install-server": "@typespec/compiler",
     "debugger": "Yes (Firefox/Chrome)"

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -189,7 +189,7 @@ As defined by the Language Server Protocol 3.16."
      lsp-ruby-syntax-tree lsp-ruff lsp-rust lsp-semgrep lsp-shader
      lsp-solargraph lsp-solidity lsp-sonarlint lsp-sorbet lsp-sourcekit
      lsp-sql lsp-sqls lsp-steep lsp-svelte lsp-tailwindcss lsp-terraform
-     lsp-tex lsp-tilt lsp-toml lsp-trunk lsp-ttcn3 lsp-typeprof lsp-v
+     lsp-tex lsp-tilt lsp-toml lsp-trunk lsp-ttcn3 lsp-typeprof lsp-typespec lsp-v
      lsp-vala lsp-verilog lsp-vetur lsp-vhdl lsp-vimscript lsp-volar lsp-wgsl
      lsp-xml lsp-yaml lsp-yang lsp-zig)
   "List of the clients to be automatically required."
@@ -796,6 +796,7 @@ Changes take effect only when a new session is started."
     ("\\.svelte$" . "svelte")
     ("\\.toml\\'" . "toml")
     ("\\.ts$" . "typescript")
+    ("\\.tsp$" . "typespec")
     ("\\.tsx$" . "typescriptreact")
     ("\\.ttcn3$" . "ttcn3")
     ("\\.vue$" . "vue")
@@ -890,6 +891,7 @@ Changes take effect only when a new session is started."
     (js-ts-mode . "javascript")
     (typescript-mode . "typescript")
     (typescript-ts-mode . "typescript")
+    (typespec-mode . "typespec")
     (tsx-ts-mode . "typescriptreact")
     (svelte-mode . "svelte")
     (fsharp-mode . "fsharp")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -173,6 +173,7 @@ nav:
     - TOML: page/lsp-toml.md
     - Trunk: page/lsp-trunk.md
     - TTCN3: page/lsp-ttcn3.md
+    - TypeSpec: page/lsp-typespec.md
     - V: page/lsp-v.md
     - Vala: page/lsp-vala.md
     - Verilog/SystemVerilog (hdl-checker): page/lsp-verilog.md


### PR DESCRIPTION
TypeSpec (https://github.com/microsoft/typespec) is a language for defining cloud service APIs and shapes. TypeSpec is a highly extensible language with primitives that can describe API shapes common among REST, OpenAPI, gRPC, and other protocols.