### PR TITLE
fix: Remove duplicate defface declarations in lsp-semantic-tokens.el

### DIFF
--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -117,7 +117,7 @@ Unless overridden by a more specific face association."
 
 (defface lsp-face-semhl-string
   '((t (:inherit font-lock-string-face)))
-  "Face used for keywords."
+  "Face used for strings."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-number
@@ -133,11 +133,6 @@ Unless overridden by a more specific face association."
 (defface lsp-face-semhl-operator
   '((t (:inherit font-lock-function-name-face)))
   "Face used for operators."
-  :group 'lsp-semantic-tokens)
-
-(defface lsp-face-semhl-namespace
-  '((t (:inherit font-lock-keyword-face)))
-  "Face used for namespaces."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-type
@@ -190,11 +185,6 @@ Unless overridden by a more specific face association."
 (defface lsp-face-semhl-macro
   '((t (:inherit font-lock-preprocessor-face)))
   "Face used for macros."
-  :group 'lsp-semantic-tokens)
-
-(defface lsp-face-semhl-variable
-  '((t (:inherit font-lock-variable-name-face)))
-  "Face used for variables."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-parameter


### PR DESCRIPTION
## Summary

- Remove duplicate `defface` declarations for `lsp-face-semhl-namespace` and `lsp-face-semhl-variable`
- Fix incorrect docstring for `lsp-face-semhl-string` ("keywords" → "strings")

Fixes #4846

## Changes

1. Removed duplicate `lsp-face-semhl-namespace` definition (kept the one with `font-lock-type-face :weight bold`)
2. Removed duplicate `lsp-face-semhl-variable` definition
3. Fixed `lsp-face-semhl-string` docstring from "Face used for keywords." to "Face used for strings."
