### PR TITLE
Name change wgsl_analyzer to wgsl-analyzer

### DIFF
--- a/clients/lsp-wgsl.el
+++ b/clients/lsp-wgsl.el
@@ -33,7 +33,7 @@
   :package-version '(lsp-mode . "9.0.0"))
 
 
-(defcustom lsp-wgsl-server-command "wgsl_analyzer"
+(defcustom lsp-wgsl-server-command "wgsl-analyzer"
   "Command to run the wgsl-analyzer executable."
   :type 'boolean
   :group 'lsp-wgsl
@@ -174,8 +174,8 @@ definitions resolved."
 
 (lsp-dependency 'wgsl-analyzer
                 '(:system lsp-wgsl-server-command)
-                '(:cargo :package "wgsl_analyzer"
-                         :path "wgsl_analyzer"
+                '(:cargo :package "wgsl-analyzer"
+                         :path "wgsl-analyzer"
                          :git "https://github.com/wgsl-analyzer/wgsl-analyzer"))
 
 (lsp-register-client

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -1360,7 +1360,7 @@
     "full-name": "wgsl",
     "server-name": "wgsl-analyzer",
     "server-url": "https://github.com/wgsl-analyzer/wgsl-analyzer",
-    "installation": "cargo install --git https://github.com/wgsl-analyzer/wgsl-analyzer wgsl_analyzer",
+    "installation": "cargo install --git https://github.com/wgsl-analyzer/wgsl-analyzer wgsl-analyzer",
     "debugger": "Not available"
   },
   {


### PR DESCRIPTION
Fix wgsl-analyzer installation by using correct package name

The cargo package name is `wgsl-analyzer` (with hyphens), not `wgsl_analyzer` (with underscores). This was causing installation to fail with:

`error: could not find wgsl_analyzer in https://github.com/wgsl-analyzer/wgsl-analyzer with version *`

Updated the package name, binary path, and documentation to use hyphens.