### PR TITLE
lsp-format-region: Fix error "no region"

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6096,7 +6096,10 @@ Request codeAction/resolve for more info if server supports."
 
 (defun lsp-format-region (s e)
   "Ask the server to format the region, or if none is selected, the current line."
-  (interactive "r")
+  (interactive
+   (if (use-region-p)
+       (list (region-beginning) (region-end))
+     (list (point) (point))))
   (let ((edits (lsp-request
                 "textDocument/rangeFormatting"
                 (lsp--make-document-range-formatting-params s e))))


### PR DESCRIPTION
The `lsp-format-region` will emit error message `The mark is not set now, so there is no region` at the very beginning.
It can be reproduced with follow steps:
Start the Emacs with lsp, and open a c++ file `/tmp/a.cpp`, and execute `lsp-format-region`, then got the error message.

To workaround the issue, just select one char/word and de-select the region, then execute the `lsp-format-region`. 

This PR will follow the document of `lsp-format-region` description to accept region or line. 

Please help review and approve this change, thanks