### PR TITLE
Do not resolve during annotate, enrich documentation with details (Fix #3201) (Fix #3905)

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -190,7 +190,7 @@ See #2675"
       (unless (lsp-get data :for_ref)
          (lsp-put data :for_ref :json-false)))))
 
-(defun lsp-completion--resolve (item)
+(defun lsp-completion-resolve (item)
   "Resolve completion ITEM.
 ITEM can be string or a CompletionItem"
   (cl-assert item nil "Completion item must not be nil")
@@ -215,7 +215,9 @@ ITEM can be string or a CompletionItem"
            item))
         (_ completion-item)))))
 
-(defun lsp-completion--resolve-async (item callback &optional cleanup-fn)
+(defalias 'lsp-completion--resolve 'lsp-completion-resolve)
+
+(defun lsp-completion-resolve-async (item callback &optional cleanup-fn)
   "Resolve completion ITEM asynchronously with CALLBACK.
 The CLEANUP-FN will be called to cleanup."
   (cl-assert item nil "Completion item must not be nil")
@@ -245,6 +247,8 @@ The CLEANUP-FN will be called to cleanup."
                                :mode 'alive))
         (funcall callback completion-item)
         (when cleanup-fn (funcall cleanup-fn))))))
+
+(defalias 'lsp-completion--resolve-async 'lsp-completion-resolve-async)
 
 (defun lsp-completion--annotate (item)
   "Annotate ITEM detail."
@@ -470,7 +474,7 @@ The MARKERS and PREFIX value will be attached to each candidate."
                completion-item))
 
         (unless (or resolved (and detail? documentation?))
-          (setq completion-item (get-text-property 0 'lsp-completion-item (lsp-completion--resolve item))
+          (setq completion-item (get-text-property 0 'lsp-completion-item (lsp-completion-resolve item))
                 resolved t))
 
         (setq detail? (lsp:completion-item-detail? completion-item)
@@ -675,7 +679,7 @@ Others: CANDIDATES"
                ;; see #3498 typescript-language-server does not provide the
                ;; proper insertText without resolving.
                (if (lsp-completion--find-workspace 'ts-ls)
-                   (lsp-completion--resolve candidate)
+                   (lsp-completion-resolve candidate)
                  candidate))
               ((&plist 'lsp-completion-item item
                        'lsp-completion-start-point start-point
@@ -717,14 +721,14 @@ Others: CANDIDATES"
                   (not (seq-empty-p additional-text-edits?)))
               (lsp--apply-text-edits additional-text-edits? 'completion)
             (-let [(callback cleanup-fn) (lsp--create-apply-text-edits-handlers)]
-              (lsp-completion--resolve-async
+              (lsp-completion-resolve-async
                item
                (-compose callback #'lsp:completion-item-additional-text-edits?)
                cleanup-fn))))
 
         (if (or resolved command?)
             (when command? (lsp--execute-command command?))
-          (lsp-completion--resolve-async
+          (lsp-completion-resolve-async
            item
            (-lambda ((&CompletionItem? :command?))
              (when command? (lsp--execute-command command?)))))

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -67,6 +67,11 @@ ignored."
   :group 'lsp-completion
   :package-version '(lsp-mode . "7.0.1"))
 
+(defcustom lsp-completion-show-detail t
+  "Whether or not to show detail of completion candidates."
+  :type 'boolean
+  :group 'lsp-completion)
+
 (defcustom lsp-completion-no-cache nil
   "Whether or not caching the returned completions from server."
   :type 'boolean
@@ -263,7 +268,8 @@ The CLEANUP-FN will be called to cleanup."
 Returns unresolved completion item detail."
   (when-let ((lsp-completion-item (get-text-property 0 'lsp-completion-unresolved-item cand)))
     (concat
-     (lsp-completion--get-label-detail lsp-completion-item)
+     (when lsp-completion-show-detail
+       (lsp-completion--get-label-detail lsp-completion-item))
      (when lsp-completion-show-kind
        (when-let* ((kind? (lsp:completion-item-kind? lsp-completion-item))
                    (kind-name (and kind? (aref lsp-completion--item-kind kind?))))

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -486,9 +486,13 @@ The MARKERS and PREFIX value will be attached to each candidate."
                                   ((and (equal kind "markdown")
                                         (not (string-match-p (regexp-quote detail?) value)))
 
-                                   (lsp--render-string
-                                    (concat "```\n" detail? "\n```\n---\n" value)
-                                    kind)))))
+                                   (concat
+                                    (propertize detail? 'face 'fixed-pitch)
+                                    (lsp--render-string
+                                     (concat
+                                      "\n---\n"
+                                      value)
+                                     kind))))))
 
                          ((and (stringp documentation?)
                                (not (string-match-p (regexp-quote detail?) documentation?)))

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -67,11 +67,6 @@ ignored."
   :group 'lsp-completion
   :package-version '(lsp-mode . "7.0.1"))
 
-(defcustom lsp-completion-show-detail nil
-  "Whether or not to show detail of completion candidates."
-  :type 'boolean
-  :group 'lsp-completion)
-
 (defcustom lsp-completion-no-cache nil
   "Whether or not caching the returned completions from server."
   :type 'boolean
@@ -248,18 +243,15 @@ The CLEANUP-FN will be called to cleanup."
                     (lsp:label-details-description? label-details?)))
            (-let (((&LabelDetails :detail? :description?) label-details?))
              (concat
-              (unless (and lsp-completion-show-detail
-                           detail?
-                           (string-prefix-p " " detail?))
+              (unless (and detail? (string-prefix-p " " detail?))
                 " ")
-              (when lsp-completion-show-detail
-                (s-replace "\r" "" detail?))
+              (s-replace "\r" "" detail?)
               (unless (or omit-description
                           (and description? (string-prefix-p " " description?)))
                 " ")
               (unless omit-description
                 description?))))
-          (lsp-completion-show-detail
+          (detail?
            (concat (unless (and detail? (string-prefix-p " " detail?))
                      " ")
                    (s-replace "\r" "" detail?))))))

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -463,25 +463,11 @@ The MARKERS and PREFIX value will be attached to each candidate."
 (defun lsp-completion--get-documentation (item)
   "Get doc comment for completion ITEM."
   (or (get-text-property 0 'lsp-completion-item-doc item)
-      (-let* ((unresolved-item (get-text-property 0 'lsp-completion-unresolved-item item))
-              (has-unresolved-detail (lsp:completion-item-detail? unresolved-item))
-              (resolved (get-text-property 0 'lsp-completion-resolved item))
-              (completion-item (if resolved
-                                   (get-text-property 0 'lsp-completion-item item)
-                                 unresolved-item))
-              ((&CompletionItem :detail?
+      (-let* (((&CompletionItem :detail?
                                 :documentation?)
-               completion-item))
-
-        (unless (or resolved (and detail? documentation?))
-          (setq completion-item (get-text-property 0 'lsp-completion-item (lsp-completion-resolve item))
-                resolved t))
-
-        (setq detail? (lsp:completion-item-detail? completion-item)
-              documentation? (lsp:completion-item-documentation? completion-item))
-
-        (let ((doc
-               (if (and (null has-unresolved-detail) detail? documentation?)
+               (get-text-property 0 'lsp-completion-item (lsp-completion-resolve item)))
+              (doc
+               (if (and detail? documentation?)
                    ;; detail was resolved, that means the candidate list has no
                    ;; detail, so we may need to prepend it to the documentation
                    (cond ((lsp-markup-content? documentation?)
@@ -517,8 +503,8 @@ The MARKERS and PREFIX value will be attached to each candidate."
 
                  (lsp--render-element documentation?))))
 
-          (put-text-property 0 (length item) 'lsp-completion-item-doc doc item)
-          doc))))
+        (put-text-property 0 (length item) 'lsp-completion-item-doc doc item)
+        doc)))
 
 (defun lsp-completion--get-context (trigger-characters same-session?)
   "Get completion context with provided TRIGGER-CHARACTERS and SAME-SESSION?."

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -501,13 +501,14 @@ Returns resolved completion item details."
                                   ((and (equal kind "markdown")
                                         (not (string-match-p (regexp-quote detail?) value)))
 
-                                   (concat
-                                    (propertize detail? 'face 'fixed-pitch)
-                                    (lsp--render-string
-                                     (concat
-                                      "\n---\n"
-                                      value)
-                                     kind))))))
+                                   (lsp--render-string
+                                    (concat
+                                     "```\n"
+                                     detail?
+                                     "\n```"
+                                     "\n---\n"
+                                     value)
+                                    kind)))))
 
                          ((and (stringp documentation?)
                                (not (string-match-p (regexp-quote detail?) documentation?)))

--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -245,7 +245,8 @@ The CLEANUP-FN will be called to cleanup."
              (concat
               (unless (and detail? (string-prefix-p " " detail?))
                 " ")
-              (s-replace "\r" "" detail?)
+              (when detail?
+                (s-replace "\r" "" detail?))
               (unless (or omit-description
                           (and description? (string-prefix-p " " description?)))
                 " ")

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3800,9 +3800,7 @@ disappearing, unset all the variables related to it."
                                                          . ((properties . ["documentation"
                                                                            "detail"
                                                                            "additionalTextEdits"
-                                                                           "command"
-                                                                           "insertTextFormat"
-                                                                           "insertTextMode"])))
+                                                                           "command"])))
                                                         (insertTextModeSupport . ((valueSet . [1 2])))
                                                         (labelDetailsSupport . t)))
                                      (contextSupport . t)

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -667,7 +667,6 @@ See `-let' for a description of the destructuring mechanism."
  (FormattingOptions (:tabSize :insertSpaces) (:trimTrailingWhitespace :insertFinalNewline :trimFinalNewlines))
  (HoverCapabilities nil (:contentFormat :dynamicRegistration))
  (ImplementationCapabilities nil (:dynamicRegistration :linkSupport))
- (LabelDetails (:detail :description) nil)
  (LinkedEditingRanges (:ranges) (:wordPattern))
  (Location (:range :uri) nil)
  (MarkedString (:language :value) nil)
@@ -824,6 +823,7 @@ See `-let' for a description of the destructuring mechanism."
  (WillSaveTextDocumentParams (:reason :textDocument) nil)
  (WorkspaceSymbolParams (:query) nil)
  ;; 3.17
+ (LabelDetails nil (:detail :description))
  (InlayHint (:label :position) (:kind :paddingLeft :paddingRight))
  (InlayHintLabelPart (:value) (:tooltip :location :command))
  (InlayHintsParams (:textDocument) (:range))


### PR DESCRIPTION
# Problem

When using `typescript-language-server`, the initial call to `textDocument/completion` does not return any `detail` or `documentation` for any of the completion items. I suppose the reason for this is many Javascript signatures are extremely long, often they are 5x to 10x longer than the label, they are unreadable when displaying beside the label on one line, so the server forces the client to make  `completionItem/resolve` requests to resolve the item detail and documentation individually, and it's up to the client to prepend the signature to the documentation, as is done in VS Code.

## VS Code Typescript
<img width="792" alt="Screenshot 2024-11-27 at 12 37 00 AM" src="https://github.com/user-attachments/assets/f5fbe727-1873-451b-8b80-a9a671105606">


This approach presents a problem to `lsp-mode` in that the CAPF function caches the partial completion item response as a text property on each candidate string, and when a completion frontend such as `company` or `corfu` calls `lsp-completion--annotate` to get a suffix, every call will issue an async `completionItem/resolve` request to modify the cached completion item in place while returning just a kind or an empty string initially, depending on some variables. This means the first completion popup will only have the kinds or simply no suffix at all, and then on the next refresh after a selection change, in the case of company, all of the candidates in the pop up will suddenly be annotated, and in the case of corfu, the previous selection will suddenly be annotated. In both cases the popup width will suddenly expand greatly, often times as wide as the window size. This is fundamentally because lsp-mode assumes the partial completion item response from `textDocument/completion` is meant to be used the same way as the fully resolved completion item response from `completionItem/resolve`.

This PR reimplements `lsp-completion--make-item`, `lsp-completion--annotate` and `lsp-completion--get-documentation` to separate the two different usages. In addition, the signature from `detail` is now prepended to the document if it has not been prepended by the language server already.

## LSP ts-ls
<img width="954" alt="Screenshot 2024-11-27 at 12 55 04 AM" src="https://github.com/user-attachments/assets/9c66d5f3-d0e0-4bca-bcdd-936512c0d4da">

## LSP pyright
<img width="707" alt="Screenshot 2024-11-27 at 12 49 31 AM" src="https://github.com/user-attachments/assets/79749ce0-4a20-4c46-8ab5-3e9c78fd593f">

## LSP gopls
<img width="1116" alt="Screenshot 2024-11-27 at 12 50 57 AM" src="https://github.com/user-attachments/assets/96919632-44f1-4b47-89fc-6c3d6ff7ebb6">

## LSP rust-analyzer
<img width="1116" alt="Screenshot 2024-11-27 at 12 46 23 AM" src="https://github.com/user-attachments/assets/562e9611-a784-451e-aa6e-16864117bdcb">

## LSP jdtls
<img width="1411" alt="Screenshot 2024-11-27 at 12 47 45 AM" src="https://github.com/user-attachments/assets/5325c7f7-cccb-44dd-965c-1412e1e63e92">

