### PR TITLE
OCaml: Add implIntf

### DIFF
--- a/docs/manual-language-docs/lsp-ocaml.md
+++ b/docs/manual-language-docs/lsp-ocaml.md
@@ -1,0 +1,13 @@
+---
+author: mattiasdrp
+template: comment.html
+root_file: docs/manual-language-docs/lsp-ocaml.md
+---
+
+## ocaml-lsp-server
+
+### Commands
+
+#### `lsp-ocaml-find-alternate-file`
+
+Find the interface corresponding to an implementation or the implementation corresponding to an interface.

--- a/lsp-protocol.el
+++ b/lsp-protocol.el
@@ -433,6 +433,8 @@ See `-let' for a description of the destructuring mechanism."
 (lsp-interface (csharp-ls:CSharpMetadata (:textDocument))
                (csharp-ls:CSharpMetadataResponse (:source :projectName :assemblyName :symbolName)))
 
+(lsp-interface (ocaml-lsp:SwitchImplIntfParams (:uri) nil))
+
 (lsp-interface (rls:Cmd (:args :binary :env :cwd) nil))
 
 (lsp-interface (rust-analyzer:AnalyzerStatusParams (:textDocument))


### PR DESCRIPTION
*This is the first of a series of PR I aim to do to improve the ocaml-lsp experience in lsp-mode*

This PR exposes `lsp-ocaml-find-alternate-file` that allows to find the file interface corresponding to an implementation or the implementation corresponding to an interface.

This function is quite simple for the moment since I first needed to make sure that the LSP requests were working as expected.

Following PRs will add more possibilities