### PR TITLE
lsp-rust: fix definition of lsp-rust-analyzer-cargo-extra-env (#4768)

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -851,10 +851,10 @@ or JSON objects in `rust-project.json` format."
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "9.0.0"))
 
-(defcustom lsp-rust-analyzer-cargo-extra-env []
+(defcustom lsp-rust-analyzer-cargo-extra-env #s(hash-table)
   "Extra environment variables that will be set when running cargo, rustc or
 other commands within the workspace.  Useful for setting RUSTFLAGS."
-  :type 'lsp-string-vector
+  :type 'alist
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "9.0.0"))
 


### PR DESCRIPTION
In rust-analyzer, cargo.extraEnv has been a map since its introduction (rust-lang/rust-analyzer@c407cc5). The definition in lsp-mode hasn't matched since then, but the mismatch has been silently ignored. From rust-lang/rust-analyzer@46ce474, rust-analyzer started showing a warning message on configuration error which we are seeing.

With this change, the definition for cargo.extraEnv should match and the warning message is not displayed.