### PR TITLE
hack: make lsp-completion super fast

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3431,11 +3431,11 @@ If NO-WAIT is non-nil send the request as notification."
                                :cancel-token :sync-request)
             (while (not (or resp-error resp-result))
               (if (functionp 'json-rpc-connection)
-                  (catch 'lsp-done (sit-for 0.01))
+                  (catch 'lsp-done (sit-for 0.001))
                 (catch 'lsp-done
                   (accept-process-output
                    nil
-                   (if expected-time (- expected-time send-time) 1))))
+                   0.001)))
               (setq send-time (float-time))
               (when (and expected-time (< expected-time send-time))
                 (error "Timeout while waiting for response.  Method: %s" method)))
@@ -3470,7 +3470,7 @@ Return same value as `lsp--while-no-input' and respecting `non-essential'."
               (while (not (or resp-error resp-result (input-pending-p)))
                 (catch 'lsp-done
                   (sit-for
-                   (if expected-time (- expected-time send-time) 1)))
+                   0.001))
                 (setq send-time (float-time))
                 (when (and expected-time (< expected-time send-time))
                   (error "Timeout while waiting for response.  Method: %s" method)))


### PR DESCRIPTION
- [ ] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)

- [x] I updated documentation if applicable (`docs` folder)

Hello,

I'm working on a rust project, which is need lsp-mode's lsp-completion to help me doing code completion:

I a rust crate: nerd_font_symbols, the code completion for `nerd_font_symbols::md` has many large candicates, then I found lsp-mode.el lsp-completion need 2 seconds to show the completion.

And I tried zed-editor, and vscode, they are very fast, they only need 0.2 s to show the completion.

Then I tried to profile lsp-mode.el and I found the cpu profiler on sit-for:

```bash
        1402  88%  - catch
        1402  88%   - sit-for
        1402  88%    - apply
        1402  88%     - time-function-advice
        1402  88%      - let
        1402  88%       - prog1
        1402  88%        - apply
        1400  88%         - #<interpreted-function E75>
        1400  88%          - if
        1400  88%           - let*
        1400  88%            - unwind-protect
        1400  88%             - progn
        1400  88%              - while
        1400  88%               - catch
        1400  88%                - sit-for
        1400  88%                 - apply
        1400  88%                  - time-function-advice
        1400  88%                   - let
        1400  88%                    - prog1
        1400  88%                     - apply
        1400  88%                      - #<native-comp-function sit-for>
          98   6%                       - redisplay_internal (C function)
          27   1%                        - eval
          13   0%                         - header--line-format-right-align
          13   0%                          - let*
           9   0%                           - progn
           8   0%                              string-pixel-width
           1   0%                            - lsp--send-request-async
           1   0%                             - let*
           1   0%                              - and
           1   0%                               - lsp--find-workspaces-for

```

I don't know why, when I do the hacks on this PR, the lsp-mode.el code-completion reduce from 2s to 0.2s:

```bash
         173  70% - redisplay_internal (C function)
         103  42%  - eval
          95  38%   - tab-line-format
          95  38%    - tab-line-tabs-window-buffers
          95  38%     - seq-remove
          95  38%      - seq-filter
          95  38%       - seq-map
          95  38%        - apply
          94  38%         - time-function-advice
          94  38%          - let
          94  38%           - prog1
          94  38%            - apply
          94  38%             - #<interpreted-function BC8>
          94  38%              - let*
          94  38%               - progn
          94  38%                - if
          94  38%                 - let*
          94  38%                  - unwind-protect
          94  38%                   - progn
          94  38%                    - while
          94  38%                     - if
          94  38%                      - catch
          94  38%                       - accept-process-output
          49  20%                        - #<interpreted-function DAA>
          49  20%                         - let
          45  18%                          - while
          45  18%                           - if
          45  18%                            - let*
          45  18%                             - if
          45  18%                              - progn
          45  18%                               - condition-case
          45  18%                                - let
          45  18%                                 - save-current-buffer
          45  18%                                  - unwind-protect
          45  18%                                   - progn
          19   7%                                      decode-coding-region
          16   6%                                    - setq
          16   6%                                     - cons
          16   6%                                        json-parse-buffer
          10   4%                                    - apply
          10   4%                                       insert

```

So I think this PR is very important, you can reproduce this by this rust code:

```rust
use nerd_font_symbols::md;
fn main(){

    // put the cursor after next line end, then trigger lsp completion to feel it.
    md::MD_
}

```

And I use this short function to record the lsp-completion's timecost:

```elisp
(defun time-function-advice (orig-fun &rest args)
  "Advice to measure and print the execution time of a function.
ORIG-FUN is the original function.
ARGS are the arguments to pass to the original function."
  (let ((start-time (current-time))
         (func-name (format "%s" (if (symbolp orig-fun) (symbol-name orig-fun) "anonymous" ))))
    (prog1
      (apply orig-fun args)
      (let ((elapsed (float-time (time-subtract (current-time) start-time))))
        (message "Function %s took %.6f seconds" func-name elapsed)))))

(defun add-timing-to-function (func-symbol)
  "Add timing advice to the function named by FUNC-SYMBOL."
  (interactive "aFunction to time: ")
  (advice-add func-symbol :around #'time-function-advice)
  (message "Timing added to %s" func-symbol))

(defun remove-timing-from-function (func-symbol)
  "Remove timing advice from the function named by FUNC-SYMBOL."
  (interactive "aFunction to remove timing from: ")
  (advice-remove func-symbol #'time-function-advice)
  (message "Timing removed from %s" func-symbol))


(add-timing-to-function #'lsp-request)
(add-timing-to-function #'lsp-request-while-no-input)

```

What do you think?
