### PR TITLE
fix: use a transient map to avoid overlay keymaps issues

### DIFF
--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -312,6 +312,7 @@ The functions receive the inserted text and the range that was updated by the co
 (defun lsp-inline-completion-cancel ()
   "Close the suggestion overlay."
   (interactive)
+  (message nil) ;; clear echo
   (let ((was-active (lsp-inline-completion--active-p)))
     (lsp-inline-completion--clear-overlay)
 
@@ -320,17 +321,13 @@ The functions receive the inserted text and the range that was updated by the co
       (run-hooks 'lsp-inline-completion-cancelled-hook))))
 
 
-(defun lsp-inline-completion-cancel-with-input (event &optional arg)
+(defun lsp-inline-completion-cancel-with-input (event)
   "Cancel the inline completion and executes whatever event was received."
-  (interactive (list last-input-event current-prefix-arg))
+  (interactive (list last-input-event))
 
   (lsp-inline-completion-cancel)
 
-  (let ((command (lookup-key (current-active-maps) (vector event)))
-        (current-prefix-arg arg))
-
-    (when (commandp command)
-      (call-interactively command))))
+  (setq unread-command-events (nconc unread-command-events (list event))))
 
 (defun lsp-inline-completion-next ()
   "Display the next inline completion."


### PR DESCRIPTION
When some other overlay is active at point with a keymap property, even when
its priority is lower than the inline completion overlay's, this foreign keymap
may take precedence over our inline completion keymap.

This happens, for example, when the inline completion is shown inside a pair
inserted by smartparens. For example, when the user types `[`, smartparens will insert the closing `]` pair and leave the cursor inside the pair -- `[|]`. The user then presses `<return>`.

The result is the buffer with the following state (cursor at `|`:

```
list = [
    |
]
```

When Smartparens inserts the closing pair, it creates an overlay from `[` to up `]`. This overlay has a
keymap property mapping `C-g` to a function that removes the overlay.

When an inline completion is shown (either on idle or by user request), the
keymap from smartparens overlay is active **despite the inline completion
overlay's higher priority**.

As a result, pressing `C-<return>` will likely display a message complaining
the key is not bound.

If the user presses `C-g` once, then they gain access to the inline completion
keymap.

This caused a weird bug in which a user gets a suggestion, but can't accept
it. Pressing C-g only once would not cancel the completion, but pressing it
again would indeed hide the completion overlay. Explicitly asking for a
suggestion at the same point would then display the completion overlay and the
keymap would work as expected, since the first `C-g` removed the smartparens
overlay.

This commit fixes the issue using `overriding-terminal-local-map`. This ensures that the inline completion
keymap is active when the overlay is shown (see
https://www.gnu.org/software/emacs/manual/html_node/elisp/Searching-Keymaps.html).

Since the inline completion keymap binds `[t]` to a "hide and execute whatever
command was bound before", we end up with the expected behavior of the
overlay keymap.