### PR TITLE
fix: Ignore persist when lsp-session-file is nil

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -43,6 +43,7 @@
   * Make lsp-headerline--check-breadcrumb public
   * Added Odin langauge server support [[https://github.com/DanielGavin/ols][ols]]
   * Fix bug in lsp-odin where ~f-join~ collapses double slashes. Using ~format~ instead.
+  * Fix bug where persist was attempted when lsp-session-file is nil
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -9380,10 +9380,13 @@ The library folders are defined by each client for each of the active workspace.
 
 (defun lsp--persist-session (session)
   "Persist SESSION to `lsp-session-file'."
-  (lsp--persist lsp-session-file (make-lsp-session
-                                  :folders (lsp-session-folders session)
-                                  :folders-blocklist (lsp-session-folders-blocklist session)
-                                  :server-id->folders (lsp-session-server-id->folders session))))
+  (if lsp-session-file
+      (lsp--persist lsp-session-file (make-lsp-session
+                                      :folders (lsp-session-folders session)
+                                      :folders-blocklist (lsp-session-folders-blocklist session)
+                                      :server-id->folders
+                                      (lsp-session-server-id->folders session)))
+    (message "lsp-session-file is nil, not persisting session.")))
 
 (defun lsp--try-project-root-workspaces (ask-for-client ignore-multi-folder)
   "Try create opening file as a project file.


### PR DESCRIPTION
Fixed this for myself and thought it might be useful for others as well.
This change ensures `lsp-mode` gracefully ignores persistence when `lsp-session-file` is `nil`.