### PR TITLE
lsp-rust: honour :environment for runnables

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -29,6 +29,7 @@
   * Add ~lsp-bash-allowed-shells~ to configure supported ~sh-shell~ values.
   * Add hint about ~activation-fn~ for unsupported buffers.
   * Add Roc support
+  * Add support for environment variables in rust analyzer runnables. Allowing the new ~Update Tests (Expect)~ code lens to work as expected.
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -449,7 +449,7 @@ See `-let' for a description of the destructuring mechanism."
                (rust-analyzer:MoveItemParams (:textDocument :range :direction) nil)
                (rust-analyzer:RunnablesParams (:textDocument) (:position))
                (rust-analyzer:Runnable (:label :kind :args) (:location))
-               (rust-analyzer:RunnableArgs (:cargoArgs :executableArgs) (:workspaceRoot :expectTest))
+               (rust-analyzer:RunnableArgs (:cargoArgs :executableArgs) (:workspaceRoot :expectTest :environment))
                (rust-analyzer:RelatedTestsParams (:textDocument :position) nil)
                (rust-analyzer:RelatedTests (:runnable) nil)
                (rust-analyzer:SsrParams (:query :parseOnly) nil)


### PR DESCRIPTION
This means the new `Update Tests (Expect)` can work as intended.