### PR TITLE
docs: fix missing config on docs page

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -1381,6 +1381,7 @@
   },
   {
     "name": "wasm-language-tools",
+    "common-group-name": "wat",
     "full-name": "WebAssembly",
     "server-name": "wat_server",
     "server-url": "https://github.com/g-plane/wasm-language-tools",


### PR DESCRIPTION
"Available configurations" section is empty on https://emacs-lsp.github.io/lsp-mode/page/lsp-wasm-language-tools/ and this PR fixes this.