### PR TITLE
update names from `copilot-node-server` to `copilot-language-server`

### DIFF
--- a/clients/lsp-copilot.el
+++ b/clients/lsp-copilot.el
@@ -22,7 +22,8 @@
 
 ;; Commentary:
 
-;; LSP client for the copilot node server -- https://www.npmjs.com/package/copilot-node-server
+;; LSP client for the Copilot Language Server:
+;; https://www.npmjs.com/package/@github/copilot-language-server
 
 ;; Package-Requires: (lsp-mode secrets s compile dash cl-lib request company)
 

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -119,9 +119,9 @@
   {
     "name": "copilot",
     "full-name": "Github Copilot",
-    "server-name": "copilot-node-server",
-    "server-url": "https://www.npmjs.com/package/copilot-node-server",
-    "installation-url": "https://www.npmjs.com/package/copilot-node-server",
+    "server-name": "copilot-language-server",
+    "server-url": "https://www.npmjs.com/package/@github/copilot-language-server",
+    "installation-url": "https://www.npmjs.com/package/@github/copilot-language-server",
     "debugger": "Not available"
   },
   {


### PR DESCRIPTION
`copilot-node-server` has already been replaced with `copilot-language-server`: https://github.com/emacs-lsp/lsp-mode/pull/4710