### PR TITLE
[chore] Update comments with old `document/onHover` API

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -519,7 +519,7 @@ supported by the language server."
   :group 'lsp-mode)
 
 (defcustom lsp-eldoc-render-all nil
-  "Display all of the info returned by document/onHover.
+  "Display all of the info returned by textDocument/hover.
 If this is set to nil, `eldoc' will show only the symbol information."
   :type 'boolean
   :group 'lsp-mode)
@@ -5580,7 +5580,7 @@ When language is nil render as markup if `markdown-mode' is loaded."
   (car (s-lines (s-trim (lsp--render-element contents)))))
 
 (defun lsp--render-on-hover-content (contents render-all)
-  "Render the content received from `document/onHover' request.
+  "Render the content received from `textDocument/hover' request.
 CONTENTS  - MarkedString | MarkedString[] | MarkupContent
 RENDER-ALL - nil if only the signature should be rendered."
   (cond


### PR DESCRIPTION
Why?:
- In the current form of the LSP specification `document/onHover` is replaced by `textDocument/hover`.

This change addresses the need by:
- Replace `document/onHover` with `textDocument/hover`