### PR TITLE
lsp-python-py: make it add-on and activated on python

### DIFF
--- a/clients/lsp-python-ty.el
+++ b/clients/lsp-python-ty.el
@@ -38,10 +38,11 @@
   :type '(repeat string))
 
 (lsp-register-client
- (make-lsp-client :new-connection (lsp-stdio-connection lsp-python-ty-clients-server-command)
-                  :major-modes '(python-mode)
-                  :server-id 'lsp-python-ty))
-
+ (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-python-ty-clients-server-command))
+                  :activation-fn (lsp-activate-on "python")
+                  :priority -1
+                  :add-on? t
+                  :server-id 'ty-ls))
 
 (lsp-consistency-check lsp-python-ty)
 


### PR DESCRIPTION
Make `ty` an add-on as it supposed to be type checker.
Also make it activatable on python file, not only the major mode.