### PR TITLE
fix: remove malformed and unnecessary Package-Requires

### DIFF
--- a/clients/lsp-copilot.el
+++ b/clients/lsp-copilot.el
@@ -25,8 +25,6 @@
 ;; LSP client for the Copilot Language Server:
 ;; https://www.npmjs.com/package/@github/copilot-language-server
 
-;; Package-Requires: (lsp-mode secrets s compile dash cl-lib request company)
-
 ;; Code:
 
 (require 'dash)

--- a/clients/lsp-pls.el
+++ b/clients/lsp-pls.el
@@ -4,7 +4,6 @@
 
 ;; Author: Alexander Adolf <alexander.adolf@condition-alpha.com>
 ;; Maintainer: Alexander Adolf <alexander.adolf@condition-alpha.com>
-;; Package-Requires: (lsp-mode)
 ;; Keywords: perl, lsp
 
 ;; This file is not part of GNU Emacs

--- a/clients/lsp-volar.el
+++ b/clients/lsp-volar.el
@@ -9,7 +9,6 @@
 ;; Version: 0.0.1
 ;; Keywords: abbrev bib c calendar comm convenience data docs emulations extensions faces files frames games hardware help hypermedia i18n internal languages lisp local maint mail matching mouse multimedia news outlines processes terminals tex tools unix vc wp
 ;; Homepage: https://github.com/jadestrong/lsp-volar
-;; Package-Requires: ((emacs "25.1"))
 ;;
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Remove malformed `Package-Requires' from lsp-copilot, lsp-pls clients, to prevent parsing error while `lsp-mode' via use-package-vc. Besides being malformed, they are quite unnecessary too, so one such comment was removed from lsp-volar client too.