### PR TITLE
disable Copilot by default

### DIFF
--- a/clients/lsp-copilot.el
+++ b/clients/lsp-copilot.el
@@ -38,7 +38,7 @@
   :tag "Copilot LSP"
   :link '(url-link "https://www.npmjs.com/package/copilot-node-server"))
 
-(defcustom lsp-copilot-enabled t
+(defcustom lsp-copilot-enabled nil
   "Whether the server should be started to provide completions."
   :type 'boolean
   :group 'lsp-copilot)


### PR DESCRIPTION
I feel strongly Copilot should be disabled by default. AI assistants are in a different category than the traditional purpose of IDE editors. Thanks

Related:
https://github.com/emacs-lsp/lsp-mode/issues/4679