### PR TITLE
lsp-volar: enable hybrid mode by default & add add-on mode

### DIFF
--- a/clients/lsp-volar.el
+++ b/clients/lsp-volar.el
@@ -53,6 +53,12 @@
   :group 'lsp-volar
   :package-version '(lsp-mode . "9.0.1"))
 
+(defcustom lsp-volar-as-add-on nil
+  "Run volar LSP server alongside other LSP server(s)"
+  :type 'boolean
+  :group 'lsp-volar
+  :package-version '(lsp-mode . "9.0.1"))
+
 (defcustom lsp-volar-activate-file ".volarrc"
   "A file with a custom name placed in WORKSPACE-ROOT is used to force enable
  volar when there is no package.json in the WORKSPACE-ROOT."
@@ -125,6 +131,7 @@ in the WORKSPACE-ROOT."
   :activation-fn 'lsp-volar--activate-p
   :priority 0
   :multi-root nil
+  :add-on? lsp-volar-as-add-on
   :server-id 'vue-semantic-server
   :initialization-options (lambda () (ht-merge (lsp-configuration-section "typescript")
                                                (lsp-configuration-section "vue")

--- a/clients/lsp-volar.el
+++ b/clients/lsp-volar.el
@@ -41,13 +41,13 @@
   :link '(url-link "https://github.com/vuejs/language-tools")
   :package-version '(lsp-mode . "9.0.0"))
 
-(defcustom lsp-volar-take-over-mode t
+(defcustom lsp-volar-take-over-mode nil
   "Enable Take Over Mode."
   :type 'boolean
   :group 'lsp-volar
   :package-version '(lsp-mode . "9.0.0"))
 
-(defcustom lsp-volar-hybrid-mode nil
+(defcustom lsp-volar-hybrid-mode t
   "Enable Hybrid Mode."
   :type 'boolean
   :group 'lsp-volar


### PR DESCRIPTION
`@vue/language-server` documentation state the following:

> Note: The "Take Over" mode has been discontinued. Instead, a new "Hybrid" mode has been introduced. In this mode, the Vue Language Server exclusively manages the CSS/HTML sections. As a result, you must run @vue/language-server in conjunction with a TypeScript server that employs @vue/typescript-plugin. Below is a streamlined configuration for Neovim's LSP, updated to accommodate the language server following the upgrade to version 2.0.0.

[source](https://github.com/vuejs/language-tools/tree/v2.2.10?tab=readme-ov-file#hybrid-mode-configuration-requires-vuelanguage-server-version-200)
 
In addition, lsp-mode state the following

> I have multiple language servers registered for language FOO. Which one will be used when opening a project?
>
> The highest number is highest priority. Note this is the opposite of [Unix priority (niceness)](https://en.wikipedia.org/wiki/Nice_(Unix)). Servers defined in `lsp-mode` tend to have lower priority than the external packages (priority 0 if unspecified). If a server is registered with `:add-on?` flag set to `t` it will be started in parallel to the other servers that are registered for the current mode. If the server that you want to use is not with the highest priority you may use `lsp-disabled-clients` to disable the server with higher `priority` or use `lsp-enabled-clients` to enable only the servers you want to use. In order to find the server ids you may check `*lsp-log*` buffer.

[source](https://github.com/emacs-lsp/lsp-mode/blob/8579c6c7771bc65564302e76296fb48855c558a4/docs/page/faq.md?plain=1#L20)

So this PR, enable hybrid mode by default as "Take Over" mode is discontinued and also create a new configuration to allow volar to be run aside other lsp (typescript for example).

Related issue: #4454

Code was inspired by
https://github.com/emacs-lsp/lsp-mode/blob/8579c6c7771bc65564302e76296fb48855c558a4/clients/lsp-sorbet.el#L41