### PR TITLE
lsp-ansible: use new ansible mode name

### DIFF
--- a/clients/lsp-ansible.el
+++ b/clients/lsp-ansible.el
@@ -212,8 +212,7 @@ Python virtual environment."
 This prevents the Ansible server from being turned on in all yaml files."
   (and (or (derived-mode-p 'yaml-mode)
            (derived-mode-p 'yaml-ts-mode))
-       ;; emacs-ansible provides ansible, not ansible-mode
-       (with-no-warnings (bound-and-true-p ansible))))
+       (bound-and-true-p ansible-mode)))
 
 (declare-function lsp-completion--clear-cache "lsp-completion" (&optional keep-last-result))
 


### PR DESCRIPTION
[Emacs-ansible](https://gitlab.com/emacs-ansible/emacs-ansible) package was taken over by a new maintainer a few months ago. The mode name changed from `ansible` to a more standard `ansible-mode`. The old name is now marked as obsolete.

This PR reflects those changes.