### PR TITLE
Explicitly enable json validation

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 9.0.1
+  * Add explicit flag to enable (or disable) JSON validation.
   * Fix Accommodate renaming of lsp-postgres binaries
   * Fix =lsp-org= for org >= 9.7 (see #4300)
   * Add format on save support

--- a/clients/lsp-json.el
+++ b/clients/lsp-json.el
@@ -54,8 +54,15 @@ here, https://github.com/emacs-lsp/lsp-mode/issues/3368#issuecomment-1049635155.
   :group 'lsp-json
   :package-version '(lsp-mode . "6.3"))
 
+(defcustom lsp-json-validate t
+  "Enable json validaten."
+  :type 'boolean
+  :group 'lsp-json
+  :package-version '(lsp-mode . "9.0.1"))
+
 (lsp-register-custom-settings
  '(("json.schemas" lsp-json-schemas)
+   ("json.validate.enable" lsp-json-validate)
    ("http.proxy" lsp-http-proxy)
    ("http.proxyStrictSSL" lsp-http-proxyStrictSSL)))
 


### PR DESCRIPTION
In my set up, json validation was not occurring despite this being a default value.  Explicitly setting this here, and also enabling a customisation to disable it if desired.

Closes Issue #4146.