### PR TITLE
Revert "Fix #4782 ensure ty is mutually exclusive to other Python servers"

### DIFF
--- a/clients/lsp-python-ty.el
+++ b/clients/lsp-python-ty.el
@@ -41,6 +41,7 @@
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-python-ty-clients-server-command))
                   :activation-fn (lsp-activate-on "python")
                   :priority -1
+                  :add-on? t
                   :server-id 'ty-ls))
 
 (lsp-consistency-check lsp-python-ty)


### PR DESCRIPTION
Reverts emacs-lsp/lsp-mode#4811