### PR TITLE
Fixed lsp-typeprof to work with typeprof 0.30.x

### DIFF
--- a/clients/lsp-typeprof.el
+++ b/clients/lsp-typeprof.el
@@ -52,7 +52,8 @@
                    #'lsp-typeprof--build-command)
   :priority -4
   :activation-fn (lsp-activate-on "ruby")
-  :server-id 'typeprof-ls))
+  :server-id 'typeprof-ls
+  :multi-root t))
 
 (lsp-consistency-check lsp-typeprof)
 


### PR DESCRIPTION
fixed https://github.com/emacs-lsp/lsp-mode/issues/4893

Since `workspaceFolders` became required from [typeprof 0.30.0](https://github.com/ruby/typeprof/releases/tag/v0.30.0), I made `multi-root` non-nil. Since more than half a year has passed since the release, I think it should be fine even if customization is not possible.

This change was worked fine with typeprof 0.30.1.
<img width="1393" height="493" alt="Screenshot From 2025-10-27 17-01-17" src="https://github.com/user-attachments/assets/892000fb-76cb-48a3-ae15-c82f5dfa0c42" />




NOTE: It seems that the behavior was changed in 0.30.0 so that typeprof only works when `typeprof.conf.json[c]` exists in the workspace root ([https://github.com/ruby/typeprof/blob/v0.30.0/lib/typeprof/lsp/server.rb\#L66-L76](https://github.com/ruby/typeprof/blob/v0.30.0/lib/typeprof/lsp/server.rb#L66-L76)).
