### PR TITLE
Rust-Analyzer fix resolve failure on for_ref value being null

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -184,7 +184,10 @@ See #2675"
   (let ((data (lsp:completion-item-data? item)))
     (when (lsp-member? data :import_for_trait_assoc_item)
       (unless (lsp-get data :import_for_trait_assoc_item)
-        (lsp-put data :import_for_trait_assoc_item :json-false)))))
+        (lsp-put data :import_for_trait_assoc_item :json-false)))
+    (when (lsp-member? data :for_ref)
+      (unless (lsp-get data :for_ref)
+         (lsp-put data :for_ref :json-false)))))
 
 (defun lsp-completion--resolve (item)
   "Resolve completion ITEM.


### PR DESCRIPTION
Client side fix for rust-lang/rust-analyzer#18767.

I found this patching function being already used for rust-analyzer in resolve request while reading the code. Seems to fix that issue as well.

If I need to add any tests for this, please tell me where and I can add those.