### PR TITLE
[fix #4099] lsp-install-server `wrong-number-of-arguments (1 .2) 0`

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7635,6 +7635,8 @@ Return a nested alist keyed by symbol names. e.g.
 (defun lsp-resolve-final-command (command &optional test?)
   "Resolve final function COMMAND."
   (let* ((command (lsp-resolve-value command))
+         ;; Filter out nil values before validation (issue #4099)
+         (command (if (listp command) (delq nil command) command))
          (command (cl-etypecase command
                     (list
                      (cl-assert (seq-every-p (apply-partially #'stringp) command) nil

--- a/test/lsp-mode-test.el
+++ b/test/lsp-mode-test.el
@@ -182,6 +182,16 @@
   (lsp-register-custom-settings '(("foo" "new value")))
   (should (equal (gethash "foo" lsp-client-settings) '("new value"))))
 
+(ert-deftest lsp-resolve-final-command-with-nil-values ()
+  "Test that lsp-resolve-final-command handles nil values in command list (issue #4099).
+This test reproduces the bug where command lists with nil values cause
+'Invalid command list' assertion errors."
+  ;; Directly pass a list with nil values - this simulates what happens when
+  ;; lsp-resolve-value returns a list containing nil elements
+  (let ((command (list "node" nil "server.js" nil "--stdio")))
+    (should (equal (lsp-resolve-final-command command t)
+                   '("node" "server.js" "--stdio")))))
+
 
 
 ;;; lsp-mode-test.el ends here


### PR DESCRIPTION
To fix the bug when trying to install lsp servers

https://github.com/emacs-lsp/lsp-mode/issues/4099

# Problem
When LSP server commands contained `nil` values (e.g., from optional/conditional arguments), `lsp-resolve-final-command` would fail with an "Invalid command list" assertion error.

Running on `$ emacs -Q`:

<img width="598" height="565" alt="image" src="https://github.com/user-attachments/assets/3b6b5a45-5ea0-4a65-b2ed-fd54e74e2cc9" />

After our bugfix:

<img width="598" height="566" alt="image" src="https://github.com/user-attachments/assets/96446d33-eddc-45d4-a9db-ec73b7ea223f" />

# Root Cause
The function validated that all elements in the command list were strings using:
```elisp
(cl-assert (seq-every-p (apply-partially #'stringp) command) nil
           "Invalid command list")
```

This assertion failed when `nil` values were present in the list.

# Solution
Filter out `nil` values **before** validation:

```elisp
(let* ((command (lsp-resolve-value command))
         ;; Filter out nil values before validation (issue #4099)
         (command (if (listp command) (delq nil command) command))
```

**Location**: `lsp-mode.el:7640-7641` in `lsp-resolve-final-command`

## Changes
- **lsp-mode.el**: Added 2 lines to filter nil values before assertion
- **test/lsp-mode-test.el**: Added test case `lsp-resolve-final-command-with-nil-values`
