### PR TITLE
lsp-csharp--cls-metadata-uri-handler: use utf-8-unix as system write encoding

### DIFF
--- a/clients/lsp-csharp.el
+++ b/clients/lsp-csharp.el
@@ -479,7 +479,8 @@ filename is returned so lsp-mode can display this file."
                                  (concat symbol-name ".cs")))
                (file-location (expand-file-name filename (lsp-workspace-root)))
                (metadata-file-location (concat file-location ".metadata-uri"))
-               (path (f-dirname file-location)))
+               (path (f-dirname file-location))
+               (coding-system-for-write 'utf-8-unix))
 
     (unless (file-exists-p file-location)
       (unless (file-directory-p path)


### PR DESCRIPTION
This to prevent `^M` show up in file for Windows system.