### PR TITLE
Return nil from passthrough-try-completion when table is nil

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -850,9 +850,10 @@ The return is nil or in range of (0, inf)."
   "Disable LSP completion support."
   (lsp-completion-mode -1))
 
-(defun lsp-completion-passthrough-try-completion (string _table _pred point)
+(defun lsp-completion-passthrough-try-completion (string table _pred point)
   "Passthrough try function, always return the passed STRING and POINT."
-  (cons string point))
+  (when table
+    (cons string point)))
 
 (defun lsp-completion-passthrough-all-completions (_string table pred _point)
   "Passthrough all completions from TABLE with PRED."


### PR DESCRIPTION
Since #4602 the passthrough-try-completion function returns a cons cell even the list of completions is empty, so completion-in-region-functions that rely on the old behavior to call the exit function with an empty string `candidate` and nil `candidates`, which will make the exit func throw. This PR fixes this issue.