### PR TITLE
Fix lsp-dependency for volar

### DIFF
--- a/clients/lsp-volar.el
+++ b/clients/lsp-volar.el
@@ -62,9 +62,9 @@ Reference: https://github.com/vuejs/language-tools/discussions/5455"
   (and filename (string-suffix-p ".vue" filename)))
 
 (lsp-dependency 'volar-language-server
+                '(:system "vue-language-server")
                 '(:npm :package "@vue/language-server" :path "vue-language-server"
-                       :version (lambda () (when lsp-volar-support-vue2 "~3.0")))
-                '(:system "vue-language-server"))
+                       :version (lambda () (when lsp-volar-support-vue2 "~3.0"))))
 
 ;; Set lsp-clients-typescript-plugins
 (condition-case nil


### PR DESCRIPTION
Move `:system` before `:npm` as the order seems to matter when loading `lsp-dependency`. Now, system-wide `vue-language-server` should be correctly detected.

See conversation in https://github.com/emacs-lsp/lsp-mode/pull/4871

Thank you @sdvcrx for all the help!