### PR TITLE
[feat]: Add new client for V language support

### DIFF
--- a/clients/lsp-v.el
+++ b/clients/lsp-v.el
@@ -1,7 +1,9 @@
 ;;; lsp-v.el --- lsp-mode V integration -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2024 niontrix
 ;; Copyright (C) 2021 remimimimi
 
+;; Author: niontrix
 ;; Author: remimimimi
 ;; Keywords: languages,tools
 
@@ -20,29 +22,67 @@
 
 ;;; Commentary:
 
-;;  client for vls, the V language server
+;;  Basic configuration for V LSP support
 
 ;;; Code:
 
 (require 'lsp-mode)
 
 (defgroup lsp-v nil
-  "LSP support for V via vls."
+  "LSP support for V via vls. NOTICE!: `vls' is deprecated"
   :group 'lsp-mode
   :link '(url-link "https://github.com/vlang/vls/tree/master"))
 
+(defgroup lsp-v-analyzer nil
+  "LSP support for V, using v-analyzer."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/vlang/v-analyzer"))
+
 (defcustom lsp-v-vls-executable "vls"
-  "The vls executable to use.
+  "NOTICE!: vls is deprecated you should use `v-analyzer' instead.
+The vls executable to use.
 Leave as just the executable name to use the default behavior of
-finding the executable with variable `exec-path'."
+finding the executable with variable `exec-path'. "
   :group 'lsp-v
-  :type 'string)
+  :type 'string
+  :package-version '(lsp-mode . "8.0.0"))
+
+(defcustom lsp-v-analyzer-path "v-analyzer"
+  "Path to `v-analyzer'
+Leave as just the executable name to use the default behavior of
+finding the executable with variable `exec-path'. "
+  :type 'number
+  :group 'lsp-nim
+  :package-version '(lsp-mode . "9.0.0"))
 
 (lsp-register-client
- (make-lsp-client
-  :new-connection (lsp-stdio-connection (lambda () lsp-v-vls-executable))
-  :activation-fn (lsp-activate-on "V")
-  :server-id 'v-ls))
+ (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-v-vls-executable))
+                  :activation-fn (lsp-activate-on "V")
+                  :priority -1
+                  :server-id 'v-ls))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   (lambda () lsp-v-analyzer-path))
+                  :activation-fn (lsp-activate-on "v")
+                  :notification-handlers
+                  (ht ("experimental/serverStatus" #'ignore))
+                  :language-id "v"
+                  :priority 1
+                  :server-id 'v-analyzer))
+
+(defun lsp-v-analyzer-init ()
+  "Runs the `v-analyzer init' command in the root folder of the current project.
+After this `v-analyzer' can be further configured through the file
+`.v-analyzer/config.toml'."
+  (interactive)
+  (let* ((project-root (lsp--suggest-project-root))
+         (default-directory project-root)
+         (v-analyzer-config ".v-analyzer/config.toml"))
+    (when (and project-root
+               (not (file-exists-p v-analyzer-config)))
+      (message
+       (shell-command-to-string (concat lsp-v-analyzer-path " init"))))))
 
 (lsp-consistency-check lsp-v)
 

--- a/clients/lsp-v.el
+++ b/clients/lsp-v.el
@@ -1,10 +1,10 @@
 ;;; lsp-v.el --- lsp-mode V integration -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024 niontrix
 ;; Copyright (C) 2021 remimimimi
+;; Copyright (C) 2024 niontrix
 
-;; Author: niontrix
 ;; Author: remimimimi
+;;         niontrix
 ;; Keywords: languages,tools
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Why?:
`vls` is deprecated as an LSP server for V. Instead `v-analyzer` is the new and actively developed LSP server.

This change addresses the need by:
- Add LSP client registration and customization options for `v-analyzer`
- Add functionality to initialize configuration for `v-analyzer` to work in a project