### PR TITLE
just-lsp: Add support for Just files

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,6 +1,7 @@
 * Changelog
 ** Unreleased 9.0.1
-  * Add supprot for RON files through ron-lsp.
+  * Add support for ~just~ files through just-lsp.
+  * Add support for RON files through ron-lsp.
   * Add explicit flag to enable (or disable) JSON validation.
   * Fix Accommodate renaming of lsp-postgres binaries
   * Fix =lsp-org= for org >= 9.7 (see #4300)

--- a/clients/lsp-just.el
+++ b/clients/lsp-just.el
@@ -1,0 +1,53 @@
+;;; lsp-just.el --- lsp-mode Just integration -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025 lsp-mode maintainers
+
+;; Author: lsp-mode maintainers
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;  Client for Just (https://github.com/terror/just-lsp)
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-just nil
+  "Settings for the Just Language Server."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/terror/just-lsp")
+  :package-version '(lsp-mode . "9.0.1"))
+
+(defcustom lsp-just-executable '("just-lsp")
+  "Command to run the Just language server."
+  :group 'lsp-just
+  :risky t
+  :type '(repeat string))
+
+(lsp-dependency 'just-language-server
+                 '(:system "just-lsp"))
+
+(lsp-register-client
+ (make-lsp-client :server-id 'just-lsp
+                  :new-connection (lsp-stdio-connection (lambda () lsp-just-executable))
+                  :major-modes '(just-mode
+                                 just-ts-mode)))
+
+(lsp-consistency-check lsp-just)
+
+(provide 'lsp-just)
+;;; lsp-just.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -558,6 +558,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "just",
+    "full-name": "Just",
+    "server-name": "just-lsp",
+    "server-url": "https://github.com/terror/just-lsp",
+    "installation-url": "https://github.com/terror/just-lsp",
+    "debugger": "Not available"
+  },
+  {
     "name": "jq",
     "full-name": "Jq (jq-lsp)",
     "server-name": "jq-lsp",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -180,7 +180,7 @@ As defined by the Language Server Protocol 3.16."
      lsp-dockerfile lsp-earthly lsp-elixir lsp-elm lsp-emmet lsp-erlang
      lsp-eslint lsp-fortran lsp-futhark lsp-fsharp lsp-gdscript lsp-gleam
      lsp-glsl lsp-go lsp-golangci-lint lsp-grammarly lsp-graphql lsp-groovy
-     lsp-hack lsp-haskell lsp-haxe lsp-idris lsp-java lsp-javascript lsp-jq
+     lsp-hack lsp-haskell lsp-haxe lsp-idris lsp-java lsp-javascript lsp-just lsp-jq
      lsp-json lsp-kotlin lsp-kubernetes-helm lsp-latex lsp-lisp lsp-ltex
      lsp-ltex-plus lsp-lua lsp-fennel lsp-magik lsp-markdown lsp-marksman
      lsp-matlab lsp-mdx lsp-meson lsp-metals lsp-mint lsp-mojo lsp-move lsp-mssql
@@ -847,6 +847,8 @@ Changes take effect only when a new session is started."
     (scala-ts-mode . "scala")
     (julia-mode . "julia")
     (julia-ts-mode . "julia")
+    (just-mode . "just")
+    (just-ts-mode . "just")
     (clojure-mode . "clojure")
     (clojurec-mode . "clojure")
     (clojurescript-mode . "clojurescript")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
     - Json: page/lsp-json.md
     - Jsonnet: page/lsp-jsonnet.md
     - Julia: page/lsp-julia.md
+    - Just: page/lsp-just.md
     - Kotlin: page/lsp-kotlin.md
     - LanguageTool (LTEX): page/lsp-ltex.md
     - LanguageTool (LTEX+): page/lsp-ltex-plus.md


### PR DESCRIPTION
 Add support for [just](https://github.com/casey/just/) files through [`just-lsp`](https://github.com/terror/just-lsp).