### PR TITLE
Feature: inline completions

### DIFF
--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -66,4 +66,239 @@
     ;; Clean up
     (lsp--spinner-stop)))
 
+
+;;;;;; Default UI -- overlay
+
+(defvar lsp-inline-completion-active-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "<tab>") #'lsp-inline-completion-next)
+    (define-key map (kbd "C-n") #'lsp-inline-completion-next)
+    (define-key map (kbd "M-n") #'lsp-inline-completion-next)
+    (define-key map (kbd "C-p") #'lsp-inline-completion-prev)
+    (define-key map (kbd "M-p") #'lsp-inline-completion-prev)
+    (define-key map (kbd "<return>") #'lsp-inline-completion-accept)
+    (define-key map [down-mouse-1] #'ignore)
+    (define-key map [down-mouse-3] #'ignore)
+    (define-key map [up-mouse-1] #'ignore)
+    (define-key map [up-mouse-3] #'ignore)
+    (define-key map [mouse-1] #'lsp-inline-completion-accept)
+    (define-key map [mouse-3] #'lsp-inline-completion-accept)
+    (define-key map (kbd "C-l") #'recenter-top-bottom)
+    (define-key map (kbd "C-g") #'lsp-inline-completion-cancel)
+    (define-key map (kbd "<escape>") #'lsp-inline-completion-cancel)
+    (define-key map (kbd "C-c C-k") #'lsp-inline-completion-cancel)
+    (define-key map [mouse-movement] #'ignore)
+    (define-key map [t] #'lsp-inline-completion-cancel)
+    map)
+  "Keymap active when showing inline code suggestions")
+
+;;;###autoload
+(defface lsp-inline-completion-overlay-face
+  '((t :inherit shadow))
+  "Face for the inline code suggestions overlay.")
+
+;; Local Buffer State
+
+(defvar-local lsp-inline-completion--items nil "The completions provided by the server")
+(defvar-local lsp-inline-completion--current nil "The current suggestion to be displayed")
+(defvar-local lsp-inline-completion--overlay nil "The overlay displaying code suggestions")
+(defvar-local lsp-inline-completion--start-point nil "The point where the completion started")
+
+(defcustom lsp-before-inline-completion-hook nil
+  "Hooks run before starting code suggestions"
+  :type 'hook)
+
+(defcustom lsp-after-inline-completion-hook nil
+  "Hooks executed after asking for code suggestions."
+  :type 'hook)
+
+;; TODO: Add parameters to the hooks!
+(defcustom lsp-inline-completion-accepted-hook nil
+  "Hooks executed after accepting a code suggestion."
+  :type 'hook)
+
+(defcustom lsp-inline-completion-shown-hook nil
+  "Hooks executed after showing a suggestion."
+  :type 'hook)
+
+(defsubst lsp-inline-completion--overlay-visible ()
+  "Return whether the `overlay' is avaiable."
+  (and (overlayp lsp-inline-completion--overlay)
+       (overlay-buffer lsp-inline-completion--overlay)))
+
+(defun lsp-inline-completion--clear-overlay ()
+  "Hide the suggestion overlay"
+  (when (lsp-inline-completion--overlay-visible)
+    (delete-overlay lsp-inline-completion--overlay))
+  (setq lsp-inline-completion--overlay nil))
+
+
+(defun lsp-inline-completion--get-overlay (beg end)
+  "Build the suggestions overlay"
+  (when (overlayp lsp-inline-completion--overlay)
+    (lsp-inline-completion--clear-overlay))
+
+  (setq lsp-inline-completion--overlay (make-overlay beg end nil nil t))
+  (overlay-put lsp-inline-completion--overlay 'keymap lsp-inline-completion-active-map)
+  (overlay-put lsp-inline-completion--overlay 'priority 9000)
+
+  lsp-inline-completion--overlay)
+
+
+;;;###autoload
+(defun lsp-inline-completion-show-keys ()
+  "Shows active keymap hints in the minibuffer"
+
+  (unless (and lsp-inline-completion--items
+               (numberp lsp-inline-completion--current))
+    (error "No completions to show 1"))
+
+  (let ((message-log-max nil))
+    (message (concat "Completion "
+                     (propertize (format "%d" (1+ lsp-inline-completion--current)) 'face 'bold)
+                     "/"
+                     (propertize (format "%d" (length lsp-inline-completion--items)) 'face 'bold)
+
+                     (-when-let (keys (where-is-internal #'lsp-inline-completion-next lsp-inline-completion-active-map))
+                       (concat ". "
+                               (propertize " Next" 'face 'italic)
+                               (format ": [%s]"
+                                       (string-join (--map (propertize (key-description it) 'face 'help-key-binding)
+                                                           keys)
+                                                    "/"))))
+                     (-when-let (keys (where-is-internal #'lsp-inline-completion-accept lsp-inline-completion-active-map))
+                       (concat (propertize " Accept" 'face 'italic)
+                               (format ": [%s]"
+                                       (string-join (--map (propertize (key-description it) 'face 'help-key-binding)
+                                                           keys)
+                                                    "/"))))))))
+
+(defun lsp-inline-completion-show-overlay ()
+  "Makes the suggestion overlay visible"
+  (unless (and lsp-inline-completion--items
+               (numberp lsp-inline-completion--current))
+    (error "No completions to show 2"))
+
+  (lsp-inline-completion--clear-overlay)
+
+  (-let* ((suggestion
+           (elt lsp-inline-completion--items
+                lsp-inline-completion--current))
+          ((&InlineCompletionItem? :insert-text :filter-text? :range? :command?) suggestion)
+          ((&RangeToPoint :start :end) range?)
+          (start-point (or start (point)))
+          (showing-at-eol (save-excursion
+                            (goto-char start-point)
+                            (eolp)))
+          (beg (if showing-at-eol (1- start-point) start-point))
+          (end-point  (or end (1+ beg)))
+          (text (cond
+                 ((lsp-markup-content? insert-text) (lsp:markup-content-value insert-text))
+                 (t insert-text)))
+          (propertizedText (concat
+                            (buffer-substring beg start-point)
+                            (propertize text 'face 'lsp-inline-completion-overlay-face)))
+          (ov (lsp-inline-completion--get-overlay  beg end-point)))
+    (goto-char beg)
+
+    (put-text-property 0 1 'cursor t propertizedText)
+    (overlay-put ov 'display (substring propertizedText 0 1))
+    (overlay-put ov 'after-string (substring propertizedText 1))
+
+    (run-hooks 'lsp-inline-completion-shown-hook)))
+
+(defun lsp-inline-completion-accept ()
+  "Accepts the current suggestion"
+  (interactive)
+  (unless (lsp-inline-completion--overlay-visible)
+    (error "Not showing suggestions"))
+
+  (lsp-inline-completion--clear-overlay)
+  (-let* ((suggestion (elt lsp-inline-completion--items lsp-inline-completion--current))
+          ((&InlineCompletionItem? :insert-text :filter-text? :range? :command?) suggestion)
+          ((kind . text) (cond
+                          ((lsp-markup-content? insert-text)
+                           (cons 'snippet (lsp:markup-content-value insert-text) ))
+                          (t (cons 'text insert-text))))
+          ((start . end) (when range?
+                           (-let (((&RangeToPoint :start :end) range?)) (cons start end))))
+          (text-insert-start (or start lsp-inline-completion--start-point))
+          text-insert-end)
+
+    (when text-insert-start
+      (goto-char text-insert-start))
+
+    ;; When range is provided, must replace the text of the range by the text
+    ;; to insert
+    (when (and start end (/= start end))
+      (delete-region start end))
+
+    ;; Insert suggestion, keeping the cursor at the start point
+    (insert text)
+    (setq text-insert-end (point))
+
+    ;; If a template, format it -- keep track of the end position!
+    (when (eq kind 'snippet)
+      (let ((end-marker (set-maker (make-maker))))
+        (lsp--expand-snippet (buffer-substring text-insert-start text-insert-end)
+                             text-insert-start
+                             text-insert-end)
+        (setq text-insert-end (marker-position end-marker))
+        (set-marker end-marker nil)))
+
+    ;; Post command
+    (when command?
+      (lsp--execute-command command?))
+
+    (goto-char text-insert-start)
+
+    ;; hooks
+    (run-hook-with-args-until-failure 'lsp-inline-completion-accepted-hook text text-insert-start text-insert-end)))
+
+(defun lsp-inline-completion-cancel ()
+  "Close the suggestion overlay"
+  (interactive)
+  (unless (lsp-inline-completion--overlay-visible)
+    (error "Not showing suggestions"))
+
+  (lsp-inline-completion--clear-overlay)
+
+  (when lsp-inline-completion--start-point
+    (goto-char lsp-inline-completion--start-point)))
+
+(defun lsp-inline-completion-next ()
+  "Display the next inline completion"
+  (interactive)
+  (unless (lsp-inline-completion--overlay-visible)
+    (error "Not showing suggestions"))
+  (setq lsp-inline-completion--current
+        (mod (1+ lsp-inline-completion--current)
+             (length lsp-inline-completion--items)))
+
+  (lsp-inline-completion-show-overlay))
+
+(defun lsp-inline-completion-prev ()
+  "Display the previous inline completion"
+  (interactive)
+  (unless (lsp-inline-completion--overlay-visible)
+    (error "Not showing suggestions"))
+  (setq lsp-inline-completion--current
+        (mod (1- lsp-inline-completion--current)
+             (length lsp-inline-completion--items)))
+
+  (lsp-inline-completion-show-overlay))
+
+;;;###autoload
+(defun lsp-inline-completion-display (&optional implicit)
+  "Displays the inline completions overlay"
+  (interactive)
+
+  (if-let* ((items (lsp-inline-completion-get-items implicit)))
+      (progn
+        (setq lsp-inline-completion--items items)
+        (setq lsp-inline-completion--current 0)
+        (setq lsp-inline-completion--start-point (point))
+        (lsp-inline-completion-show-overlay))
+    (message "No Suggestions!")))
+
 (provide 'lsp-inline-completion)

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -36,12 +36,15 @@
 (declare-function company-cancel "ext:company" (&optional result))
 (declare-function company-manual-begin "ext:company")
 
-(defun lsp-inline-completion--trigger-kind (implicit)
-  (plist-put (lsp--text-document-position-params)
-             :context (ht ("triggerKind"
-                           (if implicit
-                               lsp/inline-completion-trigger-automatic
-                             lsp/inline-completion-trigger-invoked)))))
+(defun lsp-inline-completion--params (implicit &optional identifier position)
+  "Returns a InlineCompletionParams instance"
+  (lsp-make-inline-completion-params
+   :textDocument (or identifier (lsp--text-document-identifier))
+   :position (or position (lsp--cur-position))
+   :context (lsp-make-inline-completion-context
+             :triggerKind (if implicit
+                              lsp/inline-completion-trigger-automatic
+                            lsp/inline-completion-trigger-invoked))))
 
 ;;;###autoload
 (defun lsp-inline-completion-parse-items (response)
@@ -348,7 +351,7 @@
   (lsp--spinner-start)
   (unwind-protect
       (if-let* ((resp (lsp-request-while-no-input "textDocument/inlineCompletion"
-                                                  (lsp-inline-completion--trigger-kind implicit)))
+                                                  (lsp-inline-completion--params implicit)))
                 (items (lsp-inline-completion-parse-items resp)))
 
           (progn

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -308,7 +308,7 @@
 
   (lsp-inline-completion-cancel)
 
-  (let ((command (lookup-key (current-global-map) (vector event)))
+  (let ((command (lookup-key (current-active-maps) (vector event)))
         (current-prefix-arg arg))
 
     (when (commandp command)

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -437,7 +437,7 @@ lsp-inline-completion-mode is active"
 (declare-function company--active-p "ext:company")
 (declare-function company-cancel "ext:company" (&optional result))
 (declare-function company-manual-begin "ext:company")
-
+(defvar company--begin-inhibit-commands)
 (defcustom lsp-inline-completion-mode-inhibit-when-company-active t
   "If the inline completion mode should avoid calling completions when company is active"
   :type 'boolean

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -88,7 +88,7 @@
     (define-key map (kbd "<escape>") #'lsp-inline-completion-cancel)
     (define-key map (kbd "C-c C-k") #'lsp-inline-completion-cancel)
     (define-key map [mouse-movement] #'ignore)
-    (define-key map [t] #'lsp-inline-completion-cancel)
+    (define-key map [t] #'lsp-inline-completion-cancel-with-input)
     map)
   "Keymap active when showing inline code suggestions")
 
@@ -258,13 +258,24 @@
 (defun lsp-inline-completion-cancel ()
   "Close the suggestion overlay"
   (interactive)
-  (unless (lsp-inline-completion--overlay-visible)
-    (error "Not showing suggestions"))
+  (when (lsp-inline-completion--overlay-visible)
 
-  (lsp-inline-completion--clear-overlay)
+    (lsp-inline-completion--clear-overlay)
 
-  (when lsp-inline-completion--start-point
-    (goto-char lsp-inline-completion--start-point)))
+    (when lsp-inline-completion--start-point
+      (goto-char lsp-inline-completion--start-point))))
+
+(defun lsp-inline-completion-cancel-with-input (event &optional arg)
+  "Cancel the inline completion and executes whatever event was received"
+  (interactive (list last-input-event current-prefix-arg))
+
+  (lsp-inline-completion-cancel)
+
+  (let ((command (lookup-key (current-global-map) (vector event)))
+        (current-prefix-arg current-prefix-arg))
+
+    (when (commandp command)
+      (call-interactively command))))
 
 (defun lsp-inline-completion-next ()
   "Display the next inline completion"

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -303,7 +303,7 @@
   (lsp-inline-completion-cancel)
 
   (let ((command (lookup-key (current-global-map) (vector event)))
-        (current-prefix-arg current-prefix-arg))
+        (current-prefix-arg arg))
 
     (when (commandp command)
       (call-interactively command))))

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -55,7 +55,7 @@ InlineCompletionItem objects"
     ((pred (lambda (i)
              (and (sequencep i)
                   (lsp-inline-completion-item? (elt i 0)))))
-     (seq-into i 'list))
+     (seq-into response 'list))
 
     ;; A sequence means multiple server may have responded. Iterate over them and normalize
     ((pred sequencep)

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -4,7 +4,7 @@
 
 ;; Author: Rodrigo Kassick
 ;; Keywords: languages
-;; Package-Requires: ((emacs "27.1") (dash "2.18.0") (ht "2.3") (spinner "1.7.3"))
+;; Package-Requires: ((emacs "27.1") (dash "2.18.0") (spinner "1.7.3"))
 ;; Version: 9.0.1
 
 ;; URL: https://github.com/emacs-lsp/lsp-mode

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -390,9 +390,22 @@ lsp-inline-completion-mode is active"
   :type '(repeat function)
   :group 'lsp-mode)
 
-
 (defvar-local lsp-inline-completion--idle-timer nil
   "The idle timer used by lsp-inline-completion-mode")
+
+(define-minor-mode lsp-inline-completion-mode
+  "Mode automatically displaying inline completions."
+  :lighter nil
+  (cond
+   ((and lsp-inline-completion-mode lsp--buffer-workspaces)
+    (add-hook 'lsp-on-change-hook #'lsp-inline-completion--after-change nil t))
+   (t
+    (when lsp-inline-completion--idle-timer
+      (cancel-timer lsp-inline-completion--idle-timer))
+
+    (lsp-inline-completion-cancel)
+
+    (remove-hook 'lsp-on-change-hook #'lsp-inline-completion--after-change t))))
 
 (defun lsp-inline-completion--maybe-display (buffer)
   (when (and (buffer-live-p buffer)
@@ -412,21 +425,6 @@ lsp-inline-completion-mode is active"
                             nil
                             #'lsp-inline-completion--maybe-display
                             buffer)))))
-
-(define-minor-mode lsp-inline-completion-mode
-  "Mode automatically displaying inline completions."
-  :lighter nil
-  (cond
-   ((and lsp-inline-completion-mode lsp--buffer-workspaces)
-    (add-hook 'lsp-on-change-hook #'lsp-inline-completion--after-change nil t))
-   (t
-    (when lsp-inline-completion--idle-timer
-      (cancel-timer lsp-inline-completion--idle-timer))
-
-    (lsp-inline-completion-cancel)
-
-    (remove-hook 'lsp-on-change-hook #'lsp-inline-completion--after-change t))))
-
 
 ;;;###autoload
 (add-hook 'lsp-configure-hook (lambda ()

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -198,12 +198,33 @@
           (propertizedText (concat
                             (buffer-substring beg start-point)
                             (propertize text 'face 'lsp-inline-completion-overlay-face)))
-          (ov (lsp-inline-completion--get-overlay  beg end-point)))
+          (ov (lsp-inline-completion--get-overlay beg end-point))
+          (completion-is-substr (string-equal
+                                 (buffer-substring beg lsp-inline-completion--start-point)
+                                 (substring propertizedText 0 (- lsp-inline-completion--start-point beg))))
+          display-str after-str target-position)
+
     (goto-char beg)
 
-    (put-text-property 0 1 'cursor t propertizedText)
-    (overlay-put ov 'display (substring propertizedText 0 1))
-    (overlay-put ov 'after-string (substring propertizedText 1))
+    (put-text-property 0 (length propertizedText) 'cursor t propertizedText)
+
+    (if completion-is-substr
+        (progn
+          ;; Show the prefix as `display'
+          (setq display-str (substring propertizedText 0 (- lsp-inline-completion--start-point beg)))
+          (setq after-str (substring propertizedText (- lsp-inline-completion--start-point beg) nil))
+          (setq target-position lsp-inline-completion--start-point))
+
+
+      (setq display-str (substring propertizedText 0 1))
+      (setq after-str (substring propertizedText 1))
+      (setq target-position beg)
+      )
+
+    (overlay-put ov 'display display-str)
+    (overlay-put ov 'after-string after-str)
+
+    (goto-char target-position)
 
     (run-hooks 'lsp-inline-completion-shown-hook)))
 

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -267,7 +267,7 @@
 
     ;; If a template, format it -- keep track of the end position!
     (when (eq kind 'snippet)
-      (let ((end-marker (set-marker (make-marker))))
+      (let ((end-marker (set-marker (make-marker) (point))))
         (lsp--expand-snippet (buffer-substring text-insert-start text-insert-end)
                              text-insert-start
                              text-insert-end)

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -95,7 +95,8 @@
 ;;;###autoload
 (defface lsp-inline-completion-overlay-face
   '((t :inherit shadow))
-  "Face for the inline code suggestions overlay.")
+  "Face for the inline code suggestions overlay."
+  :group 'lsp-mode)
 
 ;; Local Buffer State
 
@@ -106,20 +107,24 @@
 
 (defcustom lsp-before-inline-completion-hook nil
   "Hooks run before starting code suggestions"
-  :type 'hook)
+  :type 'hook
+  :group 'lsp-mode)
 
 (defcustom lsp-after-inline-completion-hook nil
   "Hooks executed after asking for code suggestions."
-  :type 'hook)
+  :type 'hook
+  :group 'lsp-mode)
 
 ;; TODO: Add parameters to the hooks!
 (defcustom lsp-inline-completion-accepted-hook nil
   "Hooks executed after accepting a code suggestion."
-  :type 'hook)
+  :type 'hook
+  :group 'lsp-mode)
 
 (defcustom lsp-inline-completion-shown-hook nil
   "Hooks executed after showing a suggestion."
-  :type 'hook)
+  :type 'hook
+  :group 'lsp-mode)
 
 (defsubst lsp-inline-completion--overlay-visible ()
   "Return whether the `overlay' is avaiable."
@@ -184,7 +189,7 @@
   (-let* ((suggestion
            (elt lsp-inline-completion--items
                 lsp-inline-completion--current))
-          ((&InlineCompletionItem? :insert-text :filter-text? :range? :command?) suggestion)
+          ((&InlineCompletionItem? :insert-text :range?) suggestion)
           ((&RangeToPoint :start :end) range?)
           (start-point (or start (point)))
           (showing-at-eol (save-excursion
@@ -218,8 +223,7 @@
 
       (setq display-str (substring propertizedText 0 1))
       (setq after-str (substring propertizedText 1))
-      (setq target-position beg)
-      )
+      (setq target-position beg))
 
     (overlay-put ov 'display display-str)
     (overlay-put ov 'after-string after-str)
@@ -236,7 +240,7 @@
 
   (lsp-inline-completion--clear-overlay)
   (-let* ((suggestion (elt lsp-inline-completion--items lsp-inline-completion--current))
-          ((&InlineCompletionItem? :insert-text :filter-text? :range? :command?) suggestion)
+          ((&InlineCompletionItem? :insert-text :range? :command?) suggestion)
           ((kind . text) (cond
                           ((lsp-markup-content? insert-text)
                            (cons 'snippet (lsp:markup-content-value insert-text) ))
@@ -276,6 +280,7 @@
     ;; hooks
     (run-hook-with-args-until-failure 'lsp-inline-completion-accepted-hook text text-insert-start text-insert-end)))
 
+;;;###autoload
 (defun lsp-inline-completion-cancel ()
   "Close the suggestion overlay"
   (interactive)

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -32,6 +32,10 @@
 (require 'dash)
 (require 'cl-lib)
 
+(declare-function company--active-p "ext:company")
+(declare-function company-cancel "ext:company" (&optional result))
+(declare-function company-manual-begin "ext:company")
+
 (defun lsp-inline-completion--trigger-kind (implicit)
   (plist-put (lsp--text-document-position-params)
              :context (ht ("triggerKind"

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -30,6 +30,7 @@
 
 (require 'lsp-mode)
 (require 'dash)
+(require 'cl-lib)
 
 (defun lsp-inline-completion--trigger-kind (implicit)
   (plist-put (lsp--text-document-position-params)
@@ -54,7 +55,7 @@
 
         ;; Response may or may not come inside an :items. Parse each
         ;; response to ensure compatibility.
-        (map 'list (lambda (elt)
+        (cl-map 'list (lambda (elt)
                      (if (lsp-inline-completion-list? elt)
                          (lsp:inline-completion-list-items elt)
                        elt))

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -31,6 +31,7 @@
 (require 'lsp-protocol)
 (require 'dash)
 (require 'cl-lib)
+(require 'fringe)
 
 (defun lsp-inline-completion--params (implicit &optional identifier position)
   "Returns a InlineCompletionParams instance"
@@ -69,7 +70,7 @@ InlineCompletionItem objects"
   (let ((map (make-sparse-keymap)))
     ;; accept
     (define-key map (kbd "C-<return>") #'lsp-inline-completion-accept)
-    (define-key map [mouse-1] #'lsp-inline-completion-accept)
+    (define-key map [mouse-1] #'lsp-inline-completion-accept-on-click)
     ;; navigate
     (define-key map (kbd "C-n") #'lsp-inline-completion-next)
     (define-key map (kbd "C-p") #'lsp-inline-completion-prev)
@@ -302,6 +303,18 @@ text range that was updated by the completion"
 
     ;; hooks
     (run-hook-with-args-until-failure 'lsp-inline-completion-accepted-hook text text-insert-start text-insert-end)))
+
+(defun lsp-inline-completion-accept-on-click (event)
+  (interactive "e")
+
+  (lsp-inline-completion-accept)
+  (-let (((col . row) (posn-actual-col-row (event-end event))))
+    (move-to-window-line row)
+    (beginning-of-line)
+    (forward-char (- col
+                     (if (bound-and-true-p display-line-numbers-mode)
+                         (+ 2 (line-number-display-width))
+                       0)))))
 
 (defun lsp-inline-completion-cancel ()
   "Close the suggestion overlay"

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -247,6 +247,7 @@ text range that was updated by the completion"
 
     (goto-char target-position)
 
+    (lsp-inline-completion-show-keys)
     (run-hooks 'lsp-inline-completion-shown-hook)))
 
 (defun lsp-inline-completion-accept ()

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -248,7 +248,10 @@
           ((start . end) (when range?
                            (-let (((&RangeToPoint :start :end) range?)) (cons start end))))
           (text-insert-start (or start lsp-inline-completion--start-point))
-          text-insert-end)
+          text-insert-end
+          (completion-is-substr (string-equal
+                                 (buffer-substring text-insert-start lsp-inline-completion--start-point)
+                                 (substring text 0 (- lsp-inline-completion--start-point text-insert-start)))))
 
     (when text-insert-start
       (goto-char text-insert-start))
@@ -275,7 +278,9 @@
     (when command?
       (lsp--execute-command command?))
 
-    (goto-char text-insert-start)
+    (if completion-is-substr
+        (goto-char lsp-inline-completion--start-point)
+      (goto-char text-insert-start))
 
     ;; hooks
     (run-hook-with-args-until-failure 'lsp-inline-completion-accepted-hook text text-insert-start text-insert-end)))

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -267,7 +267,7 @@
 
     ;; If a template, format it -- keep track of the end position!
     (when (eq kind 'snippet)
-      (let ((end-marker (set-maker (make-maker))))
+      (let ((end-marker (set-marker (make-marker))))
         (lsp--expand-snippet (buffer-substring text-insert-start text-insert-end)
                              text-insert-start
                              text-insert-end)

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -426,9 +426,11 @@ lsp-inline-completion-mode is active"
   ;; lsp-on-change. Do not assume that the buffer/window state has not been
   ;; modified in the meantime! Use the values in lsp--after-change-vals to
   ;; ensure this.
+
+  (when lsp-inline-completion--idle-timer
+    (cancel-timer lsp-inline-completion--idle-timer))
+
   (when (and lsp-inline-completion-mode lsp--buffer-workspaces)
-    (when lsp-inline-completion--idle-timer
-      (cancel-timer lsp-inline-completion--idle-timer))
     (let ((original-buffer (plist-get lsp--after-change-vals :buffer))
           (original-point (plist-get lsp--after-change-vals :point)))
       (setq lsp-inline-completion--idle-timer

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -470,17 +470,19 @@ lsp-inline-completion-mode is active"
     (add-hook 'lsp-inline-completion-before-show-hook #'lsp-inline-completion--company-save-state-and-hide nil t)
     (add-hook 'lsp-inline-completion-cancelled-hook #'lsp-inline-completion--company-restore-state nil t)
     (unless (memq #'lsp-inline-completion-display company--begin-inhibit-commands)
+      (make-variable-buffer-local 'company--begin-inhibit-commands)
       (push #'lsp-inline-completion-display company--begin-inhibit-commands))
     (when (and lsp-inline-completion-mode-inhibit-when-company-active
                (not (memq  #'lsp-inline-completion--company-active-p lsp-inline-completion-inhibit-predicates)))
+      (make-variable-buffer-local 'lsp-inline-completion-inhibit-predicates)
       (push #'lsp-inline-completion--company-active-p lsp-inline-completion-inhibit-predicates)))
 
    (t
     (remove-hook 'lsp-inline-completion-before-show-hook #'lsp-inline-completion--company-save-state-and-hide t)
     (remove-hook 'lsp-inline-completion-cancelled-hook #'lsp-inline-completion--company-save-state-and-hide t)
     (when (boundp 'company--begin-inhibit-commands)
-      (setq company--begin-inhibit-commands (delq #'lsp-inline-completion-display company--begin-inhibit-commands)))
-    (setq lsp-inline-completion-inhibit-predicates
+      (setq-local company--begin-inhibit-commands (delq #'lsp-inline-completion-display company--begin-inhibit-commands)))
+    (setq-local lsp-inline-completion-inhibit-predicates
           (delq #'lsp-inline-completion--company-active-p lsp-inline-completion-inhibit-predicates)))))
 
 (provide 'lsp-inline-completion)

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -131,7 +131,7 @@ text range that was updated by the completion"
   :type 'hook
   :group 'lsp-mode)
 
-(defcustom lsp-inline-completion-overlay-priority (cons nil 100)
+(defcustom lsp-inline-completion-overlay-priority 9000
   "The priority of the overlay."
   :type '(choice (const :tag "No Priority" nil)
                  (integer :tag "Simple, Overriding Priority")
@@ -424,6 +424,11 @@ lsp-inline-completion-mode is active"
     (remove-hook 'lsp-on-change-hook #'lsp-inline-completion--after-change t))))
 
 
+;;;###autoload
+(add-hook 'lsp-configure-hook (lambda ()
+                                (when (and lsp-inline-completion-enable
+                                           (lsp-feature? "textDocument/inlineCompletion"))
+                                  (lsp-inline-completion-mode))))
 
 ;; Company default integration
 

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -469,12 +469,12 @@ lsp-inline-completion-mode is active"
     (add-hook 'lsp-inline-completion-before-show-hook #'lsp-inline-completion--company-save-state-and-hide nil t)
     (add-hook 'lsp-inline-completion-cancelled-hook #'lsp-inline-completion--company-restore-state nil t)
     (unless (memq #'lsp-inline-completion-display company--begin-inhibit-commands)
-      (make-variable-buffer-local 'company--begin-inhibit-commands)
-      (push #'lsp-inline-completion-display company--begin-inhibit-commands))
+      (setq-local company--begin-inhibit-commands
+                  (cons #'lsp-inline-completion-display company--begin-inhibit-commands)))
     (when (and lsp-inline-completion-mode-inhibit-when-company-active
                (not (memq  #'lsp-inline-completion--company-active-p lsp-inline-completion-inhibit-predicates)))
-      (make-variable-buffer-local 'lsp-inline-completion-inhibit-predicates)
-      (push #'lsp-inline-completion--company-active-p lsp-inline-completion-inhibit-predicates)))
+      (setq-local lsp-inline-completion-inhibit-predicates
+                  (cons #'lsp-inline-completion--company-active-p lsp-inline-completion-inhibit-predicates))))
 
    (t
     (remove-hook 'lsp-inline-completion-before-show-hook #'lsp-inline-completion--company-save-state-and-hide t)

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -370,7 +370,7 @@ text range that was updated by the completion"
             (setq lsp-inline-completion--start-point (point))
             (lsp-inline-completion-show-overlay))
         (unless implicit
-          (message "No Suggestions!")))
+          (lsp--info "No Suggestions!")))
     ;; Clean up
     (unless implicit
       (lsp--spinner-stop))))

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -440,6 +440,7 @@ lsp-inline-completion-mode is active"
 
 (defcustom lsp-inline-completion-mode-inhibit-when-company-active t
   "If the inline completion mode should avoid calling completions when company is active"
+  :type 'boolean
   :group 'lsp-mode)
 
 (defvar-local lsp-inline-completion--showing-company nil "If company was active when the tooltip is shown")

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -398,6 +398,7 @@ lsp-inline-completion-mode is active"
 (defvar-local lsp-inline-completion--idle-timer nil
   "The idle timer used by lsp-inline-completion-mode")
 
+;;;###autoload
 (define-minor-mode lsp-inline-completion-mode
   "Mode automatically displaying inline completions."
   :lighter nil
@@ -477,6 +478,7 @@ lsp-inline-completion-mode is active"
 (defun lsp-inline-completion--company-active-p ()
   (and (bound-and-true-p company-mode) (company--active-p)))
 
+;;;###autoload
 (define-minor-mode lsp-inline-completion-company-integration-mode
   "Minor mode to be used when company mode is active with lsp-inline-completion-mode"
   :lighter nil

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -156,7 +156,7 @@
 
   (unless (and lsp-inline-completion--items
                (numberp lsp-inline-completion--current))
-    (error "No completions to show 1"))
+    (error "No completions to show"))
 
   (let ((message-log-max nil))
     (message (concat "Completion "
@@ -182,7 +182,7 @@
   "Makes the suggestion overlay visible"
   (unless (and lsp-inline-completion--items
                (numberp lsp-inline-completion--current))
-    (error "No completions to show 2"))
+    (error "No completions to show"))
 
   (lsp-inline-completion--clear-overlay)
 

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -166,7 +166,7 @@ text range that was updated by the completion"
   lsp-inline-completion--overlay)
 
 
-(defun lsp-inline-completion-show-keys ()
+(defun lsp-inline-completion--show-keys ()
   "Shows active keymap hints in the minibuffer"
 
   (unless (and lsp-inline-completion--items
@@ -247,7 +247,7 @@ text range that was updated by the completion"
 
     (goto-char target-position)
 
-    (lsp-inline-completion-show-keys)
+    (lsp-inline-completion--show-keys)
     (run-hooks 'lsp-inline-completion-shown-hook)))
 
 (defun lsp-inline-completion-accept ()

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -327,10 +327,12 @@
 
   (if-let* ((items (lsp-inline-completion-get-items implicit)))
       (progn
+        (lsp-inline-completion--clear-overlay)
         (setq lsp-inline-completion--items items)
         (setq lsp-inline-completion--current 0)
         (setq lsp-inline-completion--start-point (point))
         (lsp-inline-completion-show-overlay))
-    (message "No Suggestions!")))
+    (unless implicit
+      (message "No Suggestions!"))))
 
 (provide 'lsp-inline-completion)

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -105,6 +105,7 @@
 (defvar-local lsp-inline-completion--current nil "The current suggestion to be displayed")
 (defvar-local lsp-inline-completion--overlay nil "The overlay displaying code suggestions")
 (defvar-local lsp-inline-completion--start-point nil "The point where the completion started")
+(defvar-local lsp-inline-completion--showing-company nil "If company was active when the tooltip is shown")
 
 (defcustom lsp-before-inline-completion-hook nil
   "Hooks run before starting code suggestions"
@@ -186,6 +187,13 @@
     (error "No completions to show 2"))
 
   (lsp-inline-completion--clear-overlay)
+
+  (setq lsp-inline-completion--showing-company
+        (and (bound-and-true-p company-mode)
+             (company--active-p)))
+
+  (when lsp-inline-completion--showing-company
+    (company-cancel))
 
   (-let* ((suggestion
            (elt lsp-inline-completion--items
@@ -295,7 +303,10 @@
     (lsp-inline-completion--clear-overlay)
 
     (when lsp-inline-completion--start-point
-      (goto-char lsp-inline-completion--start-point))))
+      (goto-char lsp-inline-completion--start-point))
+
+    (when lsp-inline-completion--showing-company
+      (company-manual-begin))))
 
 (defun lsp-inline-completion-cancel-with-input (event &optional arg)
   "Cancel the inline completion and executes whatever event was received"

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -67,23 +67,23 @@ InlineCompletionItem objects"
 ;;;###autoload
 (defvar lsp-inline-completion-active-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "<tab>") #'lsp-inline-completion-next)
-    (define-key map (kbd "C-n") #'lsp-inline-completion-next)
-    (define-key map (kbd "M-n") #'lsp-inline-completion-next)
-    (define-key map (kbd "C-p") #'lsp-inline-completion-prev)
-    (define-key map (kbd "M-p") #'lsp-inline-completion-prev)
-    (define-key map (kbd "<return>") #'lsp-inline-completion-accept)
-    (define-key map [down-mouse-1] #'ignore)
-    (define-key map [down-mouse-3] #'ignore)
-    (define-key map [up-mouse-1] #'ignore)
-    (define-key map [up-mouse-3] #'ignore)
+    ;; accept
+    (define-key map (kbd "C-<return>") #'lsp-inline-completion-accept)
     (define-key map [mouse-1] #'lsp-inline-completion-accept)
-    (define-key map [mouse-3] #'lsp-inline-completion-accept)
-    (define-key map (kbd "C-l") #'recenter-top-bottom)
+    ;; navigate
+    (define-key map (kbd "C-n") #'lsp-inline-completion-next)
+    (define-key map (kbd "C-p") #'lsp-inline-completion-prev)
+    ;; cancel
     (define-key map (kbd "C-g") #'lsp-inline-completion-cancel)
     (define-key map (kbd "<escape>") #'lsp-inline-completion-cancel)
     (define-key map (kbd "C-c C-k") #'lsp-inline-completion-cancel)
+    ;; useful -- recenter without loosing the completion
+    (define-key map (kbd "C-l") #'recenter-top-bottom)
+    ;; ignore
+     (define-key map [down-mouse-1] #'ignore)
+    (define-key map [up-mouse-1] #'ignore)
     (define-key map [mouse-movement] #'ignore)
+    ;; Any event outside of the map, cancel and use it
     (define-key map [t] #'lsp-inline-completion-cancel-with-input)
     map)
   "Keymap active when showing inline code suggestions")
@@ -313,8 +313,7 @@ text range that was updated by the completion"
     (when lsp-inline-completion--start-point
       (goto-char lsp-inline-completion--start-point))
 
-    (run-hooks 'lsp-inline-completion-cancelled-hook)
-    ))
+    (run-hooks 'lsp-inline-completion-cancelled-hook)))
 
 (defun lsp-inline-completion-cancel-with-input (event &optional arg)
   "Cancel the inline completion and executes whatever event was received"

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -59,7 +59,7 @@ InlineCompletionItem objects"
 
     ;; A sequence means multiple server may have responded. Iterate over them and normalize
     ((pred sequencep)
-     (let ((item-seq (map 'list #'lsp-inline-completion--parse-items response)))
+     (let ((item-seq (cl-map 'list #'lsp-inline-completion--parse-items response)))
        (apply 'seq-concatenate `(list ,@item-seq))))))
 
 ;;;;;; Default UI -- overlay

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -353,7 +353,9 @@ text range that was updated by the completion"
   "Displays the inline completions overlay"
   (interactive)
 
-  (lsp--spinner-start)
+  (unless implicit
+    (lsp--spinner-start) )
+
   (unwind-protect
       (if-let* ((resp (lsp-request-while-no-input "textDocument/inlineCompletion"
                                                   (lsp-inline-completion--params implicit)))
@@ -368,7 +370,8 @@ text range that was updated by the completion"
         (unless implicit
           (message "No Suggestions!")))
     ;; Clean up
-    (lsp--spinner-stop)))
+    (unless implicit
+      (lsp--spinner-stop))))
 
 
 ;; Inline Completion Mode

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -1,0 +1,69 @@
+;;; lsp-inline-completion.el --- LSP mode                              -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020-2024 emacs-lsp maintainers
+
+;; Author: Rodrigo Kassick
+;; Keywords: languages
+;; Package-Requires: ((emacs "27.1") (dash "2.18.0") (ht "2.3") (spinner "1.7.3"))
+;; Version: 9.0.1
+
+;; URL: https://github.com/emacs-lsp/lsp-mode
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Inline Completions support
+;; Specification here https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_inlineCompletion
+
+;;; Code:
+
+(require 'lsp-mode)
+(require 'dash)
+
+(defun lsp-inline-completion--trigger-kind (implicit)
+  (plist-put (lsp--text-document-position-params)
+             :context (ht ("triggerKind"
+                           (if implicit
+                               lsp/inline-completion-trigger-automatic
+                             lsp/inline-completion-trigger-invoked)))))
+
+;;;###autoload
+(defun lsp-inline-completion-get-items (&optional implicit)
+  "Calls textDocument_inlineCompletion and returns a list of InlineCompletionItem's"
+
+  (lsp--spinner-start)
+  (unwind-protect
+      (-some-->
+          (lsp-request-while-no-input "textDocument/inlineCompletion"
+                                      (lsp-inline-completion--trigger-kind implicit))
+        ;; Kludge to workaround multiple backends responding -- it may
+        ;; come as a list (multiple servers) or as a single ht (single
+        ;; server). Promote it to list and move on
+        (if (ht-p it) (list it) it)
+
+        ;; Response may or may not come inside an :items. Parse each
+        ;; response to ensure compatibility.
+        (map 'list (lambda (elt)
+                     (if (lsp-inline-completion-list? elt)
+                         (lsp:inline-completion-list-items elt)
+                       elt))
+             it)
+
+        ;; Join everything into a single list
+        (apply 'seq-concatenate `(list ,@it)))
+
+    ;; Clean up
+    (lsp--spinner-stop)))
+
+(provide 'lsp-inline-completion)

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -64,6 +64,7 @@ InlineCompletionItem objects"
 
 ;;;;;; Default UI -- overlay
 
+;;;###autoload
 (defvar lsp-inline-completion-active-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "<tab>") #'lsp-inline-completion-next)

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -28,7 +28,7 @@
 
 ;;; Code:
 
-(require 'lsp-mode)
+(require 'lsp-protocol)
 (require 'dash)
 (require 'cl-lib)
 
@@ -361,5 +361,58 @@ InlineCompletionItem objects"
           (message "No Suggestions!")))
     ;; Clean up
     (lsp--spinner-stop)))
+
+
+;; Inline Completion Mode
+(defcustom lsp-inline-completion-enable t
+  "If non-nil it will enable inline completions on idle."
+  :type 'boolean
+  :group 'lsp-mode
+  :package-version '(lsp-mode . "9.0.1"))
+
+(defcustom lsp-inline-completion-idle-delay 2
+  "The number of seconds before trying to fetch inline completions, when
+lsp-inline-completion-mode is active"
+  :type 'number
+  :group 'lsp-mode
+  :package-version '(lsp-mode . "9.0.1"))
+
+(defcustom lsp-inline-completion-inhibit-predicates nil
+  "When a function of this list returns non nil, lsp-inline-completion-mode will not show the completion"
+  :type '(repeat function)
+  :group 'lsp-mode)
+
+
+(defvar-local lsp-inline-completion--idle-timer nil
+  "The idle timer used by lsp-inline-completion-mode")
+
+(defun lsp-inline-completion--maybe-display ()
+  (unless (--any (funcall it) lsp-inline-completion-inhibit-predicates)
+    (setq last-command this-command)
+    (setq this-command 'lsp-inline-completion-display)
+    (lsp-inline-completion-display 'implicit)))
+
+(defun lsp-inline-completion--after-change (&rest _)
+  (when (and lsp-inline-completion-mode lsp--buffer-workspaces)
+    (when lsp-inline-completion--idle-timer
+      (cancel-timer lsp-inline-completion--idle-timer))
+    (setq lsp-inline-completion--idle-timer
+          (run-with-timer lsp-inline-completion-idle-delay
+                          nil
+                          #'lsp-inline-completion--maybe-display))))
+
+(define-minor-mode lsp-inline-completion-mode
+  "Mode automatically displaying inline completions."
+  :lighter nil
+  (cond
+   ((and lsp-inline-completion-mode lsp--buffer-workspaces)
+    (add-hook 'lsp-on-change-hook #'lsp-inline-completion--after-change nil t))
+   (t
+    (when lsp-inline-completion--idle-timer
+      (cancel-timer lsp-inline-completion--idle-timer))
+
+    (lsp-inline-completion-cancel)
+
+    (remove-hook 'lsp-on-change-hook #'lsp-inline-completion--after-change t))))
 
 (provide 'lsp-inline-completion)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6287,7 +6287,10 @@ A reference is highlighted only if it is visible in a window."
 
   (let* ((wins-visible-pos (-map (lambda (win)
                                    (cons (1- (line-number-at-pos (window-start win) t))
-                                         (1+ (line-number-at-pos (window-end win) t))))
+                                         (1+ (line-number-at-pos (min (window-end win)
+                                                                      (with-current-buffer (window-buffer win)
+                                                                        (buffer-end +1)))
+                                                                 t))))
                                  (get-buffer-window-list nil nil 'visible))))
     (setq lsp--have-document-highlights t)
     (-map

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -57,7 +57,6 @@
 (require 'minibuffer)
 (require 'help-mode)
 (require 'lsp-protocol)
-(require 'lsp-inline-completion)
 
 (defgroup lsp-mode nil
   "Language Server Protocol client."
@@ -4274,10 +4273,6 @@ yet."
       (when (and lsp-inlay-hint-enable
                  (lsp-feature? "textDocument/inlayHint"))
         (lsp-inlay-hints-mode))
-
-      (when (and lsp-inline-completion-enable
-                 (lsp-feature? "textDocument/inlineCompletion"))
-        (lsp-inline-completion-mode))
 
       (when (and lsp-enable-dap-auto-configure
                  (functionp 'dap-mode))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5439,9 +5439,9 @@ If EXCLUDE-DECLARATION is non-nil, request the server to include declarations."
               (lsp-help-mode)
               (with-help-window lsp-help-buf-name
                 (insert
-         (mapconcat 'string-trim-right
-                (split-string (lsp--render-on-hover-content contents t) "\n")
-                "\n"))))
+                 (mapconcat 'string-trim-right
+                            (split-string (lsp--render-on-hover-content contents t) "\n")
+                            "\n"))))
             (run-mode-hooks)))
       (lsp--info "No content at point."))))
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1010,6 +1010,7 @@ directory")
                       (with-lsp-workspace wk
                         (lsp:completion-options-resolve-provider?
                          (lsp--capability-for-method "textDocument/completion")))))
+    ("textDocument/inlineCompletion" :capability :inlineCompletionProvider)
     ("textDocument/declaration" :capability :declarationProvider)
     ("textDocument/definition" :capability :definitionProvider)
     ("textDocument/documentColor" :capability :colorProvider)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -9976,6 +9976,15 @@ string."
 
     (remove-hook 'lsp-on-change-hook #'lsp-inline-completion--after-change t))))
 
+(defcustom lsp-inline-completion-inhibit-predicates nil
+  "When a function of this list returns non nil, lsp-inline-completion-mode will not show the completion"
+  :type '(repeat function)
+  :group 'lsp-mode)
+
+(defun lsp-inline-completion--maybe-display ()
+  (unless (--any (funcall it) lsp-inline-completion-inhibit-predicates)
+    (lsp-inline-completion-display 'implicit)))
+
 (defun lsp-inline-completion--after-change (&rest _)
   (when (and lsp-inline-completion-mode lsp--buffer-workspaces)
     (when lsp-inline-completion--idle-timer
@@ -9983,8 +9992,7 @@ string."
     (setq lsp-inline-completion--idle-timer
           (run-with-timer lsp-inline-completion-idle-delay
                           nil
-                          #'lsp-inline-completion-display
-                          'implicit))))
+                          #'lsp-inline-completion--maybe-display))))
 
 
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -68,6 +68,8 @@
 (declare-function yas-expand-snippet "ext:yasnippet")
 (declare-function dap-mode "ext:dap-mode")
 (declare-function dap-auto-configure-mode "ext:dap-mode")
+(declare-function lsp-inline-completion-display "lsp-inline-completion" (&optional implicit))
+(declare-function lsp-inline-completion-cancel "lsp-inline-completion")
 
 (defvar yas-inhibit-overlay-modification-protection)
 (defvar yas-indent-line)
@@ -3692,6 +3694,19 @@ and expand the capabilities section"
   :type 'boolean
   :group 'lsp-mode
   :package-version '(lsp-mode . "9.0.0"))
+
+(defcustom lsp-inline-completion-enable t
+  "If non-nil it will enable inline completions on idle."
+  :type 'boolean
+  :group 'lsp-mode
+  :package-version '(lsp-mode . "9.0.1"))
+
+(defcustom lsp-inline-completion-idle-delay 2
+  "The number of seconds before trying to fetch inline completions, when
+lsp-inline-completion-mode is active"
+  :type 'number
+  :group 'lsp-mode
+  :package-version '(lsp-mode . "9.0.1"))
 
 (defun lsp--uninitialize-workspace ()
   "Cleanup buffer state.
@@ -9944,29 +9959,8 @@ string."
 
 
 ;; Inline Completions
-(defcustom lsp-inline-completion-enable t
-  "If non-nil it will enable inline completions on idle."
-  :type 'boolean
-  :group 'lsp-mode
-  :package-version '(lsp-mode . "9.0.1"))
-
-(defcustom lsp-inline-completion-idle-delay 2
-  "The number of seconds before trying to fetch inline completions, when
-lsp-inline-completion-mode is active"
-  :type 'number)
-
 (defvar-local lsp-inline-completion--idle-timer nil
   "The idle timer used by lsp-inline-completion-mode")
-
-(defun lsp-inline-completion--after-change (&rest args)
-  (when (and lsp-inline-completion-mode lsp--buffer-workspaces)
-    (when lsp-inline-completion--idle-timer
-      (cancel-timer lsp-inline-completion--idle-timer))
-    (setq lsp-inline-completion--idle-timer
-          (run-with-timer lsp-inline-completion-idle-delay
-                          nil
-                          #'lsp-inline-completion-display
-                          'implicit))))
 
 (define-minor-mode lsp-inline-completion-mode
   "Mode automatically displaying inline completions."
@@ -9981,6 +9975,16 @@ lsp-inline-completion-mode is active"
     (lsp-inline-completion-cancel)
 
     (remove-hook 'lsp-on-change-hook #'lsp-inline-completion--after-change t))))
+
+(defun lsp-inline-completion--after-change (&rest _)
+  (when (and lsp-inline-completion-mode lsp--buffer-workspaces)
+    (when lsp-inline-completion--idle-timer
+      (cancel-timer lsp-inline-completion--idle-timer))
+    (setq lsp-inline-completion--idle-timer
+          (run-with-timer lsp-inline-completion-idle-delay
+                          nil
+                          #'lsp-inline-completion-display
+                          'implicit))))
 
 
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4950,6 +4950,12 @@ Added to `after-change-functions'."
              lsp-managed-mode)
     (run-hooks 'lsp-on-change-hook)))
 
+
+(defvar-local lsp--after-change-vals nil
+  "plist that stores the buffer state when `lsp--after-change' has ben activated. Since the
+functions in `lsp-on-change-hook' are called with a timer, mouse
+movements may have changed the position")
+
 (defun lsp--after-change (buffer)
   "Called after most textDocument/didChange events."
   (setq lsp--signature-last-index nil
@@ -4965,6 +4971,9 @@ Added to `after-change-functions'."
     (lsp--semantic-tokens-refresh-if-enabled buffer))
   (when lsp--on-change-timer
     (cancel-timer lsp--on-change-timer))
+
+  (setq lsp--after-change-vals (list :point (point)
+                                     :buffer (current-buffer)))
   (setq lsp--on-change-timer (run-with-idle-timer
                               lsp-idle-delay
                               nil

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -823,6 +823,8 @@ See `-let' for a description of the destructuring mechanism."
  (InlayHintLabelPart (:value) (:tooltip :location :command))
  (InlayHintsParams (:textDocument) (:range))
  ;; 3.18
+ (InlineCompletionParams (:textDocument :position :context))
+ (InlineCompletionContext (:triggerKind))
  (InlineCompletionItem (:insertText) (:filterText :range :command))
  (InlineCompletionList (:items) nil))
 

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -500,6 +500,8 @@ See `-let' for a description of the destructuring mechanism."
 (defconst lsp/completion-trigger-kind-invoked 1)
 (defconst lsp/completion-trigger-kind-trigger-character 2)
 (defconst lsp/completion-trigger-kind-trigger-for-incomplete-completions 3)
+(defconst lsp/inline-completion-trigger-invoked 1 "Explicit invocation as per https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#inlineCompletionTriggerKind")
+(defconst lsp/inline-completion-trigger-automatic 2 "Automatic invocation as per https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#inlineCompletionTriggerKind")
 (defvar lsp/diagnostic-severity-lookup
   [nil Error Warning Information Hint Max])
 (defconst lsp/diagnostic-severity-error 1)
@@ -624,6 +626,8 @@ See `-let' for a description of the destructuring mechanism."
  (CompletionItemKindCapabilities nil (:valueSet))
  (CompletionItemTagSupportCapabilities (:valueSet) nil)
  (CompletionOptions nil (:resolveProvider :triggerCharacters :allCommitCharacters))
+ (InlineCompletionItem (:insertText) (:filterText :range :command))
+ (InlineCompletionList (:items) nil)
  (ConfigurationItem nil (:scopeUri :section))
  (CreateFileOptions nil (:ignoreIfExists :overwrite))
  (DeclarationCapabilities nil (:dynamicRegistration :linkSupport))

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -626,8 +626,6 @@ See `-let' for a description of the destructuring mechanism."
  (CompletionItemKindCapabilities nil (:valueSet))
  (CompletionItemTagSupportCapabilities (:valueSet) nil)
  (CompletionOptions nil (:resolveProvider :triggerCharacters :allCommitCharacters))
- (InlineCompletionItem (:insertText) (:filterText :range :command))
- (InlineCompletionList (:items) nil)
  (ConfigurationItem nil (:scopeUri :section))
  (CreateFileOptions nil (:ignoreIfExists :overwrite))
  (DeclarationCapabilities nil (:dynamicRegistration :linkSupport))
@@ -823,7 +821,10 @@ See `-let' for a description of the destructuring mechanism."
  ;; 3.17
  (InlayHint (:label :position) (:kind :paddingLeft :paddingRight))
  (InlayHintLabelPart (:value) (:tooltip :location :command))
- (InlayHintsParams (:textDocument) (:range)))
+ (InlayHintsParams (:textDocument) (:range))
+ ;; 3.18
+ (InlineCompletionItem (:insertText) (:filterText :range :command))
+ (InlineCompletionList (:items) nil))
 
 ;; 3.17
 (defconst lsp/inlay-hint-kind-type-hint 1)


### PR DESCRIPTION
As discussed in https://github.com/emacs-lsp/lsp-mode/issues/4581, this PR adds support for Inline Completions

Using some server with `inlineCompletionProvider` capability (I'm using the [copilot-node-server](https://www.npmjs.com/package/copilot-node-server) with [this implementation](https://github.com/kassick/copilot-lsp/)), the inline completion is triggered automatically if `lsp-inline-completion-enable` is set to `t`. The user can also call `lsp-inline-completion-display` explicitly to have the completion displayed.

![Captura de tela de 2024-11-25 10-50-01](https://github.com/user-attachments/assets/31cbbf43-97a5-4c56-9790-0f1f3ea46e38)

![Kooha-2024-11-25-10-51-45](https://github.com/user-attachments/assets/87533d43-30b1-4fba-8ab0-87ef6a3b8c87)

~Optionally, the  user can add `lsp-inline-completion-show-keys` to the `lsp-inline-completion-shown-hook` and the number of available completions and the keys used to interact with the tooltips are shown in the minibuffer.~
When the completion overlay is displayed, a message is shown in the minibuffer as part of the UI, so the user knows if there are more then one completion available.

![image](https://github.com/user-attachments/assets/c5d40875-737c-44c8-bfff-b827fc31f3a2)

When the inline completion tooltip is being displayed, pressing any key that is not mapped in `lsp-inline-completion-active-map` causes the tooltip to be hidden and the key is processed with the current active keymap. This way, if the completion is shown automatically, the user can continue typing to have the completion ignored.
