### PR TITLE
fix(lsp-roslyn): Return command-process for PID tracking

### DIFF
--- a/clients/lsp-roslyn.el
+++ b/clients/lsp-roslyn.el
@@ -176,7 +176,7 @@ creates another process connecting to the named pipe it specifies."
         (set-process-query-on-exit-flag (get-buffer-process stderr-buffer) nil))
       (set-process-query-on-exit-flag command-process nil)
       (set-process-query-on-exit-flag communication-process nil)
-      (cons communication-process communication-process))))
+      (cons communication-process command-process))))
 
 (defun lsp-roslyn--uri-to-path (uri)
   "Convert a URI to a file path, without unhexifying."


### PR DESCRIPTION
## Summary

- Fix `lsp-roslyn--connect` to return `(cons communication-process command-process)` instead of `(cons communication-process communication-process)`

## Problem

`lsp-describe-session` displays `csharp-roslyn:nil` instead of showing the actual server PID. This happens because:

1. `lsp-roslyn--connect` returns `(cons communication-process communication-process)`
2. lsp-mode expects `(cons proc cmd-proc)` where `cmd-proc` is the actual server process
3. The `communication-process` is a network process (named pipe connection) which doesn't have a PID
4. The `command-process` (the dotnet process running Roslyn) has the actual PID but was being discarded

## Solution

Return `command-process` as the second element of the cons cell so lsp-mode can properly track and display the server PID.

## Test plan

1. Open a C# file with lsp-roslyn
2. Run `M-x lsp-describe-session`
3. Verify it shows `csharp-roslyn:<PID>` with an actual number instead of `csharp-roslyn:nil`