### PR TITLE
Add missing argument in call to cl-assert

### DIFF
--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -270,7 +270,7 @@ Otherwise, PROPERTY is let-bound to the field's value.
   (cl-check-type interface symbol)
   (let ((lsp-pcase-macroexpander
          (intern (format "lsp--pcase-macroexpander-%s" interface))))
-    (cl-assert (fboundp lsp-pcase-macroexpander) "not a known LSP interface: %s" interface)
+    (cl-assert (fboundp lsp-pcase-macroexpander) nil "not a known LSP interface: %s" interface)
     (apply lsp-pcase-macroexpander property-bindings)))
 
 (if lsp-use-plists


### PR DESCRIPTION
The current code says:

```
(cl-assert (fboundp lsp-pcase-macroexpander) "not a known LSP interface: %s" interface)
```

This is missing the SHOW-ARGS argument, so a failed assertion triggers a backtrace rather than an error message:

```
ELISP> (cl-assert nil "not a known LSP interface: %s" 'foo)
*** Eval error ***  Wrong type argument: stringp, foo
```
