### PR TITLE
Add support for swift-ts-mode

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -902,6 +902,7 @@ Changes take effect only when a new session is started."
     (tuareg-mode . "ocaml")
     (futhark-mode . "futhark")
     (swift-mode . "swift")
+    (swift-ts-mode . "swift")
     (elixir-mode . "elixir")
     (elixir-ts-mode . "elixir")
     (heex-ts-mode . "elixir")


### PR DESCRIPTION
[lsp-sourcekit.el already supports swift-ts-mode](https://github.com/emacs-lsp/lsp-sourcekit/blob/master/lsp-sourcekit.el#L84), but as base lsp-mode does not and lsp-sourcekit.el doesn't add it to the list itself lsp-mode does work properly