### PR TITLE
feat(deno): add lsp-install-server support for Deno LSP

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 9.0.1
+  * Add ~lsp-install-server~ support for Deno LSP via npm.
   * Add diagnostic and formatter custom settings for [[https://github.com/rcjsuen/dockerfile-language-server-nodejs][Dockerfile language server]].
   * Fix "Eager macro-expansion failure" errors with lsp-interface pcase patterns (see #4723)
   * Add support for [[https://github.com/Myriad-Dreamin/tinymist][Typst (Tinymist)]] language server.

--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -991,7 +991,14 @@ particular FILE-NAME and MODE."
 
 
 (defgroup lsp-deno nil
-  "LSP support for the Deno language server."
+  "LSP support for the Deno language server.
+
+Deno can be installed via `lsp-install-server' or manually:
+- Shell: curl -fsSL https://deno.land/install.sh | sh
+- Homebrew: brew install deno
+
+Note: npm installation is not recommended due to performance degradation.
+See URL `https://docs.deno.com/runtime/getting_started/installation/'."
   :group 'lsp-mode
   :link '(url-link "https://deno.land/"))
 
@@ -1085,15 +1092,25 @@ Examples: `./import-map.json',
                                                  lsp-clients-deno-enable-code-lens-references-all-functions))
                  :referencesAllFunctions ,(lsp-json-bool lsp-clients-deno-enable-code-lens-references-all-functions))))
 
+(lsp-dependency
+ 'deno
+ `(:system ,lsp-clients-deno-server)
+ '(:npm :package "deno" :path "deno"))
+
 (lsp-register-client
  (make-lsp-client :new-connection
                   (lsp-stdio-connection (lambda ()
-                                          (cons lsp-clients-deno-server
-                                                lsp-clients-deno-server-args)))
+                                          `(,(lsp-package-path 'deno)
+                                            ,@lsp-clients-deno-server-args)))
                   :initialization-options #'lsp-clients-deno--make-init-options
                   :priority -5
                   :activation-fn #'lsp-typescript-javascript-tsx-jsx-activate-p
-                  :server-id 'deno-ls))
+                  :server-id 'deno-ls
+                  :download-server-fn (lambda (_client callback error-callback _update?)
+                                        (lsp-package-ensure
+                                         'deno
+                                         callback
+                                         error-callback))))
 
 
 


### PR DESCRIPTION
## Summary

- Add `lsp-install-server` support for Deno LSP via npm fallback
- Enhance `lsp-deno` docstring with installation guidance
- Update `lsp-register-client` to use `lsp-package-path` for executable resolution

Closes #4174

## Motivation

Users requested the ability to install Deno LSP via `M-x lsp-install-server`.
While the official Deno documentation recommends shell-based installation for better performance, providing npm as a fallback option improves accessibility for users who prefer lsp-mode's integrated server management.

## Changes

1. **`lsp-dependency` registration**: Added `lsp-dependency` with `:system` (respects `lsp-clients-deno-server` customization) and `:npm` fallback
2. **`lsp-register-client` update**: Changed `:new-connection` to use `lsp-package-path` for proper executable resolution
3. **`:download-server-fn`**: Added handler to enable `lsp-install-server` functionality
4. **Documentation**: Enhanced `lsp-deno` defgroup docstring with installation options and performance note
