### PR TITLE
lsp-graphql: fix regexp for ext check

### DIFF
--- a/clients/lsp-graphql.el
+++ b/clients/lsp-graphql.el
@@ -51,7 +51,7 @@
 (defun lsp-graphql-activate-p (filename &optional _)
   "Check if the GraphQL language server should be enabled based on FILENAME."
   (let ((target-extensions (mapconcat 'identity lsp-graphql-target-file-extensions "\\|")))
-    (or (string-match-p (format "\\.%s\\'" target-extensions) filename)
+    (or (string-match-p (format "\\.\\(?:%s\\)\\'" target-extensions) filename)
         (and (derived-mode-p 'js-mode 'js2-mode 'typescript-mode 'typescript-ts-mode)
              (not (derived-mode-p 'json-mode))))))
 


### PR DESCRIPTION
## About

`lsp-graphql` should be enabled when matching specified file extensions, but it gets activated when the file path contains strings like "graphql"

### Ex.

Currently, `lsp-graphql` is enabled for the following filename:  
- `/path/to/graphql/test.go`

