### PR TITLE
feat: do not watch devenv and jj directories

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -48,6 +48,7 @@
   * Fix missing gopls inlay hints when ~lsp-use-plist~ is true
   * Fix bug where persist was attempted when lsp-session-file is nil
   * Debugging tests in Rust no longer runs all the tests prior to launching debug session.
+  * Add [[https://devenv.sh/][devenv]] and [[https://jj-vcs.github.io/jj/latest/][jj]] directories to the list of ignored directories (~lsp-file-watch-ignored-directories~)
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -352,6 +352,7 @@ the server has requested that."
     "[/\\\\]_darcs\\'"
     "[/\\\\]\\.svn\\'"
     "[/\\\\]_FOSSIL_\\'"
+    "[/\\\\]\\.jj\\'"
     ;; IDE or build tools
     "[/\\\\]\\.idea\\'"
     "[/\\\\]\\.ensime_cache\\'"
@@ -423,7 +424,9 @@ the server has requested that."
     ;; nix-direnv
     "[/\\\\]\\result"
     "[/\\\\]\\result-bin"
-    "[/\\\\]\\.direnv\\'")
+    "[/\\\\]\\.direnv\\'"
+    ;; nix-devenv
+    "[/\\\\]\\.devenv\\'")
   "List of regexps matching directory paths which won't be monitored when
 creating file watches. Customization of this variable is only honored at
 the global level or at a root of an lsp workspace."


### PR DESCRIPTION
Ignore the following directiories:
- .devenv created by devenv (https://devenv.sh)
- .jj created by jj (https://jj-vcs.github.io/jj/latest/)