### PR TITLE
Add format on save option (issue #3944)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 9.0.1
+  * Add format on save support
   * Fix beancount journal file init option
   * Add support for [[https://github.com/glehmann/earthlyls][earthlyls]]
   * Add support for GNAT Project (~gpr-mode~, ~gpr-ts-mode~).

--- a/docs/page/main-features.md
+++ b/docs/page/main-features.md
@@ -92,6 +92,8 @@ the formatting is triggered when the corresponding character is
 pressed(typically, `}`, `RET`). This behaviour is controlled via
 `lsp-enable-on-type-formatting` and it is enabled by default.
 
+You can also trigger format on save by setting the variable `lsp-format-buffer-on-save` to a non-nil value. To select what major modes to format use `lsp-format-buffer-on-save-list`.
+
 ## Debugger
 
 `lsp-mode` integrates with [dap-mode](https://emacs-lsp.github.io/dap-mode/) with implements the DAP(Debugger Adapter Protocol), for more information check the [`dap-mode` documentation](https://emacs-lsp.github.io/dap-mode/).

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -575,6 +575,18 @@ before saving a document."
   :type 'boolean
   :group 'lsp-mode)
 
+(defcustom lsp-format-buffer-on-save nil
+  "If non-nil format buffer on save.
+To only format specific major-mode buffers see `lsp-format-buffer-on-save-list'."
+  :type 'boolean
+  :group 'lsp-mode)
+
+(defcustom lsp-format-buffer-on-save-list '()
+  "If the list is empty format all buffer on save. Else only format buffers
+if their major-mode is in the list."
+  :type '(repeat symbol)
+  :group 'lsp-mode)
+
 (defcustom lsp-after-apply-edits-hook nil
   "Hooks to run when text edit is applied.
 It contains the operation source."
@@ -5201,6 +5213,13 @@ if it's closing the last buffer in the workspace."
                'before-save)
             (error)))))))
 
+(defun lsp--format-buffer-before-save ()
+  (when lsp-format-buffer-on-save
+    (if (not lsp-format-buffer-on-save-list)
+        (lsp-format-buffer)
+      (when (member major-mode lsp-format-buffer-on-save-list)
+        (lsp-format-buffer)))))
+
 (defun lsp--on-auto-save ()
   "Handler for auto-save."
   (when (lsp--send-will-save-p)
@@ -9397,6 +9416,7 @@ Errors if there are none."
   (lsp--text-document-did-close t)
   (lsp-managed-mode -1)
   (lsp-mode -1)
+  (remove-hook 'before-save-hook #'lsp--format-buffer-before-save t)
   (setq lsp--buffer-workspaces nil)
   (lsp--info "Disconnected"))
 
@@ -9445,6 +9465,7 @@ argument ask the user to select which language server to start."
                         (lsp--try-project-root-workspaces (equal arg '(4))
                                                           (and arg (not (equal arg 1))))))
           (lsp-mode 1)
+          (add-hook 'before-save-hook #'lsp--format-buffer-before-save nil t)
           (when lsp-auto-configure (lsp--auto-configure))
           (setq lsp-buffer-uri (lsp--buffer-uri))
           (lsp--info "Connected to %s."


### PR DESCRIPTION
Add format on save (issue #3944) with two option:

- `lsp-format-buffer-on-save` to turn on / off
- `lsp-format-buffer-on-save-list` to specify what major modes to save (nil saves all buffer)
