### PR TITLE
lsp: Add support for external document show (showDocument param :external?)

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -2226,14 +2226,16 @@ PARAMS - the data sent from WORKSPACE."
         (completing-read (concat message " ") (seq-into choices 'list) nil t)
       (lsp-log message))))
 
-(lsp-defun lsp--window-show-document ((&ShowDocumentParams :uri :selection?))
-  "Show document URI in a buffer and go to SELECTION if any."
+(lsp-defun lsp--window-show-document ((&ShowDocumentParams :uri :selection? :external?))
+  "Show document URI in a buffer or in a external browser if EXTERNAL is t, and go to SELECTION if any."
   (let ((path (lsp--uri-to-path uri)))
-    (when (f-exists? path)
-      (with-current-buffer (find-file path)
-        (when selection?
-          (goto-char (lsp--position-to-point (lsp:range-start selection?))))
-        t))))
+    (if external?
+	(browse-url uri)
+      (when (f-exists? path)
+	(with-current-buffer (find-file path)
+          (when selection?
+            (goto-char (lsp--position-to-point (lsp:range-start selection?))))
+          t)))))
 
 (defcustom lsp-progress-prefix "⌛ "
   "Progress prefix."


### PR DESCRIPTION
This change enhances lsp--window-show-document to handle external URLs by:
- Adding `external?` parameter support from ShowDocumentParams
- Opening external URIs in browser via browse-url if external? is t
- Maintaining existing file-based document handling