### PR TITLE
Suppress obsolete warning on latest emacs

### DIFF
--- a/Eask
+++ b/Eask
@@ -56,4 +56,5 @@
 (add-hook 'eask-before-compile-hook
            (lambda ()
              (setq byte-compile-error-on-warn t)
+             (setq byte-compile--suppressed-warnings '((obsolete revert-buffer-in-progress-p)))
              (setq byte-compile-docstring-max-column 1000)))


### PR DESCRIPTION
Emacs HEAD has obsoleted `revert-buffer-in-progress-p`: https://github.com/emacs-mirror/emacs/commit/
1fc4bb1fead205e425f69fa803a71f4e446d48a8

We can't use the new name because it doesn't exist on older emacs versions, so just ignore the warning for now.