### PR TITLE
Add lsp-elixir missing options and update to latest version

### DIFF
--- a/clients/lsp-elixir.el
+++ b/clients/lsp-elixir.el
@@ -27,11 +27,23 @@
 (require 'lsp-mode)
 (require 'ht)
 
+(defcustom lsp-elixir-auto-build t
+  "Trigger ElixirLS build when code is saved."
+  :type 'boolean
+  :group 'lsp-elixir
+  :package-version '(lsp-mode . "9.0.0"))
+
 (defcustom lsp-elixir-dialyzer-enabled t
   "Run ElixirLS's rapid Dialyzer when code is saved."
   :type 'boolean
   :group 'lsp-elixir
   :package-version '(lsp-mode . "8.0.0"))
+
+(defcustom lsp-elixir-incremental-dialyzer nil
+  "Use OTP incremental dialyzer."
+  :type 'boolean
+  :group 'lsp-elixir
+  :package-version '(lsp-mode . "9.0.0"))
 
 (defcustom lsp-elixir-dialyzer-warn-opts '()
   "Dialyzer options to enable or disable warnings.
@@ -81,6 +93,12 @@ This requires Dialyzer."
   :group 'lsp-elixir
   :package-version '(lsp-mode . "8.0.0"))
 
+(defcustom lsp-elixir-auto-insert-required-alias t
+  "Enable auto-insert required alias."
+  :type 'boolean
+  :group 'lsp-elixir
+  :package-version '(lsp-mode . "9.0.0"))
+
 (defcustom lsp-elixir-signature-after-complete t
   "Show signature help after confirming autocomplete."
   :type 'boolean
@@ -120,7 +138,6 @@ be available here: https://github.com/elixir-lsp/elixir-ls/releases/"
   :type 'string
   :group 'lsp-elixir
   :package-version '(lsp-mode . "9.0.0"))
-
 
 (defconst lsp-elixir-ls-server-dir
   (f-join lsp-server-install-dir "elixir-ls")
@@ -170,7 +187,9 @@ be available here: https://github.com/elixir-lsp/elixir-ls/releases/"
              :set-executable? t))
 
 (lsp-register-custom-settings
- '(("elixirLS.dialyzerEnabled" lsp-elixir-dialyzer-enabled t)
+ '(("elixirLS.autoBuild" lsp-elixir-auto-build t)
+   ("elixirLS.dialyzerEnabled" lsp-elixir-dialyzer-enabled t)
+   ("elixirLS.incrementalDialyzer" lsp-elixir-incremental-dialyzer)
    ("elixirLS.dialyzerWarnOpts" lsp-elixir-dialyzer-warn-opts)
    ("elixirLS.dialyzerFormat" lsp-elixir-dialyzer-format)
    ("elixirLS.mixEnv" lsp-elixir-mix-env)
@@ -178,6 +197,7 @@ be available here: https://github.com/elixir-lsp/elixir-ls/releases/"
    ("elixirLS.projectDir" lsp-elixir-project-dir)
    ("elixirLS.fetchDeps" lsp-elixir-fetch-deps t)
    ("elixirLS.suggestSpecs" lsp-elixir-suggest-specs t)
+   ("elixirLS.autoInsertRequiredAlias" lsp-elixir-auto-insert-required-alias t)
    ("elixirLS.signatureAfterComplete" lsp-elixir-signature-after-complete t)
    ("elixirLS.enableTestLenses" lsp-elixir-enable-test-lenses t)))
 

--- a/clients/lsp-elixir.el
+++ b/clients/lsp-elixir.el
@@ -195,7 +195,7 @@ be available here: https://github.com/elixir-lsp/elixir-ls/releases/"
    ("elixirLS.mixEnv" lsp-elixir-mix-env)
    ("elixirLS.mixTarget" lsp-elixir-mix-target)
    ("elixirLS.projectDir" lsp-elixir-project-dir)
-   ("elixirLS.fetchDeps" lsp-elixir-fetch-deps t)
+   ("elixirLS.fetchDeps" lsp-elixir-fetch-deps)
    ("elixirLS.suggestSpecs" lsp-elixir-suggest-specs t)
    ("elixirLS.autoInsertRequiredAlias" lsp-elixir-auto-insert-required-alias t)
    ("elixirLS.signatureAfterComplete" lsp-elixir-signature-after-complete t)

--- a/clients/lsp-elixir.el
+++ b/clients/lsp-elixir.el
@@ -123,7 +123,7 @@ Leave as default to let `executable-find' search for it."
   :type '(repeat string)
   :package-version '(lsp-mode . "8.0.0"))
 
-(defcustom lsp-elixir-ls-version "v0.25.0"
+(defcustom lsp-elixir-ls-version "v0.26.4"
   "Elixir-Ls version to download.
 It has to be set before `lsp-elixir.el' is loaded and it has to
 be available here: https://github.com/elixir-lsp/elixir-ls/releases/"


### PR DESCRIPTION
This PR has the following commits: 

[Add missing options for lsp-elixir](https://github.com/emacs-lsp/lsp-mode/pull/4704/)
These options were added and can be pretty useful. Options list: https://github.com/elixir-lsp/elixir-ls?tab=readme-ov-file#elixirls-configuration-settings

[Update lsp-elixir-fetch-specs to reflect community preference](https://github.com/emacs-lsp/lsp-mode/pull/4704/)
Automatically fetching deps has/had some issues and this change reflects the server default and vscode preference

[Bump lsp-elixir version](https://github.com/emacs-lsp/lsp-mode/pull/4704/)
The latest lsp-elixir server version


I am not sure which version the variables should be, so just added 9.0.0 for now? 
