### PR TITLE
Encapsulate GLSL executable string, so it can be overridden

### DIFF
--- a/clients/lsp-glsl.el
+++ b/clients/lsp-glsl.el
@@ -40,7 +40,9 @@
 
 (lsp-register-client
  (make-lsp-client
-  :new-connection (lsp-stdio-connection lsp-glsl-executable)
+  :new-connection (lsp-stdio-connection
+                   (lambda ()
+                     lsp-glsl-executable))
   :activation-fn (lsp-activate-on "glsl")
   :priority -1
   :server-id 'glslls))


### PR DESCRIPTION
In the current solution, the correct value of `lsp-glsl-executable` have to be set before `lsp-glsl.el` is loaded. This is good in most cases, but I hate having to restart Emacs sessions for basic things like this. Encapsulating the variable in a lambda during connection creation helps with this, and the variable can be overridden while Emacs is running. No need to reload any files.


Why? On some machines, I might have issues with executables not in path etc. Instead of fiddling forever (like on Mac OS gah...), I can simply set the absolute path to the executable in such a setting as `lsp-glsl-executable`.