### PR TITLE
fix(beancount): defer evaluation of initialization options

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -228,6 +228,7 @@
   * Add support for signatureHelp using ~posframe~. #1999
   * Add ~iedit~ integration. #2478
   * Add client for Verible SystemVerilog language Server ([[https://github.com/chipsalliance/verible]])
+  * Add support for per-project Beancount initialization-options
 
 ** Release 7.0.1
   * Introduced ~lsp-diagnostics-mode~.

--- a/clients/lsp-beancount.el
+++ b/clients/lsp-beancount.el
@@ -55,7 +55,8 @@ Use nil (the default) to use the current beancount buffer as the journal file."
      `(,lsp-beancount-langserver-executable "--stdio")))
   :major-modes '(beancount-mode)
   :initialization-options
-  `((journal_file . ,lsp-beancount-journal-file))
+  (lambda ()
+    `((journal_file . ,lsp-beancount-journal-file)))
   :server-id 'beancount-ls))
 
 (lsp-consistency-check lsp-beancount)


### PR DESCRIPTION
Per-project `journal_file` configuration was being ignored, as the backquote expansion is too eager (load time, not execution time)

Thanks for lsp-mode! 