### PR TITLE
docs: fix typos and improve grammar in documentation and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
 title: LSP Mode - Language Server Protocol support for Emacs
-description: Language Server Protocol support with multiples languages support for Emacs
+description: Language Server Protocol support with multiple languages support for Emacs
 root_file: README.md
 ---
 
@@ -130,8 +130,8 @@ You can help us keep going and improving it by **[supporting the project](https:
 
 ### Members
 
-Here it is a list of the current `lsp-mode` members and what they are
-primary working on/responsible for.
+Here is a list of the current `lsp-mode` members and what they are
+primarily working on/responsible for.
 
 <table id="emacs-lsp-members">
   <tr>

--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -618,17 +618,17 @@ TypeScript 3.0 or newer in the workspace."
   :package-version '(lsp-mode . "6.1"))
 
 (defcustom lsp-javascript-suggest-enabled t
-  "Enabled/disable autocomplete suggestions."
+  "Enable/disable autocomplete suggestions."
   :type 'boolean
   :package-version '(lsp-mode . "6.1"))
 
 (defcustom lsp-typescript-suggest-enabled t
-  "Enabled/disable autocomplete suggestions."
+  "Enable/disable autocomplete suggestions."
   :type 'boolean
   :package-version '(lsp-mode . "6.1"))
 
 (defcustom lsp-typescript-surveys-enabled t
-  "Enabled/disable occasional surveys that help us improve VS
+  "Enable/disable occasional surveys that help us improve VS
 Code's JavaScript and TypeScript support."
   :type 'boolean
   :package-version '(lsp-mode . "6.1"))
@@ -791,7 +791,7 @@ name (e.g. `data' variable passed as `data' parameter)."
   nil)
 
 (defun lsp-javascript-rename-file ()
-  "Rename current file and all it's references in other files."
+  "Rename current file and all its references in other files."
   (interactive)
   (let* ((name (buffer-name))
          (old (buffer-file-name))

--- a/clients/lsp-json.el
+++ b/clients/lsp-json.el
@@ -55,7 +55,7 @@ here, https://github.com/emacs-lsp/lsp-mode/issues/3368#issuecomment-1049635155.
   :package-version '(lsp-mode . "6.3"))
 
 (defcustom lsp-json-validate t
-  "Enable json validaten."
+  "Enable JSON validation."
   :type 'boolean
   :group 'lsp-json
   :package-version '(lsp-mode . "9.0.1"))

--- a/clients/lsp-kubernetes-helm.el
+++ b/clients/lsp-kubernetes-helm.el
@@ -216,7 +216,7 @@ Limited for performance reasons."
   :package-version '(lsp-mode . "9.0.0"))
 
 (defcustom lsp-kubernetes-helm-server-arguments '("serve" "--stdio")
-  "Command to start helm-ls.  Minimally needs serve otherwise the server wont start properly."
+  "Command to start helm-ls.  Minimally needs serve otherwise the server won't start properly."
   :type '(repeat string)
   :group 'lsp-kubernetes-helm
   :package-version '(lsp-mode . "9.0.0"))

--- a/clients/lsp-ocaml.el
+++ b/clients/lsp-ocaml.el
@@ -329,7 +329,7 @@ If TYPE is a single-line that represents a module type, reformat it."
           (index lsp-ocaml--type-enclosing-index)
           (type_result (lsp-ocaml--type-enclosing verbosity index))
           ((&ocaml-lsp:TypeEnclosingResult :index :type :enclosings) type_result)
-          ;; Get documentation informations
+          ;; Get documentation information
           (markupkind (symbol-name lsp-ocaml-markupkind))
           (doc_result (lsp-ocaml--get-documentation nil markupkind))
           (doc (cl-getf (cl-getf doc_result :doc) :value)))

--- a/clients/lsp-wgsl.el
+++ b/clients/lsp-wgsl.el
@@ -114,7 +114,7 @@
 ;; Currently it relies on a custom extension to query the clients.
 ;; (could not get standard custom-settings blocks to work)
 (defun lsp-wgsl--send-configuration (&rest _)
-  ;; TODO: why doesnt this behave like the normal lists?!?!? I cant just send a list?!?!?! why the fuck?!?!
+  ;; TODO: why doesn't this behave like the normal lists?!?!? I can't just send a list?!?!?! why the fuck?!?!
   (list :customImports lsp-wgsl-custom-imports
         :diagnostics (list :typeErrors (lsp-json-bool lsp-wgsl-diagnostics-type-errors)
                            :nagaParsingErrors (lsp-json-bool lsp-wgsl-diagnostics-naga-parsing-errors)

--- a/docs/lsp-doc.el
+++ b/docs/lsp-doc.el
@@ -20,7 +20,7 @@
 
 ;;; Commentary:
 
-;; Tool for convert elisp files into documentation.
+;; Tool to convert elisp files into documentation.
 
 ;;; Code:
 

--- a/docs/manual-language-docs/lsp-org.md
+++ b/docs/manual-language-docs/lsp-org.md
@@ -7,10 +7,10 @@ inside of [org-mode](https://orgmode.org/) source blocks. `lsp-mode` is
 achieving this by obtaining the information about the source block from the
 source block header(language + `:tangle`) then translating the point to the LSP
 positions back and forth so the language server thinks that Emacs has opened the
-original file. In order that to work the files has to be present on the disk as
+original file. For this to work, the files have to be present on the disk as
 well because the server expects to find them.
 
-Here it is a sample source block:
+Here is a sample source block:
 
 ``` org
 #+BEGIN_SRC python :tangle "python.py"

--- a/docs/manual-language-docs/lsp-yang.md
+++ b/docs/manual-language-docs/lsp-yang.md
@@ -17,7 +17,7 @@ since [`yang-mode`][2] is the supported major mode.
 (add-hook 'yang-mode-hook 'lsp)
 ```
 
-It recommended to add following configuration for the `yang.settings` file,
+It is recommended to add the following configuration for the `yang.settings` file,
 which resides at the user/project/workspace root, to be validated via
 [`lsp-json`][5]. This may be automated by `lsp-yang` in later stages.
 

--- a/docs/page/faq.md
+++ b/docs/page/faq.md
@@ -27,7 +27,7 @@ The highest number is highest priority. Note this is the opposite of [Unix prior
 You may create `dir-local` for each of the projects and specify list of `lsp-enabled-clients`. This will narrow the list of the clients that are going to be tested for the project.
 
 ---
-### :grey_question: The completion does not work fine and inserts arguments and placeholders, what I am doing wrong?
+### :grey_question: The completion does not work fine and inserts arguments and placeholders, what am I doing wrong?
 
 make sure you have installed `yasnippet` and you have `yasnippet` minor mode enabled.
 

--- a/docs/page/installation.md
+++ b/docs/page/installation.md
@@ -3,7 +3,7 @@ root_file: docs/page/installation.md
 ---
 # Installation
 
-You need first `lsp-mode`, that is a Emacs client for an LSP server.
+You need first `lsp-mode`, which is an Emacs client for an LSP server.
 Then you need to install the specific LSP server for your language.
 Finally, call `M-x lsp` or use the corresponding major mode hook to autostart the server.
 

--- a/docs/page/main-features.md
+++ b/docs/page/main-features.md
@@ -96,7 +96,7 @@ You can also trigger format on save by setting the variable `lsp-format-buffer-o
 
 ## Debugger
 
-`lsp-mode` integrates with [dap-mode](https://emacs-lsp.github.io/dap-mode/) with implements the DAP(Debugger Adapter Protocol), for more information check the [`dap-mode` documentation](https://emacs-lsp.github.io/dap-mode/).
+`lsp-mode` integrates with [dap-mode](https://emacs-lsp.github.io/dap-mode/) which implements the DAP (Debugger Adapter Protocol), for more information check the [`dap-mode` documentation](https://emacs-lsp.github.io/dap-mode/).
 
 ![](../examples/lsp-dart-flutter-debug.gif)
 

--- a/docs/tutorials/debugging-clojure-script.md
+++ b/docs/tutorials/debugging-clojure-script.md
@@ -19,7 +19,7 @@ features check [Clojure Guide](clojure-guide.md).
 
 # Sample minimal configuration
 
-Here it is sample configuration based on the basic configuration in [Clojure Guide](clojure-guide.md).
+Here is a sample configuration based on the basic configuration in [Clojure Guide](clojure-guide.md).
 
 ``` emacs-lisp
 (require 'package)


### PR DESCRIPTION
## Summary

This PR fixes various English grammar mistakes and typos throughout the codebase.

Related issue: #4363

## Changes

### Grammar fixes

- "multiples languages" → "multiple languages"
- "Here it is a" / "Here it is sample" → "Here is a" / "Here is a sample"
- "Enabled/disable" → "Enable/disable" (verb consistency)
- "it's references" → "its references" (possessive)
- "primary working" → "primarily working"
- "Tool for convert" → "Tool to convert"
- "In order that to work the files has to be" → "For this to work, the files have to be" (subject-verb agreement)
- "It recommended to add following" → "It is recommended to add the following"
- "what I am doing wrong" → "what am I doing wrong"
- "that is a Emacs" → "which is an Emacs"
- "with implements the DAP" → "which implements the DAP"
- "documentation informations" → "documentation information"

### Typo fixes

- "json validaten" → "JSON validation"
- "wont" → "won't"
- "doesnt" → "doesn't"
- "cant" → "can't"