### PR TITLE
lsp-system-path: return absolute path

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8362,7 +8362,7 @@ nil."
      ((and (f-absolute? path)
            (f-exists? path))
       path)
-     ((executable-find path t) path))))
+     ((executable-find path t)))))
 
 (defun lsp-package-path (dependency)
   "Path to the DEPENDENCY each of the registered providers."


### PR DESCRIPTION
Make sure to return the absolute path as documented