### PR TITLE
[feat] Handling `nimlangserver` `extension/statusUpdate`

### DIFF
--- a/clients/lsp-nim.el
+++ b/clients/lsp-nim.el
@@ -95,6 +95,8 @@
                                    (lambda () lsp-nim-langserver))
                   :synchronize-sections '("nim")
                   :activation-fn (lsp-activate-on "nim")
+                  :notification-handlers
+                  (ht ("extension/statusUpdate" #'ignore))
                   :server-id 'nimlangserver))
 
 (lsp-consistency-check lsp-nim)


### PR DESCRIPTION
Why?:
- Since version 1.6.0 `nimlangserver` periodically sends an `extension/statusUpdate` notification which triggers a warning by `lsp-mode`. Because of the notification being sent quite frequently it prevents the user from actually being able to work on a Nim file. So, at the moment we should just ignore the notification which can still be inspected when setting `lsp-log-io` to `t`.

This change addresses the need by:
- Add notification handler #'ignore to `lsp-nim.el` for `extension/statusUpdate`