### PR TITLE
Revert lsp-elixir-ls-download-url and update version to v0.29.1

### DIFF
--- a/clients/lsp-elixir.el
+++ b/clients/lsp-elixir.el
@@ -129,7 +129,7 @@ Leave as default to let `executable-find' search for it."
   :type '(repeat string)
   :package-version '(lsp-mode . "8.0.0"))
 
-(defcustom lsp-elixir-ls-version "v0.29.0"
+(defcustom lsp-elixir-ls-version "v0.29.1"
   "Elixir-Ls version to download.
 It has to be set before `lsp-elixir.el' is loaded and it has to
 be available here: https://github.com/elixir-lsp/elixir-ls/releases/"
@@ -138,7 +138,7 @@ be available here: https://github.com/elixir-lsp/elixir-ls/releases/"
   :package-version '(lsp-mode . "9.0.0"))
 
 (defcustom lsp-elixir-ls-download-url
-  (format "https://github.com/elixir-lsp/elixir-ls/releases/download/%1$s/elixir-ls.zip"
+  (format "https://github.com/elixir-lsp/elixir-ls/releases/download/%1$s/elixir-ls-%1$s.zip"
           lsp-elixir-ls-version)
   "Automatic download url for elixir-ls."
   :type 'string


### PR DESCRIPTION
The previous url change was a mistake on the release for v0.29.0 and was corrected on v0.29.1.  The old format would be preserved for future minor releases, because other integrations like zed relies on the existing format.

Sorry for the back and forth on this one, I might have jumped the gun to quickly on the first PR for v0.29. 

Reference: https://github.com/elixir-lsp/elixir-ls/releases/tag/v0.29.1