### PR TITLE
docs: update Helm LSP client name to kubernetes-helm in docs JSON

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -1406,7 +1406,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "helm",
+    "name": "kubernetes-helm",
     "full-name": "YAML (helm-ls)",
     "server-name": "helm-ls",
     "server-url": "https://github.com/mrjosh/helm-ls",


### PR DESCRIPTION
Fixes #4771

## Summary

- Add missing documentation file for Kubernetes Helm (helm-ls) language server
  - https://emacs-lsp.github.io/lsp-mode/page/lsp-kubernetes-helm.md
- Fix client name in `lsp-clients.json` from "helm" to "kubernetes-helm" to match mkdocs.yml reference

<img width="3024" height="1706" alt="CleanShot 2026-01-04 at 21 09 24@2x" src="https://github.com/user-attachments/assets/cd957473-ab06-4d02-9a04-e4e4646f9474" />

## Changes

- `docs/lsp-clients.json`: Changed client name from "helm" to "kubernetes-helm"
