### PR TITLE
feat: `lsp-format-buffer-on-save` configurable via `.dir-locals.el`

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -579,6 +579,8 @@ before saving a document."
   "If non-nil format buffer on save.
 To only format specific major-mode buffers see `lsp-format-buffer-on-save-list'."
   :type 'boolean
+  :safe t
+  :local t
   :group 'lsp-mode)
 
 (defcustom lsp-format-buffer-on-save-list '()


### PR DESCRIPTION
Add `:safe t` and `:local t` properties to `lsp-format-buffer-on-save` to enable
project-specific configuration through `.dir-locals.el` without security prompts.

Thanks to PR #4753 for implementing the `format-on-save` functionality.
This enhancement allows keeping automatic formatting disabled by default
(avoiding unwanted diffs in third-party projects)
while enabling it for personal or team projects with established formatting standards.

The security implications are minimal
since LSP formatting capabilities are limited to code reformatting,
and any project where you're running an LSP server
already has significant execution privileges.
