### PR TITLE
feat: Drop Emacs 27.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: purcell/setup-emacs@master
         with:
-          version: 27.1
+          version: 28.1
 
       - uses: conao3/setup-cask@master
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         emacs-version:
-          - 27.2
           - 28.2
           - 29.4
           - 30.1
@@ -33,9 +32,6 @@ jobs:
           - os: windows-latest
             emacs-version: snapshot
             experimental: true
-        exclude:
-          - os: macos-latest
-            emacs-version: 27.2
 
     steps:
     - uses: jcs090218/setup-emacs@master

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -33,6 +33,7 @@
   * Add support for environment variables in rust analyzer runnables. Allowing the new ~Update Tests (Expect)~ code lens to work as expected.
   * Add support for [[https://github.com/mathworks/MATLAB-language-server][MATLAB language server]] (requires [[https://github.com/MathWorks/Emacs-MATLAB-Mode][matlab-mode]]).
   * Add support for [[https://github.com/c3lang/c3c][c3 language]] (requires [[https://github.com/c3lang/c3-ts-mode][c3-ts-mode]] and [[https://github.com/pherrymason/c3-lsp][c3lsp]]).    
+  * Drop support for emacs 27.1 and 27.2
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/Eask
+++ b/Eask
@@ -29,7 +29,7 @@
  "lsp-semantic-tokens.el"
  "clients/*.el")
 
-(depends-on "emacs" "27.1")
+(depends-on "emacs" "28.1")
 (depends-on "dash")
 (depends-on "f")
 (depends-on "ht")

--- a/lsp-inline-completion.el
+++ b/lsp-inline-completion.el
@@ -1,10 +1,10 @@
 ;;; lsp-inline-completion.el --- LSP mode                              -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2020-2024 emacs-lsp maintainers
+;; Copyright (C) 2020-2025 emacs-lsp maintainers
 
 ;; Author: Rodrigo Kassick
 ;; Keywords: languages
-;; Package-Requires: ((emacs "27.1") (dash "2.18.0") (spinner "1.7.3"))
+;; Package-Requires: ((emacs "28.1") (dash "2.18.0") (spinner "1.7.3"))
 ;; Version: 9.0.1
 
 ;; URL: https://github.com/emacs-lsp/lsp-mode

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1,10 +1,10 @@
 ;;; lsp-mode.el --- LSP mode                              -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2020-2024 emacs-lsp maintainers
+;; Copyright (C) 2020-2025 emacs-lsp maintainers
 
 ;; Author: Vibhav Pant, Fangrui Song, Ivan Yonchovski
 ;; Keywords: languages
-;; Package-Requires: ((emacs "27.1") (dash "2.18.0") (f "0.20.0") (ht "2.3") (spinner "1.7.3") (markdown-mode "2.3") (lv "0") (eldoc "1.11"))
+;; Package-Requires: ((emacs "28.1") (dash "2.18.0") (f "0.20.0") (ht "2.3") (spinner "1.7.3") (markdown-mode "2.3") (lv "0") (eldoc "1.11"))
 ;; Version: 9.0.1
 
 ;; URL: https://github.com/emacs-lsp/lsp-mode

--- a/test/lsp-mock-server-test.el
+++ b/test/lsp-mock-server-test.el
@@ -1,9 +1,9 @@
 ;;; lsp-mock-server-test.el --- Unit test utilities -*- lexical-binding: t -*-
 
-;; Copyright (C) 2024-2024 emacs-lsp maintainers
+;; Copyright (C) 2024-2025 emacs-lsp maintainers
 
 ;; Author: Arseniy Zaostrovnykh
-;; Package-Requires: ((emacs "27.1"))
+;; Package-Requires: ((emacs "28.1"))
 ;; Version: 0.0.1
 ;; License: GPL-3.0-or-later
 

--- a/test/mock-lsp-server.el
+++ b/test/mock-lsp-server.el
@@ -1,9 +1,9 @@
 ;;; mock-lsp-server.el --- Mock LSP server                       -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2024 emacs-lsp maintainers
+;; Copyright (C) 2024-2025 emacs-lsp maintainers
 
 ;; Author: Arseniy Zaostrovnykh
-;; Package-Requires: ((emacs "27.1"))
+;; Package-Requires: ((emacs "28.1"))
 ;; Version: 0.1.0
 ;; License: GPL-3.0-or-later
 


### PR DESCRIPTION
`markdown-mode` has dropped support for Emacs 27.x; see https://github.com/jrblevin/markdown-mode/commit/708fe466f8bebf70605567e4b72dcd2548e253d0.