### PR TITLE
lsp-erlang: fix download URLs for erlang-language-platform

### DIFF
--- a/clients/lsp-erlang.el
+++ b/clients/lsp-erlang.el
@@ -267,18 +267,31 @@ Code Lenses. Only applies when `#elp.lens.enabled` and
   :group 'lsp-erlang-elp
   :package-version '(lsp-mode . "8.0.0"))
 
-(defcustom lsp-erlang-elp-download-url
-  (format "https://github.com/WhatsApp/erlang-language-platform/releases/latest/download/%s"
-          (pcase system-type
-            ('gnu/linux "elp-linux-x86_64-unknown-linux-gnu-otp-26.tar.gz")
-            ('darwin
-             (if (string-match "^aarch64-.*" system-configuration)
-                 "elp-macos-aarch64-apple-darwin-otp-25.3.tar.gz"
-               "elp-macos-x86_64-apple-darwin-otp-25.3.tar.gz"))))
-  "Automatic download url for erlang-language-platform."
-  :type 'string
+(defcustom lsp-erlang-elp-otp-download-version "27.1"
+  "OTP version used as part of the file name when downlading the ELP binary.
+It must match those used in https://github.com/WhatsApp/erlang-language-platform/releases/latest"
+  :type '(choice (string :tag "25.3")
+                 (string :tag "26.2")
+                 (string :tag "27.1"))
   :group 'lsp-erlang-elp
   :package-version '(lsp-mode . "8.0.0"))
+
+(defcustom lsp-erlang-elp-download-url
+  (format "https://github.com/WhatsApp/erlang-language-platform/releases/latest/download/elp-%s-otp-%s.tar.gz"
+          (pcase system-type
+            ('gnu/linux
+             (if (string-match "^aarch64-.*" system-configuration)
+                 "linux-aarch64-unknown-linux-gnu"
+               "linux-x86_64-unknown-linux-gnu"))
+             ('darwin
+              (if (string-match "^aarch64-.*" system-configuration)
+                  "macos-aarch64-apple-darwin"
+                "macos-x86_64-apple-darwin")))
+            lsp-erlang-elp-otp-download-version)
+          "Automatic download url for erlang-language-platform."
+          :type 'string
+          :group 'lsp-erlang-elp
+          :package-version '(lsp-mode . "8.0.0"))
 
 (defcustom lsp-erlang-elp-store-path (f-join lsp-server-install-dir
                                                 "erlang"


### PR DESCRIPTION
ELP provides downloads in a matrix by OTP version (25.3, 26.2, 27.1) and base os, linux x86_64 and arm, macos x86 and arm

Add a custom entry to choose the OTP version, and detect linux arm/x86 as already happening for macos.

Tested on linux x86, report issues on other architectures