### PR TITLE
fix: extract major version from custom golangci-lint

### DIFF
--- a/clients/lsp-golangci-lint.el
+++ b/clients/lsp-golangci-lint.el
@@ -147,7 +147,7 @@
   (with-temp-buffer
     (when (= 0 (call-process lsp-golangci-lint-path nil t nil "version"))
       (goto-char (point-min))
-      (when (re-search-forward "has version \\([0-9]+\\)\\." nil t)
+      (when (re-search-forward "has version v?\\([0-9]+\\)\\." nil t)
         (string-to-number (match-string 1))))))
 
 (defun lsp-golangci-lint--get-initialization-options ()


### PR DESCRIPTION
Allows the "v" prefix in the version string because a custom binary of golangci-lint built using the [module plugin system](https://golangci-lint.run/plugins/module-plugins/) has that prefix.

* original binary
`golangci-lint has version 2.1.6 built with go1.24.2 from eabc263 on 2025-05-04T15:36:41Z`

* custom binary
`golangci-lint has version v2.1.6-custom-gcl built with go1.24.3 from ? on 2025-05-18 10:07:06.838917 +0000 UTC`