### PR TITLE
lsp-ruff: enable multi-root support

### DIFF
--- a/clients/lsp-ruff.el
+++ b/clients/lsp-ruff.el
@@ -92,6 +92,7 @@ Previous ruff-lsp should change this to (\"ruff-lsp\")"
   :server-id 'ruff
   :priority -2
   :add-on? t
+  :multi-root t
   :initialization-options
   (lambda ()
     (list :settings


### PR DESCRIPTION
Have been running this in my own configuration with no noticeable issues. The [initial commit message](https://github.com/astral-sh/ruff/commit/0c84fbb6db646550e00eed5560a692f2ea1b6224) of ruff's LSP server implementation lists multi-workspace as a supported feature.

Fixes #4831