### PR TITLE
fix(lsp-bufls): Resolve timeout issues

### DIFF
--- a/clients/lsp-bufls.el
+++ b/clients/lsp-bufls.el
@@ -71,7 +71,7 @@
   :link '(url-lint "https://github.com/bufbuild/buf")
   :package-version '(lsp-mode . "9.0.0"))
 
-(defcustom lsp-buf-args `("beta" "lsp")
+(defcustom lsp-buf-args `("beta" "lsp" "--timeout" "0" "--log-format" "json")
   "Arguments to pass to buf CLI."
   :type '(repeat string)
   :group 'lsp-buf


### PR DESCRIPTION
## About

- Fix timeout issue
  - The buf LSP server shuts down after exceeding the default timeout of 2 minutes.
  - So set the timeout to 0 to disable it.
- Modify log-format for more readable
  - The default log-format set to `color`
  - The `*buf:stderr*` buffer is difficult to read.

## Ref. `buf beta lsp` help

```
❯ buf beta lsp --help
Start the language server

Usage:
  buf beta lsp [flags]

Flags:
  -h, --help          help for lsp
      --pipe string   path to a UNIX socket to listen on; uses stdio if not specified

Global Flags:
      --debug               Turn on debug logging
      --log-format string   The log format [text,color,json] (default "color")
      --timeout duration    The duration until timing out, setting it to zero means no timeout (default 2m0s)
```

## `*buf:stderr*` sample

### log-format: `color`

```
[33mWARN[0m	notify returned	{"method": "$/progress"}
[33mWARN[0m	notify returned	{"method": "$/progress"}
```

### log-format: `json`

```json
{"level":"warn","time":"2025-03-14T15:30:36.890+0900","message":"notify returned","method":"$/progress"}
{"level":"warn","time":"2025-03-14T15:30:36.890+0900","message":"notify returned","method":"$/progress"}
```