### PR TITLE
Fix missing ty inlay hints when using `lsp-use-plists`

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -56,6 +56,7 @@
   * Fix default value for ~lsp-rust-analyzer-cargo-cfgs~
   * Add ~lsp-ruby-lsp-server-command~ variable to allow overriding of the path to ~ruby-lsp~ executable
   * Add support for the ~javascript.preferences.importModuleSpecifierEnding~ and ~typescript.preferences.importModuleSpecifierEnding~ preferences.
+  * Fix missing ty (a fast python language server) inlay hints when ~lsp-use-plist~ is true
 
 ** 9.0.0
   * Add language server config for QML (Qt Modeling Language) using qmlls.

--- a/clients/lsp-python-ty.el
+++ b/clients/lsp-python-ty.el
@@ -42,7 +42,11 @@
                   :activation-fn (lsp-activate-on "python")
                   :priority -1
                   :add-on? t
-                  :server-id 'ty-ls))
+                  :server-id 'ty-ls
+                  :initialized-fn (lambda (workspace)
+                                    (let ((caps (lsp--workspace-server-capabilities workspace)))
+                                      (unless (lsp-get caps :inlayHintProvider)
+                                        (lsp:set-server-capabilities-inlay-hint-provider? caps t))))))
 
 (lsp-consistency-check lsp-python-ty)
 


### PR DESCRIPTION
This PR fixes missing inlay hints for `ty` (fast python language server). I just copied a fix from #4882.