### PR TITLE
Make LSP completions resolve capabilities more spec-compliant

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3775,9 +3775,7 @@ disappearing, unset all the variables related to it."
                                                         (insertReplaceSupport . t)
                                                         (deprecatedSupport . t)
                                                         (resolveSupport
-                                                         . ((properties . ["documentation"
-                                                                           "detail"
-                                                                           "additionalTextEdits"
+                                                         . ((properties . ["additionalTextEdits"
                                                                            "command"
                                                                            "insertTextFormat"
                                                                            "insertTextMode"])))


### PR DESCRIPTION
Closes https://github.com/emacs-lsp/lsp-mode/issues/4591
Closes https://github.com/emacs-lsp/lsp-mode/issues/4607
Part of https://github.com/rust-lang/rust-analyzer/issues/18504

rust-analyzer started to be more spec-compliant when it comes to completion resolve: 

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion

> Since 3.16.0 the client can signal that it can resolve more properties lazily. This is done using the `completionItem#resolveSupport` client capability which lists all properties that can be filled in during a ‘completionItem/resolve’ request. All other properties (usually `sortText`, `filterText`, `insertText` and `textEdit`) must be provided in the [`textDocument/completion`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion) response and must not be changed during resolve.

So, if the editor declares a completion resolve support for the `documentation`, rust-analyzer as a server can omit it in the initial response and now it does so.

According to https://github.com/emacs-lsp/lsp-mode/issues/4591 
1. https://github.com/emacs-lsp/lsp-mode/issues/4591#issuecomment-2440888639


>> Can you try to move to the next item in the completion list to see if the function detail will be displayed for the previously selected item?

> I do not see any lsp communication in the (lsp-workspace-show-log) buffer when selecting another element.

2.  https://github.com/emacs-lsp/lsp-mode/issues/4591#issue-2604618861

> Removing "documentation" + "detail" from  ...  seems to restore the wanted behaviour.


---------------

Before rust-analyzer's change, it sent back every possible property.
Now, it starts to send back only things that are not declared in the completion resolve capabilities, as by the spec, the rest should be possible to get resolved later by the editor.

Apparently, despite the resolve capabilities declaration, Emacs lsp-mode client cannot properly resolve these, hence the PR restores the status-quo by making rust-analyzer to return these properties immediately, as it had been before.

Later, a better resolve mechanism may be implemented to resolve these, if needed.