### PR TITLE
add add L? to regex for links in ui-doc

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5114,7 +5114,7 @@ Applies on type formatting."
       ("file"
        (xref-push-marker-stack)
        (find-file (lsp--uri-to-path url))
-       (-when-let ((_ line column) (s-match (rx "#" (group (1+ num)) (or "," "#") (group (1+ num))) url))
+       (-when-let ((_ line column) (s-match (rx "#" (optional "L") (group (1+ num)) (or "," "#") (group (1+ num))) url))
          (goto-char (lsp--position-to-point
                      (lsp-make-position :character (1- (string-to-number column))
                                         :line (1- (string-to-number line)))))))


### PR DESCRIPTION
Some LSP servers report line-level links to files with github's convention: `#L$LINE,$COL`. which does not match the existing regex `#\d+[,#]\d+`. Instead we modify the rx expression to correspond to `#L?\d+[,#]\d+`