### PR TITLE
fix `gopls` code lenses when using `lsp-use-plists`

### DIFF
--- a/clients/lsp-go.el
+++ b/clients/lsp-go.el
@@ -453,7 +453,9 @@ Will update if UPDATE? is t"
                   :initialized-fn (lambda (workspace)
                                     (let ((caps (lsp--workspace-server-capabilities workspace)))
                                       (unless (lsp-get caps :inlayHintProvider)
-                                        (lsp:set-server-capabilities-inlay-hint-provider? caps t))))))
+                                        (lsp:set-server-capabilities-inlay-hint-provider? caps t))
+                                      (unless (lsp-get caps :codeLensProvider)
+                                        (lsp:set-server-capabilities-code-lens-provider? caps t))))))
 
 (lsp-consistency-check lsp-go)
 


### PR DESCRIPTION
this PR fixes displaying of code lenses in go and go.mod files when using plists. It looks like `{}` value of `codeLensProvider` resolves to `null` which disables code lenses.

<img width="342" height="93" alt="image" src="https://github.com/user-attachments/assets/8b350190-16bc-44fd-b824-09e75e9fd1e0" />

this fix is similar to what's done in https://github.com/emacs-lsp/lsp-mode/pull/4882