### PR TITLE
lsp-ron: Add support for RON files.

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 9.0.1
+  * Add supprot for RON files through ron-lsp.
   * Add explicit flag to enable (or disable) JSON validation.
   * Fix Accommodate renaming of lsp-postgres binaries
   * Fix =lsp-org= for org >= 9.7 (see #4300)

--- a/clients/lsp-ron.el
+++ b/clients/lsp-ron.el
@@ -1,0 +1,52 @@
+;;; lsp-ron.el --- lsp-mode RON integration -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025 lsp-mode maintainers
+
+;; Author: lsp-mode maintainers
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;  Client for RON, Rusty Object notation (https://github.com/ron-rs/ron)
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-ron nil
+  "Settings for the RON Language Server."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/jasonjmcghee/ron-lsp/")
+  :package-version '(lsp-mode . "9.0.1"))
+
+(defcustom lsp-ron-executable '("ron-lsp")
+  "Command to run the RON language server."
+  :group 'lsp-ron
+  :risky t
+  :type '(repeat string))
+
+(lsp-dependency 'ron-language-server
+                '(:system "ron-lsp"))
+
+(lsp-register-client
+ (make-lsp-client :server-id 'ron-lsp
+                  :new-connection (lsp-stdio-connection (lambda () lsp-ron-executable))
+                  :major-modes '(ron-mode)))
+
+(lsp-consistency-check lsp-ron)
+
+(provide 'lsp-ron)
+;;; lsp-ron.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -1036,6 +1036,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "ron",
+    "full-name": "Rusty Object Notation",
+    "server-name": "ron-lsp",
+    "server-url": "https://github.com/jasonjmcghee/ron-lsp/",
+    "installation": "cargo install ron-lsp",
+    "debugger": "Not available"
+  },
+  {
     "name": "ruby-lsp",
     "full-name": "Ruby (ruby-lsp)",
     "server-name": "ruby-lsp",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -187,7 +187,7 @@ As defined by the Language Server Protocol 3.16."
      lsp-nextflow lsp-nginx lsp-nim lsp-nix lsp-nushell lsp-ocaml lsp-odin lsp-openscad
      lsp-pascal lsp-perl lsp-perlnavigator lsp-php lsp-pls lsp-postgres
      lsp-purescript lsp-pwsh lsp-pyls lsp-pylsp lsp-pyright lsp-python-ms lsp-python-ty
-     lsp-qml lsp-r lsp-racket lsp-remark lsp-rf lsp-roc lsp-roslyn lsp-rubocop
+     lsp-qml lsp-r lsp-racket lsp-remark lsp-rf lsp-roc lsp-ron lsp-roslyn lsp-rubocop
      lsp-ruby-lsp lsp-ruby-syntax-tree lsp-ruff lsp-rust lsp-semgrep lsp-shader
      lsp-solargraph lsp-solidity lsp-sonarlint lsp-sorbet lsp-sourcekit
      lsp-sql lsp-sqls lsp-steep lsp-svelte lsp-tailwindcss lsp-terraform
@@ -969,6 +969,7 @@ Changes take effect only when a new session is started."
     (perl-ts-mode . "perl")
     (robot-mode . "robot")
     (roc-ts-mode . "roc")
+    (ron-mode . "ron")
     (racket-mode . "racket")
     (nix-mode . "nix")
     (nix-ts-mode . "nix")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,6 +157,7 @@ nav:
     - Racket (jeapostrophe): page/lsp-racket-langserver.md
     - Racket (Theia): page/lsp-racket-language-server.md
     - Roc: page/lsp-roc.md
+    - RON: page/ron-lsp.md
     - RPM Spec: page/lsp-rpm-spec.md
     - Ruby (RuboCop): page/lsp-rubocop.md
     - Ruby (ruby-lsp): page/lsp-ruby-lsp.md


### PR DESCRIPTION
This adds support for [RON](https://github.com/ron-rs/ron) files through [ron-lsp](https://github.com/jasonjmcghee/ron-lsp/).