### PR TITLE
lsp-rust: Append --no-run flag for debugging

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -47,6 +47,7 @@
   * Fix bug in lsp-odin where ~f-join~ collapses double slashes. Using ~format~ instead.
   * Fix missing gopls inlay hints when ~lsp-use-plist~ is true
   * Fix bug where persist was attempted when lsp-session-file is nil
+  * Debugging tests in Rust no longer runs all the tests prior to launching debug session.
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1561,7 +1561,7 @@ and run a compilation"
            :label) runnable))
     (pcase (aref cargo-args 0)
       ("run" (aset cargo-args 0 "build"))
-      ("test" (when (-contains? (append cargo-args ()) "--no-run")
+      ("test" (unless (-contains? (append cargo-args ()) "--no-run")
                 (cl-callf append cargo-args (list "--no-run")))))
     (->> (append (list (executable-find "cargo"))
                  cargo-args


### PR DESCRIPTION
For me the tests were always being ran when Clicking on "Debug" button on a test in a rust file. I have gone over the logic and I am pretty confident that the condition here is wrong as it seems to me it should append --no-run only if it's not already present. This is to prevent having two --no-run flags that lead to an error `error: the argument '--no-run' cannot be used multiple times`.

Change the logic of lsp-rust-analyzer-debug to append --no-run when it's not already in cargo-args, not the other way round. The result is used only for obtaining the compiler-artifact, no need to run the tests to obtain it.