### PR TITLE
lsp-lens: fix overlay location to avoid conflict with lsp-ui-sideline

### DIFF
--- a/lsp-lens.el
+++ b/lsp-lens.el
@@ -103,9 +103,10 @@ Results are meaningful only if FROM and TO are on the same line."
   "Find or create a lens for the line at POS."
   (-doto (save-excursion
            (goto-char pos)
-           (if (eq 'end-of-line lsp-lens-place-position)
-               (make-overlay (line-end-position) -1 nil t t)
-             (make-overlay (line-beginning-position) (1+ (line-end-position)) nil t t)))
+           (let ((eol (line-end-position)))
+             (if (eq 'end-of-line lsp-lens-place-position)
+                 (make-overlay eol eol nil t t)
+               (make-overlay (line-beginning-position) (1+ eol) nil t t))))
     (overlay-put 'lsp-lens t)
     (overlay-put 'lsp-lens-position pos)))
 

--- a/test/lsp-mock-server-test.el
+++ b/test/lsp-mock-server-test.el
@@ -862,6 +862,6 @@ line 3 words here and here
        (should (string-match-p "My command"
                                (overlay-get (car lenses) 'after-string)))
        (goto-char (overlay-start (car lenses)))
-       (should (equal (line-number-at-pos) (- line 1)))))))
+       (should (equal (line-number-at-pos) (+ line 1)))))))
 
 ;;; lsp-mock-server-test.el ends here


### PR DESCRIPTION
Hi,

Currently, when `lsp-lens-place-position` is set to `'end-of-line', there is a conflict between the overlay location of `lsp-lens` and `lsp-ui-sidelines`.

For example, when lsp-ui-sideline code action is enabled, it will push the `lsp-lens` overlays down to the new line, like in this screenshot:

<img width="733" height="161" alt="lsp-lens-before-fixed" src="https://github.com/user-attachments/assets/4a182240-39d0-40a0-982d-c70713e1cd0f" />

This is due to the end index `-1` of `lsp-lens` overlays, set by the code  `(make-overlay (line-end-position) -1 nil t t)`

I fixed this issue in this PR and below is the screenshot after applying the patch:

<img width="721" height="139" alt="lsp-lens-after-fixed" src="https://github.com/user-attachments/assets/9fd4bc78-5cef-4441-a11f-9b7530b757b8" />

Please consider merging this PR.

Thanks!