### PR TITLE
docs: Add toml-tombi to TOML LSP clients

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -1231,6 +1231,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "toml-tombi",
+    "full-name": "TOML",
+    "server-name": "tombi",
+    "server-url": "https://github.com/tombi-toml/tombi",
+    "installation-url": "https://tombi-toml.github.io/tombi/docs/installation",
+    "debugger": "Not available"
+  },
+  {
     "name": "trunk",
     "full-name": "Trunk",
     "server-name": "trunk-lsp",


### PR DESCRIPTION
Adds a new entry for the 'tombi' TOML Language Server Protocol (LSP) server to the list of available TOML LSP clients. Hopefully this should fix the missing 404 page here:
https://emacs-lsp.github.io/lsp-mode/page/lsp-toml-tombi.md