### PR TITLE
lsp-inline-completion: cleanup autoload to make it loads correctly

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -45,6 +45,7 @@
 (define-obsolete-variable-alias 'lsp-enable-completion-at-point
   'lsp-completion-enable "lsp-mode 7.0.1")
 
+;;;###autoload
 (defcustom lsp-completion-enable t
   "Enable `completion-at-point' integration."
   :type 'boolean

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -529,14 +529,6 @@ If this is set to nil, `eldoc' will show only the symbol information."
   :type 'boolean
   :group 'lsp-mode)
 
-(define-obsolete-variable-alias 'lsp-enable-completion-at-point
-  'lsp-completion-enable "lsp-mode 7.0.1")
-
-(defcustom lsp-completion-enable t
-  "Enable `completion-at-point' integration."
-  :type 'boolean
-  :group 'lsp-completion)
-
 (defcustom lsp-enable-symbol-highlighting t
   "Highlight references of the symbol at point."
   :type 'boolean
@@ -1407,6 +1399,33 @@ Symlinks are not followed."
   (unless (lsp-f-same? path-a path-b)
     (s-prefix? (concat (lsp-f-canonical path-a) (f-path-separator))
                (lsp-f-canonical path-b))))
+
+;; compat
+(if (version< emacs-version "29.1")
+    ;; Undo macro probably introduced in 29.1
+    (defmacro lsp-with-undo-amalgamate (&rest body)
+      "Like `progn' but perform BODY with amalgamated undo barriers.
+
+This allows multiple operations to be undone in a single step.
+When undo is disabled this behaves like `progn'."
+      (declare (indent 0) (debug t))
+      (let ((handle (make-symbol "--change-group-handle--")))
+        `(let ((,handle (prepare-change-group))
+               ;; Don't truncate any undo data in the middle of this,
+               ;; otherwise Emacs might truncate part of the resulting
+               ;; undo step: we want to mimic the behavior we'd get if the
+               ;; undo-boundaries were never added in the first place.
+               (undo-outer-limit nil)
+               (undo-limit most-positive-fixnum)
+               (undo-strong-limit most-positive-fixnum))
+           (unwind-protect
+               (progn
+                 (activate-change-group ,handle)
+                 ,@body)
+             (progn
+               (accept-change-group ,handle)
+               (undo-amalgamate-change-group ,handle))))))
+  (defalias 'lsp-with-undo-amalgamate 'with-undo-amalgamate))
 
 (defun lsp--merge-results (results method)
   "Merge RESULTS by filtering the empty hash-tables and merging


### PR DESCRIPTION
Make `lsp-inline-completion-enable` be autoloaded so it will be evaluated correctly in the `add-hook` autoload.
Also, do a few other cleanups:
- Add `lsp-completion-enable` as autoload and remove its definition from `lsp-mode.el`
- Remove autoload from `lsp-inline-completion-active-map` and `lsp-inline-completion-overlay-face`. They can be loaded with require `lsp-inline-completion`
- Move `lsp-inline-completion--with-undo-amalgamate` to `lsp-with-undo-amalgamate`.