### PR TITLE
lsp-update-inlay-hint only remove (start-end) range overlays

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6332,10 +6332,12 @@ execute a CODE-ACTION-KIND action."
     (2 . lsp-face-highlight-read)
     (3 . lsp-face-highlight-write)))
 
-(defun lsp--remove-overlays (name)
+(defun lsp--remove-overlays (name &optional beg end)
   (save-restriction
     (widen)
-    (remove-overlays (point-min) (point-max) name t)))
+    (remove-overlays (or beg (point-min))
+                     (or end (point-max))
+                     name t)))
 
 (defun lsp-document-highlight ()
   "Highlight all relevant references to the symbol under point."
@@ -9984,7 +9986,7 @@ string."
                            :end
                            (lsp-point-to-position end)))
    (lambda (res)
-     (lsp--remove-overlays 'lsp-inlay-hint)
+     (lsp--remove-overlays 'lsp-inlay-hint start end)
      (dolist (hint res)
        (-let* (((&InlayHint :label :position :kind? :padding-left? :padding-right?) hint)
                (kind (or kind? lsp/inlay-hint-kind-type-hint))


### PR DESCRIPTION
- [] I added a new entry to [CHANGELOG.md](https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md)

- [x] I updated documentation if applicable (`docs` folder)
