### PR TITLE
Add perl-ts-mode in lsp-language-id-configuration

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -962,6 +962,7 @@ Changes take effect only when a new session is started."
     (gdscript-ts-mode . "gdscript")
     (perl-mode . "perl")
     (cperl-mode . "perl")
+    (perl-ts-mode . "perl")
     (robot-mode . "robot")
     (roc-ts-mode . "roc")
     (racket-mode . "racket")


### PR DESCRIPTION
Just to ensure that `lsp-mode` works out-of-the-box with https://github.com/emacsmirror/perl-ts-mode