### PR TITLE
    issue 4386: lsp-completion-at-point short-circuits the completion…

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -806,7 +806,9 @@ The return is nil or in range of (0, inf)."
         (after-completion-fn (lambda (result)
                                (when (stringp result)
                                  (lsp-completion--clear-cache))
-                               (setq-local lsp-inhibit-lsp-hooks nil))))
+                               (setq-local lsp-inhibit-lsp-hooks nil)))
+        (lsp-capf-in-capfs-p
+         (memq #'lsp-completion-at-point completion-at-point-functions)))
     (cond
      (lsp-completion-mode
       (make-local-variable 'completion-at-point-functions)
@@ -842,7 +844,8 @@ The return is nil or in range of (0, inf)."
                   t))
       (add-hook 'lsp-unconfigure-hook #'lsp-completion--disable nil t))
      (t
-      (remove-hook 'completion-at-point-functions #'lsp-completion-at-point t)
+      (unless lsp-capf-in-capfs-p
+        (remove-hook 'completion-at-point-functions #'lsp-completion-at-point t))
       (setq-local completion-category-defaults
                   (cl-remove 'lsp-capf completion-category-defaults :key #'cl-first))
       (setq-local completion-styles-alist


### PR DESCRIPTION
… function chain

    lsp-completion-mode will make a buffer-local version of the `completion-at-point-functions' list and will add `lsp-completion-at-point' to the head of the list if that symbol is not already present.

    However, an `lsp-unconfigure-hook' is called which results in removal of `lsp-completion-at-point' from the buffer-local version. The next time `lsp-completion-mode' runs, `lsp-completion-at-point' is added to the head of the `completion-at-points-functions'.

    To fix, a flag variable is set whose use prevents `lsp-completion-at-point' from removed from `completion-at-point-functions' if it was present at the start.