### PR TITLE
lsp-rust: adds support for cargo.buildScripts.overrideCommand

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1722,7 +1722,8 @@ https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/lsp-extensions.m
              :loadOutDirsFromCheck ,(lsp-json-bool lsp-rust-analyzer-cargo-run-build-scripts)
              :autoreload ,(lsp-json-bool lsp-rust-analyzer-cargo-auto-reload)
              :useRustcWrapperForBuildScripts ,(lsp-json-bool lsp-rust-analyzer-use-rustc-wrapper-for-build-scripts)
-             :unsetTest ,lsp-rust-analyzer-cargo-unset-test)
+             :unsetTest ,lsp-rust-analyzer-cargo-unset-test
+	     :buildScripts (:overrideCommand ,lsp-rust-analyzer-cargo-override-command))
     :rustfmt ( :extraArgs ,lsp-rust-analyzer-rustfmt-extra-args
                :overrideCommand ,lsp-rust-analyzer-rustfmt-override-command
                :rangeFormatting (:enable ,(lsp-json-bool lsp-rust-analyzer-rustfmt-rangeformatting-enable)))


### PR DESCRIPTION
This PR makes it so that lsp-rust-analyzer-cargo-override-command also applies to the [rust-analyzer.cargo.buildScripts.overrideCommand](https://rust-analyzer.github.io/book/configuration#cargo.buildScripts.overrideCommand) option.

This is important because cargo wrappers may apply different configuration that conflict with the normal build process, creating unnecessary rebuilds and sometimes making the LSP report false positives. This is the case for [servo](https://book.servo.org/hacking/editor-support.html), in which mach wraps cargo, making it necessary to override cargo commands.