### PR TITLE
lsp-roslyn: fix arm64 detection and use default window/logMessage handler

### DIFF
--- a/clients/lsp-roslyn.el
+++ b/clients/lsp-roslyn.el
@@ -81,7 +81,7 @@ Unused on other platforms.")
   :package-version '(lsp-mode . "8.0.0")
   :group 'lsp-roslyn)
 
-(defcustom lsp-roslyn-package-version "4.12.0-3.24470.11"
+(defcustom lsp-roslyn-package-version "4.13.0-2.24564.12"
   "Version of the Roslyn package to install.
 Gotten from https://dev.azure.com/azure-public/vside/_artifacts/feed/vs-impl/NuGet/Microsoft.CodeAnalysis.LanguageServer.win-x64"
   :type 'string
@@ -125,6 +125,7 @@ Gotten from https://dev.azure.com/azure-public/vside/_artifacts/feed/vs-impl/NuG
                    ,lsp-roslyn--stdpipe-path "."
                    ,lsp-roslyn--pipe-name))))
      (t (make-network-process
+         :service "roslyn"
          :name process-name
          :remote lsp-roslyn--pipe-name
          :sentinel sentinel
@@ -203,15 +204,6 @@ creates another process connecting to the named pipe it specifies."
   "Convert PATH to a URI, without hexifying."
   (url-unhex-string (lsp--path-to-uri-1 path)))
 
-(lsp-defun lsp-roslyn--log-message (_workspace params)
-  (let ((type (gethash "type" params))
-        (mes (gethash "message" params)))
-    (cl-case type
-      (1 (lsp--error "%s" mes))   ; Error
-      (2 (lsp--warn "%s" mes))    ; Warning
-      (3 (lsp--info "%s" mes))    ; Info
-      (t (lsp--info "%s" mes))))) ; Log
-
 (lsp-defun lsp-roslyn--on-project-initialization-complete (workspace _params)
   (lsp--info "%s: Project initialized successfully."
              (lsp--workspace-print workspace)))
@@ -268,17 +260,17 @@ Assumes it was installed with the server install function."
 
 (defun lsp-roslyn--get-rid ()
   "Retrieves the .NET Runtime Identifier (RID) for the current system."
-  (let* ((is-x64 (string-match-p (rx (or "x86_64" "aarch64")) system-configuration))
-         (is-x86 (and (string-match-p "x86" system-configuration) (not is-x64)))
-         (is-arm (string-match-p (rx (or "arm" "aarch")) system-configuration)))
-    (if-let ((platform-name (cond
+  (let* ((is-x64 (string-match-p "x86_64" system-configuration))
+         (is-arm64 (string-match-p "aarch64" system-configuration))
+         (is-x86 (and (string-match-p "x86" system-configuration) (not is-x64))))
+    (if-let* ((platform-name (cond
                              ((eq system-type 'gnu/linux) "linux")
                              ((eq system-type 'darwin) "osx")
                              ((eq system-type 'windows-nt) "win")))
              (arch-name (cond
                          (is-x64 "x64")
-                         (is-x86 "x86")
-                         (is-arm "arm64"))))
+                         (is-arm64 "arm64")
+                         (is-x86 "x86"))))
         (format "%s-%s" platform-name arch-name)
       (error "Unsupported platform: %s (%s)" system-type system-configuration))))
 
@@ -345,8 +337,7 @@ FORCED if specified with prefix argument."
                   :priority 0
                   :server-id 'csharp-roslyn
                   :activation-fn (lsp-activate-on "csharp")
-                  :notification-handlers (ht ("window/logMessage" 'lsp-roslyn--log-message)
-                                             ("workspace/projectInitializationComplete" 'lsp-roslyn--on-project-initialization-complete))
+                  :notification-handlers (ht ("workspace/projectInitializationComplete" 'lsp-roslyn--on-project-initialization-complete))
 
                   ;; These two functions are the same as lsp-mode's except they do not
                   ;; (un)hexify URIs.


### PR DESCRIPTION
Also fix #4520 