### PR TITLE
fix(lsp-format-buffer-on-save): `:safe` syntax to correctly

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -579,7 +579,7 @@ before saving a document."
   "If non-nil format buffer on save.
 To only format specific major-mode buffers see `lsp-format-buffer-on-save-list'."
   :type 'boolean
-  :safe t
+  :safe #'booleanp
   :local t
   :group 'lsp-mode)
 


### PR DESCRIPTION
My
[feat: `lsp-format-buffer-on-save` configurable via `.dir-locals.el` by ncaq · Pull Request #4760 · emacs-lsp/lsp-mode](https://github.com/emacs-lsp/lsp-mode/pull/4760)
is invalid.
I fix to `:safe #'booleanp` syntax.
