### PR TITLE
Fix asm-lsp install command

### DIFF
--- a/clients/lsp-asm.el
+++ b/clients/lsp-asm.el
@@ -61,7 +61,7 @@ Will update if UPDATE? is t."
   (lsp-async-start-process
    callback
    error-callback
-   "cargo" "install" "--git" lsp-asm-home-url "--root" lsp-asm-store-path))
+   "cargo" "install" "--git" lsp-asm-home-url "--root" lsp-asm-store-path "asm-lsp"))
 
 (defun lsp-asm--executable ()
   "Return asm-lsp executable."


### PR DESCRIPTION
Install command was outdated. Last year, the project was restructured into several crates. We now need to specify that we want to install the `asm-lsp` crate, which this PR does.

Fixes #4617 
(more details in issue)