### PR TITLE
Don't return invalid region from lsp-semantic-tokens--fontify.

### DIFF
--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -492,7 +492,7 @@ LOUDLY will be forwarded to OLD-FONTIFY-REGION as-is."
       (funcall old-fontify-region beg-orig end-orig loudly))
      ((not (= lsp--cur-version (plist-get lsp--semantic-tokens-cache :_documentVersion)))
       ;; delay fontification until we have fresh tokens
-      '(jit-lock-bounds 0 . 0))
+      nil)
      (t
       (setq old-bounds (funcall old-fontify-region beg-orig end-orig loudly))
       ;; this is to prevent flickering when semantic token highlighting


### PR DESCRIPTION
Currently it returns 0 . 0 which is outside of the buffer, (point-min) is 1. It's better to return nil instead because such invalid region might break other packages, i.e. indent-bars.

See https://github.com/jdtsmith/indent-bars/issues/117