### PR TITLE
Declare labelDetailsSupport client capability

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3801,7 +3801,8 @@ disappearing, unset all the variables related to it."
                                                                            "command"
                                                                            "insertTextFormat"
                                                                            "insertTextMode"])))
-                                                        (insertTextModeSupport . ((valueSet . [1 2])))))
+                                                        (insertTextModeSupport . ((valueSet . [1 2])))
+                                                        (labelDetailsSupport . t)))
                                      (contextSupport . t)
                                      (dynamicRegistration . t)))
                       (signatureHelp . ((signatureInformation . ((parameterInformation . ((labelOffsetSupport . t)))))

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -627,7 +627,7 @@ See `-let' for a description of the destructuring mechanism."
  (CompletionCapabilities nil (:completionItem :completionItemKind :contextSupport :dynamicRegistration))
  (CompletionContext (:triggerKind) (:triggerCharacter))
  (CompletionItem (:label) (:additionalTextEdits :command :commitCharacters :data :deprecated :detail :documentation :filterText :insertText :insertTextFormat :insertTextMode :kind :preselect :sortText :tags :textEdit :score :labelDetails))
- (CompletionItemCapabilities nil (:commitCharactersSupport :deprecatedSupport :documentationFormat :preselectSupport :snippetSupport :tagSupport :insertReplaceSupport :resolveSupport))
+ (CompletionItemCapabilities nil (:commitCharactersSupport :deprecatedSupport :documentationFormat :preselectSupport :snippetSupport :tagSupport :insertReplaceSupport :resolveSupport :labelDetailsSupport))
  (CompletionItemKindCapabilities nil (:valueSet))
  (CompletionItemTagSupportCapabilities (:valueSet) nil)
  (CompletionOptions nil (:resolveProvider :triggerCharacters :allCommitCharacters))


### PR DESCRIPTION
While #3495 claimed `labelDetails` was implemented, it really wasn't because the client capability was never declared, so AFAICT, servers do not send them down.

Servers tested against:

- pyright (server does not support `labelDetails`)
- typescript-language-server (server does not support `labelDetails`)
- gopls (server does not support `labelDetails`)
- jdtls (server supports `labelDetails` fully, spec compliant)
- clangd (server supports `labelDetails`, but the `CompletionItemLabelDetails#description` property is never filled in, so it's a noop as far as lsp-mode is concerned, but still spec compliant)
- rust-analyzer (server supports `labelDetails`, but the signature is in `CompletionItemLabelDetails#description`, not spec compliant)

P.S. For jdtls, the annotation function will return a really long partly qualified method signature for `CompletionItem#detail`, concatenated to the return type, which is the `CompletionItemLabelDetails#description`. To avoid this verbosity and duplication of information, the users are advised to do this:

```elisp
;; or java-ts-mode for emacs 29
(add-hook 'java-mode (lambda () (setq-local lsp-completion-show-detail nil)))
```

P.P.S rust-analyzer's implementation for `labelDetails` has always been wrong in all channels as of 2024-12-17, but wrong in a way that incidentally can alleviate #4591. If and when the R-A team decides to collectively sit down, study and implement the spec properly, we can see if there's any adjustment we need to do, but otherwise I assume the user can do their own adjustments similar to jdtls.
