### PR TITLE
Adds remove-unused-imports to lsp-mode.el

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -37,6 +37,7 @@
   * Drop support for emacs 27.1 and 27.2
   * Add ~lsp-nix-nixd-server-arguments~ to allow passing arguments to the ~nixd~ LSP.
   * Improve the lsp-ocaml client (see [[https://github.com/emacs-lsp/lsp-mode/issues/4731][#4731]] for the follow-up issue. MRs: [[https://github.com/emacs-lsp/lsp-mode/pull/4741][#4741]], [[https://github.com/emacs-lsp/lsp-mode/pull/4732][#4732]])
+  * Added support for ~source.organizeImports~
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6324,6 +6324,8 @@ execute a CODE-ACTION-KIND action."
 
 (lsp-make-interactive-code-action organize-imports "source.organizeImports")
 
+(lsp-make-interactive-code-action remove-unused-imports "source.removeUnusedImports")
+
 (defun lsp--make-document-range-formatting-params (start end)
   "Make DocumentRangeFormattingParams for selected region."
   (lsp:set-document-range-formatting-params-range (lsp--make-document-formatting-params)


### PR DESCRIPTION
Hi there,

great work on this project!

I was wondering, why organizing imports did not remove unused imports as tide-mode does and noticed, that `source.organizeImports` was not implemented.

I added one line to add support, it works on my machine. 

Cheers

Closes #4773


