### PR TITLE
Make lsp-headerline update breadcrumb when previewing with consult-xref

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -38,6 +38,7 @@
   * Add ~lsp-nix-nixd-server-arguments~ to allow passing arguments to the ~nixd~ LSP.
   * Improve the lsp-ocaml client (see [[https://github.com/emacs-lsp/lsp-mode/issues/4731][#4731]] for the follow-up issue. MRs: [[https://github.com/emacs-lsp/lsp-mode/pull/4741][#4741]], [[https://github.com/emacs-lsp/lsp-mode/pull/4732][#4732]])
   * Add support for ~source.removeUnusedImports~ for lsp-javascript
+  * Fix lsp-headerline to update breadcrumb when previewing with consult-xref.
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/lsp-headerline.el
+++ b/lsp-headerline.el
@@ -441,6 +441,7 @@ PATH is the current folder to be checked."
     (add-to-list 'header-line-format '(t (:eval (window-parameter nil 'lsp-headerline--string) )))
 
     (add-hook 'xref-after-jump-hook #'lsp-headerline--check-breadcrumb nil t)
+    (add-hook 'consult-after-jump-hook #'lsp-headerline--check-breadcrumb nil t)
 
     (add-hook 'lsp-on-idle-hook #'lsp-headerline--check-breadcrumb nil t)
     (add-hook 'lsp-configure-hook #'lsp-headerline--enable-breadcrumb nil t)
@@ -451,6 +452,7 @@ PATH is the current folder to be checked."
     (remove-hook 'lsp-unconfigure-hook #'lsp-headerline--disable-breadcrumb t)
 
     (remove-hook 'xref-after-jump-hook #'lsp-headerline--check-breadcrumb t)
+    (remove-hook 'consult-after-jump-hook #'lsp-headerline--check-breadcrumb t)
 
     (setq lsp-headerline--path-up-to-project-segments nil)
     (setq header-line-format (remove '(t (:eval (window-parameter nil 'lsp-headerline--string) )) header-line-format)))))


### PR DESCRIPTION
lsp-mode doesn't depend on 'consult being loaded, but it is safe in emacs to call add-hook before loading the package that provides the hook, and that is the simplest approach here. If 'consult is not installed or is never loaded, then the hook will simply never be used.

Fixes #4802

![after-fix](https://github.com/user-attachments/assets/fcfff3e3-51bd-427c-8d8a-8db0238bdd01)
