### PR TITLE
lsp-buf: change buf CLI args

### DIFF
--- a/clients/lsp-bufls.el
+++ b/clients/lsp-bufls.el
@@ -71,7 +71,7 @@
   :link '(url-lint "https://github.com/bufbuild/buf")
   :package-version '(lsp-mode . "9.0.0"))
 
-(defcustom lsp-buf-args `("beta" "lsp" "--timeout" "0" "--log-format" "json")
+(defcustom lsp-buf-args `("lsp" "serve")
   "Arguments to pass to buf CLI."
   :type '(repeat string)
   :group 'lsp-buf


### PR DESCRIPTION
## WHAT

Change args of `buf`

## WHY

- The lsp command in buf has graduated from beta
    - https://github.com/bufbuild/buf/releases/tag/v1.59.0
        > Promote buf beta lsp to buf lsp serve. Command buf beta lsp is now deprecated.
- No longer times out by default
    - https://github.com/bufbuild/buf/releases/tag/v1.60.0
        > Update default value of --timeout flag to 0, which results in no timeout by default.
- Use logformat default (text)
    - https://github.com/emacs-lsp/lsp-mode/pull/4739#issuecomment-2750505706