### PR TITLE
clients/lsp-trunk.el - prevent error when using lsp on non-file buffer

### DIFF
--- a/clients/lsp-trunk.el
+++ b/clients/lsp-trunk.el
@@ -46,7 +46,8 @@
   "Check if the file exists in a workspace that has a .trunk/trunk.yaml"
   (let ((dir (file-name-directory filename))
         (trunk-file ".trunk/trunk.yaml"))
-    (locate-dominating-file dir trunk-file)))
+    (when dir
+      (locate-dominating-file dir trunk-file))))
 
 (defun lsp-trunk-check-disable (command)
   "Disable a linter in your repo."


### PR DESCRIPTION
Protect against error when (file-name-directory filename) is nil which occurs on non-file buffer. We were hitting this when using lsp-mode with the p4.el package which when diff'ing pulls files from Perforce into non-file buffers and then activates a major mode that runs lsp.  This ends up calling lsp-trunk-check-for-init.