### PR TITLE
[beancount] Fix lsp-beancount-journal-file

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 9.0.1
+  * Fix beancount journal file init option
   * Add support for [[https://github.com/glehmann/earthlyls][earthlyls]]
   * Add support for GNAT Project (~gpr-mode~, ~gpr-ts-mode~).
   * Add SQL support

--- a/clients/lsp-beancount.el
+++ b/clients/lsp-beancount.el
@@ -52,7 +52,7 @@ Use nil (the default) to use the current beancount buffer as the journal file."
   :new-connection
   (lsp-stdio-connection
    (lambda ()
-      `(,lsp-beancount-langserver-executable "--stdio")))
+     `(,lsp-beancount-langserver-executable "--stdio")))
   :major-modes '(beancount-mode)
   :initialization-options
   `((journalFile . ,lsp-beancount-journal-file))

--- a/clients/lsp-beancount.el
+++ b/clients/lsp-beancount.el
@@ -55,7 +55,7 @@ Use nil (the default) to use the current beancount buffer as the journal file."
      `(,lsp-beancount-langserver-executable "--stdio")))
   :major-modes '(beancount-mode)
   :initialization-options
-  `((journalFile . ,lsp-beancount-journal-file))
+  `((journal_file . ,lsp-beancount-journal-file))
   :server-id 'beancount-ls))
 
 (lsp-consistency-check lsp-beancount)


### PR DESCRIPTION
This has been broken for a while.

```emacs-lisp
(setq lsp-beancount-journal-file (expand-file-name "~/accounting/journal.beancount"))
```