### PR TITLE
Add support for markdown-ts-mode

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -973,6 +973,7 @@ Changes take effect only when a new session is started."
     (zig-ts-mode . "zig")
     (text-mode . "plaintext")
     (markdown-mode . "markdown")
+    (markdown-ts-mode . "markdown")
     (gfm-mode . "markdown")
     (beancount-mode . "beancount")
     (conf-toml-mode . "toml")


### PR DESCRIPTION
Like the issue #4793 mentions, there is a treesitter mode for Markdown now. Supporting it with our markdown lsps is quite easy by adding it to the language ids. All relevant servers activate on markdown language after all.

Fixes #4793 