### PR TITLE
fix(graphql): use `npm i-peers` instead of `npm-install-peers`

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8395,7 +8395,7 @@ nil."
                                          (lsp-async-start-process callback
                                                                   error-callback
                                                                   (executable-find "npx")
-                                                                  "npm-install-peers")))))
+                                                                  "i-peers")))))
                                  error-callback
                                  npm-binary
                                  "-g"


### PR DESCRIPTION
When I run `npm-install-peers` in the `graphql-language-service-cli` directory,
oddly enough, the `graphql-language-service` disappears from `node_modules` as a result of dependency resolution.
As a result, the graphql language server does not work at all.
From the PR I linked to, it seems that the mechanism to run `npm-install-peers` was originally put in for graphql.
[Pull npm peerDependencies as required by elken · Pull Request #3511 · emacs-lsp/lsp-mode](https://github.com/emacs-lsp/lsp-mode/pull/3511)
Maybe if it was a previous version, it would rather not work without installing it.
Replaced with a working package.
I honestly don't know why `npm-install-peers` removes existing packages when dependency conflicts occur.
