### PR TITLE
Fix webpage Erlang docs references

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,8 @@ nav:
     - Emacs Lisp (Ellsp): https://github.com/elisp-lsp/ellsp
     - Emacs Lisp (Elsa): https://github.com/emacs-elsa/Elsa
     - Emmet: page/lsp-emmet.md
-    - Erlang: page/lsp-erlang.md
+    - Erlang (Erlang Language Server): page/lsp-erlang-ls.md
+    - Erlang (ELP): page/lsp-erlang-elp.md
     - ESLint: page/lsp-eslint.md
     - F#: page/lsp-fsharp.md
     - Fortran: page/lsp-fortran.md


### PR DESCRIPTION
Tried running `make docs` locally, and noticed that the Erlang docs are separated into two doc files. Changed to use the correct references in the `mkdocs.yml` file, so the web page will have the correct links when generated. 

If we check the web site for the relevant Erlang lsps, they are there, just not linked to from anywhere atm.
https://emacs-lsp.github.io/lsp-mode/page/lsp-erlang-ls/
https://emacs-lsp.github.io/lsp-mode/page/lsp-erlang-elp/

Fixes #4874


EDIT: The test failures seem unrelated? It seems like they are failing in main as well.