### PR TITLE
feat: added odin language support through ols

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -41,6 +41,7 @@
   * Add Python(ty) support
   * Add support for [[https://github.com/tombi-toml/tombi][Tombi language server]] (TOML language).
   * Make lsp-headerline--check-breadcrumb public
+  * Added Odin langauge server support [[https://github.com/DanielGavin/ols][ols]]
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/clients/lsp-odin.el
+++ b/clients/lsp-odin.el
@@ -48,9 +48,7 @@
                 ((and (eq system-type 'gnu/linux)
                       (or (eq (string-match "^x86_64" system-configuration) 0)
                           (eq (string-match "^i[3-6]86" system-configuration) 0)))
-                 "ols-x86_64-unknown-linux-gnu.zip")
-
-                (t "omnisharp-mono.zip")))
+                 "ols-x86_64-unknown-linux-gnu.zip")))
   "Automatic download url for ols language server."
   :group 'lsp-odin-ols
   :type 'string)

--- a/clients/lsp-odin.el
+++ b/clients/lsp-odin.el
@@ -45,14 +45,13 @@
                 "ols-arm64-darwin.zip"
               "ols-x86_64-darwin.zip"))
            (_
-            "ols-x86_64-unknown-linux-gnu")))
-        (when suffix
-          (f-join "https://github.com/DanielGavin/ols/releases/download/nightly/"
-                  suffix))))
+            "ols-x86_64-unknown-linux-gnu"))))
+    (when suffix
+      (f-join "https://github.com/DanielGavin/ols/releases/download/nightly/"
+              suffix)))
   "Automatic download url for ols language server."
   :group 'lsp-odin-ols
   :type 'string)
-
 
 (defcustom lsp-odin-ols-server-install-dir
   (f-join lsp-server-install-dir "ols/")

--- a/clients/lsp-odin.el
+++ b/clients/lsp-odin.el
@@ -75,14 +75,6 @@ Set this if you have the binary installed or have it built yourself."
 
 
 (defcustom lsp-odin-ols-binary-path
-  (f-join lsp-odin-ols-server-install-dir "latest" (if (eq system-type 'windows-nt)
-                                                       "ols-x86_64-pc-windows-msvc.exe"
-                                                     "ols-x86_64-unknown-linux-gnu"))
-  "The path where ols binary after will be stored."
-  :group 'lsp-odin-ols
-  :type 'file)
-
-(defcustom lsp-odin-ols-binary-path
   (f-join lsp-odin-ols-server-install-dir "latest" (cond ((eq system-type 'windows-nt)
                                                           "ols-x86_64-pc-windows-msvc.exe")
 

--- a/clients/lsp-odin.el
+++ b/clients/lsp-odin.el
@@ -1,0 +1,134 @@
+;;; lsp-odin.el --- Description -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2025 Sam Precious
+;;
+;; Author: Sam Precious <samwdp@gmail.com>
+;; Keywords: lsp, odin
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;;
+;; LSP client for Odin using the ols language server
+;;
+;;; Code:
+
+(require 'lsp-mode)
+(require 'f)
+
+(defgroup lsp-odin-ols nil
+  "LSP support for Odin, using ols."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/DanielGavin/ols")
+  :package-version '(lsp-mode . "9.0.0"))
+
+(defcustom lsp-odin-ols-download-url
+  (concat "https://github.com/DanielGavin/ols/releases/download/nightly/"
+          (cond ((eq system-type 'windows-nt)
+                 (if (and (string-match "^x86_64-.*" system-configuration)
+                          (version<= "26.4" emacs-version))
+                     "ols-x86_64-pc-windows-msvc.zip"))
+
+                ((eq system-type 'darwin)
+                 (if (string-match "aarch64-.*" system-configuration)
+                     "ols-arm64-darwin.zip"
+                   "ols-x86_64-darwin.zip"))
+
+                ((and (eq system-type 'gnu/linux)
+                      (or (eq (string-match "^x86_64" system-configuration) 0)
+                          (eq (string-match "^i[3-6]86" system-configuration) 0)))
+                 "ols-x86_64-unknown-linux-gnu.zip")
+
+                (t "omnisharp-mono.zip")))
+  "Automatic download url for ols language server."
+  :group 'lsp-odin-ols
+  :type 'string)
+
+
+(defcustom lsp-odin-ols-server-install-dir
+  (f-join lsp-server-install-dir "ols/")
+  "Installation directory for ols server."
+  :group 'lsp-odin-ols
+  :type 'directory)
+
+(defcustom lsp-odin-ols-store-path
+  (f-join lsp-odin-ols-server-install-dir "latest" "ols.zip")
+  "The path where ols .zip archive will be stored."
+  :group 'lsp-odin-ols
+  :type 'file)
+
+(defcustom lsp-odin-ols-server-path
+  nil
+  "The path to ols language-server binary.
+Set this if you have the binary installed or have it built yourself."
+  :group 'lsp-odin-ols
+  :type '(string :tag "Single string value or nil"))
+
+
+(defcustom lsp-odin-ols-binary-path
+  (f-join lsp-odin-ols-server-install-dir "latest" (if (eq system-type 'windows-nt)
+                                                       "ols-x86_64-pc-windows-msvc.exe"
+                                                     "ols-x86_64-unknown-linux-gnu"))
+  "The path where ols binary after will be stored."
+  :group 'lsp-odin-ols
+  :type 'file)
+
+(defcustom lsp-odin-ols-binary-path
+  (f-join lsp-odin-ols-server-install-dir "latest" (cond ((eq system-type 'windows-nt)
+                                                          "ols-x86_64-pc-windows-msvc.exe")
+
+                                                         ((eq system-type 'darwin)
+                                                          (if (string-match "aarch64-.*" system-configuration)
+                                                              "ols-arm64-darwin"
+                                                            "ols-x86_64-darwin"))
+
+                                                         ((and (eq system-type 'gnu/linux)
+                                                               (or (eq (string-match "^x86_64" system-configuration) 0)
+                                                                   (eq (string-match "^i[3-6]86" system-configuration) 0)))
+                                                          "ols-x86_64-unknown-linux-gnu")))
+  "The path where ols binary after will be stored."
+  :group 'lsp-odin-ols
+  :type 'file)
+
+(defcustom lsp-odin-ols-server-dir
+  (f-join lsp-odin-ols-server-install-dir "latest" "ols")
+  "The path where ols .zip archive will be extracted."
+  :group 'lsp-odin-ols
+  :type 'file)
+
+(lsp-dependency
+ 'ols
+ `(:download :url lsp-odin-ols-download-url
+             :decompress :zip
+             :store-path lsp-odin-ols-store-path
+             :binary-path lsp-odin-ols-binary-path
+             :set-executable? t)
+ '(:system "ols"))
+
+(defun lsp-odin--ols-download-server (_client callback error-callback _update?)
+  "Download zip package for ols and install it.
+Will invoke CALLBACK on success, ERROR-CALLBACK on error."
+  (lsp-package-ensure 'ols callback error-callback))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection lsp-odin-ols-binary-path)
+                  :major-modes '(odin-mode odin-ts-mode)
+                  :language-id "odin"
+                  :activation-fn (lsp-activate-on "odin")
+                  :server-id 'ols
+                  :multi-root t
+                  :download-server-fn #'lsp-odin--ols-download-server))
+
+(provide 'lsp-odin)
+;;; lsp-odin.el ends here

--- a/clients/lsp-odin.el
+++ b/clients/lsp-odin.el
@@ -34,21 +34,21 @@
   :package-version '(lsp-mode . "9.0.0"))
 
 (defcustom lsp-odin-ols-download-url
-  (concat "https://github.com/DanielGavin/ols/releases/download/nightly/"
-          (cond ((eq system-type 'windows-nt)
-                 (if (and (string-match "^x86_64-.*" system-configuration)
-                          (version<= "26.4" emacs-version))
-                     "ols-x86_64-pc-windows-msvc.zip"))
-
-                ((eq system-type 'darwin)
-                 (if (string-match "aarch64-.*" system-configuration)
-                     "ols-arm64-darwin.zip"
-                   "ols-x86_64-darwin.zip"))
-
-                ((and (eq system-type 'gnu/linux)
-                      (or (eq (string-match "^x86_64" system-configuration) 0)
-                          (eq (string-match "^i[3-6]86" system-configuration) 0)))
-                 "ols-x86_64-unknown-linux-gnu.zip")))
+  (let ((suffix
+         (pcase system-type
+           ('windows-nt
+            (when (and (string-match "^x86_64-.*" system-configuration)
+                       (version<= "26.4" emacs-version))
+              "ols-x86_64-pc-windows-msvc.zip"))
+           ('darwin
+            (if (string-match "aarch64-.*" system-configuration)
+                "ols-arm64-darwin.zip"
+              "ols-x86_64-darwin.zip"))
+           (_
+            "ols-x86_64-unknown-linux-gnu")))
+        (when suffix
+          (f-join "https://github.com/DanielGavin/ols/releases/download/nightly/"
+                  suffix))))
   "Automatic download url for ols language server."
   :group 'lsp-odin-ols
   :type 'string)
@@ -66,36 +66,27 @@
   :group 'lsp-odin-ols
   :type 'file)
 
-(defcustom lsp-odin-ols-server-path
-  nil
-  "The path to ols language-server binary.
-Set this if you have the binary installed or have it built yourself."
-  :group 'lsp-odin-ols
-  :type '(string :tag "Single string value or nil"))
-
-
-(defcustom lsp-odin-ols-binary-path
-  (f-join lsp-odin-ols-server-install-dir "latest" (cond ((eq system-type 'windows-nt)
-                                                          "ols-x86_64-pc-windows-msvc.exe")
-
-                                                         ((eq system-type 'darwin)
-                                                          (if (string-match "aarch64-.*" system-configuration)
-                                                              "ols-arm64-darwin"
-                                                            "ols-x86_64-darwin"))
-
-                                                         ((and (eq system-type 'gnu/linux)
-                                                               (or (eq (string-match "^x86_64" system-configuration) 0)
-                                                                   (eq (string-match "^i[3-6]86" system-configuration) 0)))
-                                                          "ols-x86_64-unknown-linux-gnu")))
-  "The path where ols binary after will be stored."
-  :group 'lsp-odin-ols
-  :type 'file)
-
 (defcustom lsp-odin-ols-server-dir
   (f-join lsp-odin-ols-server-install-dir "latest" "ols")
   "The path where ols .zip archive will be extracted."
   :group 'lsp-odin-ols
   :type 'file)
+
+(defcustom lsp-odin-ols-binary-path
+  (f-join lsp-odin-ols-server-install-dir "latest"
+          (pcase system-type
+            ('windows-nt
+             "ols-x86_64-pc-windows-msvc.exe")
+            ('darwin
+             (if (string-match "aarch64-.*" system-configuration)
+                 "ols-arm64-darwin"
+               "ols-x86_64-darwin"))
+            (_
+             "ols-x86_64-unknown-linux-gnu")))
+  "The path where ols binary after will be stored."
+  :group 'lsp-odin-ols
+  :type 'file)
+
 
 (lsp-dependency
  'ols

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -799,6 +799,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "ols",
+    "full-name": "Odin Language Server",
+    "server-name": "ols",
+    "server-url": "https://github.com/DanielGavin/ols",
+    "installation-url": "https://github.com/DanielGavin/ols",
+    "debugger": "Not available"
+  },
+  {
     "name": "openscad",
     "full-name": "OpenSCAD",
     "server-name": "openscad-lsp",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -184,7 +184,7 @@ As defined by the Language Server Protocol 3.16."
      lsp-json lsp-kotlin lsp-kubernetes-helm lsp-latex lsp-lisp lsp-ltex
      lsp-ltex-plus lsp-lua lsp-fennel lsp-magik lsp-markdown lsp-marksman
      lsp-matlab lsp-mdx lsp-meson lsp-metals lsp-mint lsp-mojo lsp-move lsp-mssql
-     lsp-nextflow lsp-nginx lsp-nim lsp-nix lsp-nushell lsp-ocaml lsp-openscad
+     lsp-nextflow lsp-nginx lsp-nim lsp-nix lsp-nushell lsp-ocaml lsp-odin lsp-openscad
      lsp-pascal lsp-perl lsp-perlnavigator lsp-php lsp-pls lsp-postgres
      lsp-purescript lsp-pwsh lsp-pyls lsp-pylsp lsp-pyright lsp-python-ms lsp-python-ty
      lsp-qml lsp-r lsp-racket lsp-remark lsp-rf lsp-roc lsp-roslyn lsp-rubocop
@@ -1004,7 +1004,9 @@ Changes take effect only when a new session is started."
     (yang-mode . "yang")
     (matlab-mode . "matlab")
     (message-mode . "plaintext")
-    (mu4e-compose-mode . "plaintext"))
+    (mu4e-compose-mode . "plaintext")
+    (odin-mode . "odin")
+    (odin-ts-mode . "odin"))
   "Language id configuration.")
 
 (defvar lsp--last-active-workspaces nil

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
     - Nix (nil): page/lsp-nix-nil.md
     - Nushell: page/lsp-nushell.md
     - OCaml (ocaml-lsp): page/lsp-ocaml-lsp-server.md
+    - Odin (ols): page/lsp-odin-ols-server.md
     - OpenSCAD: page/lsp-openscad.md
     - Pascal/Object Pascal: page/lsp-pascal.md
     - Perl (PLS): page/lsp-pls.md


### PR DESCRIPTION
Added odin language support though the [ols](https://github.com/DanielGavin/ols) server by Daniel Gavin 
This will automatically install the server based on the nightly release provided by the repository and should work for all platforms. I have only been able to test on Windows but I have included the binary names for mac os (x86 and arm) and also the linux binary. 

A user should install either [odin-mode](https://github.com/mattt-b/odin-mode) (this hasn't seen active development for the last 2 years and the maintainer seems to have abandoned it) or [odin-ts-mode](https://github.com/Sampie159/odin-ts-mode) (still in development)