### PR TITLE
lsp-bash: only take into account buffer-local sh-shell

### DIFF
--- a/clients/lsp-bash.el
+++ b/clients/lsp-bash.el
@@ -74,7 +74,7 @@ See instructions at https://marketplace.visualstudio.com/items?itemName=mads-har
   "Check whether `sh-shell' is supported.
 
 This prevents the Bash server from being turned on for unsupported dialects, e.g. `zsh`."
-  (and (boundp 'sh-shell)
+  (and (local-variable-p 'sh-shell)
        (memq sh-shell lsp-bash-allowed-shells)))
 
 (lsp-register-client


### PR DESCRIPTION
Recent changes (https://github.com/emacs-lsp/lsp-mode/pull/4620) make `lsp-bash` eligible for all buffers if Emacs is launch from a bash shell. It's because `sh-shell` is a global variable and its value is set to the shell used to launch Emacs (and there is no more major-mode check in `lsp-bash-check-sh-shell`).

This can lead to choose the wrong server (depending on priorities). For example, if I open a typescript file, I can observe the following logs:
```
Command "semgrep lsp" is not present on the path.
Command "deno lsp" is not present on the path.
Command "typescript-language-server --stdio" is present on the path.
Command "bash-language-server start" is present on the path.
Found the following clients for /home/fred/Projets/test/test.ts: (server-id ts-ls, priority -2), (server-id bash-ls, priority -1)
The following clients were selected based on priority: (server-id bash-ls, priority -1)
```

To fix the problem, we can reintroduce major-mode check or only take into account buffer-local `sh-shell` (as proposed by this PR). Feel free to choose the solution you prefer.