### PR TITLE
Touch up signature faces

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5855,6 +5855,11 @@ It will show up only if current point has signature help."
                                     (list lsp-signature-doc-lines))))
   (lsp-signature-activate))
 
+(defface lsp-signature-highlight-function-argument
+  '((t :inherit eldoc-highlight-function-argument))
+  "The face to use to highlight function arguments in signatures."
+  :group 'lsp-mode)
+
 (defun lsp--signature->message (signature-help)
   "Generate eldoc message from SIGNATURE-HELP response."
   (setq lsp--signature-last signature-help)
@@ -5900,7 +5905,7 @@ It will show up only if current point has signature help."
                      (end (if (stringp selected-param-label)
                               (+ start (length selected-param-label))
                             (cl-second selected-param-label))))
-          (add-face-text-property start end 'eldoc-highlight-function-argument nil label)))
+          (add-face-text-property start end 'lsp-signature-highlight-function-argument nil label)))
       (concat prefix label method-docs))))
 
 (defun lsp-signature ()

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5797,7 +5797,10 @@ RENDER-ALL - nil if only the signature should be rendered."
               (list :position (point)
                     :background-color (face-attribute 'lsp-signature-posframe :background nil t)
                     :foreground-color (face-attribute 'lsp-signature-posframe :foreground nil t)
-                    :border-color (face-attribute 'font-lock-comment-face :foreground nil t))))
+                    :border-color (face-attribute (if (facep 'child-frame-border)
+                                                      'child-frame-border
+                                                    'internal-border)
+                                                  :background nil t))))
     (posframe-hide " *lsp-signature*")))
 
 (defun lsp--handle-signature-update (signature)


### PR DESCRIPTION
1. We should not use `font-lock-comment-face` as the signature posframe border color. There are actually proper faces that frame borders use for this purpose, so let's just use them so we can have a child frame that has borders that look like every other child frame. These are also faces `posframe-show` will set the border color on.
2. When propertizing the parameter hints highlight in the signature string, instead of using the `eldoc-highlight-function-argument` face, let's use a new LSP-specific face that by default inherits from `eldoc-highlight-function-argument` so users can theme it.