### PR TITLE
Fix type and group of lsp-v-analyzer-path

### DIFF
--- a/clients/lsp-v.el
+++ b/clients/lsp-v.el
@@ -51,8 +51,8 @@ finding the executable with variable `exec-path'. "
   "Path to `v-analyzer'
 Leave as just the executable name to use the default behavior of
 finding the executable with variable `exec-path'. "
-  :type 'number
-  :group 'lsp-nim
+  :type 'string
+  :group 'lsp-v
   :package-version '(lsp-mode . "9.0.0"))
 
 (lsp-register-client


### PR DESCRIPTION
Custom setting lsp-v-analyzer-path has the wrong type and the wrong group.