### PR TITLE
Add `~/.cargo/git` to `lsp-rust-analyzer-library-directories`

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -354,7 +354,7 @@ PARAMS progress report notification data."
   :package-version '(lsp-mode . "6.2"))
 
 (defcustom lsp-rust-analyzer-library-directories
-  '("~/.cargo/registry/src" "~/.rustup/toolchains")
+  '("~/.cargo/git" "~/.cargo/registry/src" "~/.rustup/toolchains")
   "List of directories which will be considered to be libraries."
   :risky t
   :type '(repeat string)


### PR DESCRIPTION
When [specifying-dependencies-from-git-repositories](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories), `~/.cargo/git` should be considered as `lsp-rust-analyzer-library-directories` too.