### PR TITLE
feat: Add tombi LSP client for TOML

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -39,6 +39,7 @@
   * Improve the lsp-ocaml client (see [[https://github.com/emacs-lsp/lsp-mode/issues/4731][#4731]] for the follow-up issue. MRs: [[https://github.com/emacs-lsp/lsp-mode/pull/4741][#4741]], [[https://github.com/emacs-lsp/lsp-mode/pull/4732][#4732]])
   * Add support for ~source.removeUnusedImports~ for lsp-javascript
   * Add Python(ty) support
+  * Add support for [[https://github.com/tombi-toml/tombi][Tombi language server]] (TOML language).
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/clients/lsp-toml-tombi.el
+++ b/clients/lsp-toml-tombi.el
@@ -1,0 +1,56 @@
+;;; lsp-toml-tombi.el --- lsp-mode TOML integration  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Sibi Prabakaran
+
+;; Author: Sibi Prabakaran <sibi@psibi.in>
+;; Keywords: lsp, toml
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Client for tombi
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-tombi-toml nil
+  "LSP support for TOML, using Tombi."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/tombi-toml/tombi"))
+
+(defcustom lsp-tombi-toml-command "tombi"
+  "Path to tombi command."
+  :type 'string
+  :group 'lsp-tombi-toml
+  :package-version '(lsp-mode . "9.0.0"))
+
+(defun lsp-tombi-toml--check-enabled (_file-name _mode)
+  "Check if the tombi language server should be enabled in this buffer."
+  (when (string= (lsp-buffer-language) "toml")
+    t))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection (lambda () (list lsp-tombi-toml-command "lsp")))
+  :activation-fn #'lsp-tombi-toml--check-enabled
+  :multi-root t
+  :server-id 'tombi
+  :priority -2))
+
+(lsp-consistency-check lsp-tombi-toml)
+
+(provide 'lsp-toml-tombi)
+;;; lsp-toml-tombi.el ends here

--- a/docs/manual-language-docs/lsp-toml-tombi.md
+++ b/docs/manual-language-docs/lsp-toml-tombi.md
@@ -1,0 +1,17 @@
+---
+author: psibi
+template: comment.html
+root_file: docs/manual-language-docs/lsp-toml-tombi.md
+---
+
+## Server note
+
+This page documents the Tombi's language server for Toml.
+
+Note that currently lsp-mode supports two Toml language servers. This
+[FAQ entry](https://emacs-lsp.github.io/lsp-mode/page/faq/#i-have-multiple-language-servers-registered-for-language-foo-which-one-will-be-used-when-opening-a-project) shows how to choose a specific one. If you would want
+to go with the Tombi's server, set this:
+
+``` emacs-lisp
+(setq lsp-disabled-clients '(taplo))
+```

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -191,7 +191,7 @@ As defined by the Language Server Protocol 3.16."
      lsp-ruby-lsp lsp-ruby-syntax-tree lsp-ruff lsp-rust lsp-semgrep lsp-shader
      lsp-solargraph lsp-solidity lsp-sonarlint lsp-sorbet lsp-sourcekit
      lsp-sql lsp-sqls lsp-steep lsp-svelte lsp-tailwindcss lsp-terraform
-     lsp-tex lsp-tilt lsp-toml lsp-trunk lsp-ts-query lsp-ttcn3 lsp-typeprof
+     lsp-tex lsp-tilt lsp-toml lsp-toml-tombi lsp-trunk lsp-ts-query lsp-ttcn3 lsp-typeprof
      lsp-typespec lsp-v lsp-vala lsp-verilog lsp-vetur lsp-vhdl lsp-vimscript
      lsp-volar lsp-wgsl lsp-xml lsp-yaml lsp-yang lsp-zig)
   "List of the clients to be automatically required."

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -180,7 +180,8 @@ nav:
     - TeX, LaTeX, etc (texlab): page/lsp-texlab.md
     - TeX, LaTeX, etc (texlab, external): page/lsp-latex.md
     - Tilt: page/lsp-tilt.md
-    - TOML: page/lsp-toml.md
+    - TOML (Taplo): page/lsp-toml.md
+    - TOML (Tombi): page/lsp-toml-tombi.md
     - Tree-sitter Query: page/lsp-ts-query.md
     - Trunk: page/lsp-trunk.md
     - TTCN3: page/lsp-ttcn3.md


### PR DESCRIPTION
Adds support for the Tombi language server for TOML files. This introduces a new client definition, integrates it into the list of known clients, and provides documentation on how to use and select it.

*   Add `clients/lsp-toml-tombi.el` with client definition.
*   Add documentation page for the tombi client.
*   Register `lsp-toml-tombi` in `lsp-clients` variable.
*   Update mkdocs navigation to include the new doc page.
*   Clarify the existing TOML doc page as 'Taplo'.