### PR TITLE
lsp-rust: add lsp-rust-analyzer-cargo-target-dir config

### DIFF
--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -566,6 +566,20 @@ belongs to."
   :group 'lsp-rust-analyzer
   :package-version '(lsp-mode . "8.0.0"))
 
+(defcustom lsp-rust-analyzer-cargo-target-dir nil
+  "Optional path to a rust-analyzer specific target directory.
+This prevents rust-analyzer's `cargo check` and initial build-script and
+proc-macro building from locking the `Cargo.lock` at the expense of
+duplicating build artifacts.
+
+Set to `true` to use a subdirectory of the existing target directory or
+set to a path relative to the workspace to use that path."
+  :type '(choice
+          (string :tag "Directory")
+          boolean)
+  :group 'lsp-rust-analyzer
+  :package-version '(lsp-mode . "8.0.0"))
+
 (defcustom lsp-rust-analyzer-cargo-watch-enable t
   "Enable Cargo watch."
   :type 'boolean
@@ -1717,6 +1731,7 @@ https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/lsp-extensions.m
              :extraArgs ,lsp-rust-analyzer-cargo-extra-args
              :extraEnv ,lsp-rust-analyzer-cargo-extra-env
              :target ,lsp-rust-analyzer-cargo-target
+             :targetDir ,lsp-rust-analyzer-cargo-target-dir
              :runBuildScripts ,(lsp-json-bool lsp-rust-analyzer-cargo-run-build-scripts)
              ;; Obsolete, but used by old Rust-Analyzer versions
              :loadOutDirsFromCheck ,(lsp-json-bool lsp-rust-analyzer-cargo-run-build-scripts)


### PR DESCRIPTION
Allow setting the config option to have RA put its build artefacts in a separate dir.