### PR TITLE
Fix `lsp-org` compatibility with Org 9.7

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 9.0.1
+  * Fix =lsp-org= for org >= 9.7 (see #4300)
   * Add format on save support
   * Fix beancount journal file init option
   * Add support for [[https://github.com/glehmann/earthlyls][earthlyls]]


### PR DESCRIPTION
With `org-mode` >= 9.7, the api to access some node data has changed and requires to use a new function `org-element-property`. This fixes #4300. 

The fix is a simple one-liner but, in order to preserve the functionality for `org-mode` < 9.7:

- we define a variable to indicate which api we need to use
- we initialize that variable when `org-element` is loaded by testing it
- we branch between the two ways of accessing the needed property depending on the variable when `lsp-org` is run

Thanks to @fanshi1028 for the more elegant one-liner.