### PR TITLE
fix: Ols server download url getting malformed

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -42,6 +42,7 @@
   * Add support for [[https://github.com/tombi-toml/tombi][Tombi language server]] (TOML language).
   * Make lsp-headerline--check-breadcrumb public
   * Added Odin langauge server support [[https://github.com/DanielGavin/ols][ols]]
+  * Fix bug in lsp-odin where ~f-join~ collapses double slashes. Using ~format~ instead.
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/clients/lsp-odin.el
+++ b/clients/lsp-odin.el
@@ -33,25 +33,18 @@
   :link '(url-link "https://github.com/DanielGavin/ols")
   :package-version '(lsp-mode . "9.0.0"))
 
-(defcustom lsp-odin-ols-download-url
-  (let ((suffix
-         (pcase system-type
-           ('windows-nt
-            (when (and (string-match "^x86_64-.*" system-configuration)
-                       (version<= "26.4" emacs-version))
-              "ols-x86_64-pc-windows-msvc.zip"))
-           ('darwin
-            (if (string-match "aarch64-.*" system-configuration)
-                "ols-arm64-darwin.zip"
-              "ols-x86_64-darwin.zip"))
-           (_
-            "ols-x86_64-unknown-linux-gnu"))))
-    (when suffix
-      (f-join "https://github.com/DanielGavin/ols/releases/download/nightly/"
-              suffix)))
-  "Automatic download url for ols language server."
+(setq lsp-odin-ols-download-url
+  (let* ((x86 (string-prefix-p "x86_64" system-configuration))
+         (arch (if x86 "x86_64" "arm64")))
+    (format "https://github.com/DanielGavin/ols/releases/download/nightly/%s"
+            (pcase system-type
+              ('gnu/linux (format "ols-%s-unknown-linux-gnu.zip" arch))
+              ('darwin (format "ols-%s-darwin.zip" arch))
+              ('windows-nt (format "ols-%s-pc-windows-msvc.zip" arch)))))
+  "Automatic download url for ols aaaa"
+  :type 'string
   :group 'lsp-odin-ols
-  :type 'string)
+  :package-version '(lsp-mode . "9.0.0"))
 
 (defcustom lsp-odin-ols-server-install-dir
   (f-join lsp-server-install-dir "ols/")

--- a/clients/lsp-odin.el
+++ b/clients/lsp-odin.el
@@ -33,7 +33,8 @@
   :link '(url-link "https://github.com/DanielGavin/ols")
   :package-version '(lsp-mode . "9.0.0"))
 
-(setq lsp-odin-ols-download-url
+
+(defcustom lsp-odin-ols-download-url
   (let* ((x86 (string-prefix-p "x86_64" system-configuration))
          (arch (if x86 "x86_64" "arm64")))
     (format "https://github.com/DanielGavin/ols/releases/download/nightly/%s"
@@ -41,7 +42,7 @@
               ('gnu/linux (format "ols-%s-unknown-linux-gnu.zip" arch))
               ('darwin (format "ols-%s-darwin.zip" arch))
               ('windows-nt (format "ols-%s-pc-windows-msvc.zip" arch)))))
-  "Automatic download url for ols aaaa"
+  "Automatic download url for ols language server."
   :type 'string
   :group 'lsp-odin-ols
   :package-version '(lsp-mode . "9.0.0"))


### PR DESCRIPTION
f-join was collapsing `//` (doubleslash) into a single slash. This was causing the resulting URL to be incorrect when getting the binary from github. Using `format` as this will not modify the string in any unexpected way