### PR TITLE
Check for an empty ConfigurationItem list

### DIFF
--- a/test/lsp-common-test.el
+++ b/test/lsp-common-test.el
@@ -187,6 +187,13 @@
     (cl-assert (equal (ht-get result "prop2") "20"))
     (cl-assert (equal (ht-get result "prop1") "10"))))
 
+(ert-deftest lsp--build-workspace-configuration-response-test-no-section-given ()
+  (-let* ((request (lsp-make-configuration-params
+                    :items (list (lsp-make-configuration-item :section nil))))
+          (result (aref (lsp--build-workspace-configuration-response request) 0)))
+    (cl-assert (equal (hash-table-count (ht-get result "section1")) 1))
+    (cl-assert (equal (hash-table-count (ht-get (ht-get result "section2") "nested")) 2))))
+
 (defcustom lsp-prop3 nil
   "docs"
   :group 'lsp-python


### PR DESCRIPTION
If no ConfigurationItems are passed in the ‘workspace/configuration’ request
by the server, send the settings for all clients instead.

This change is needed to use the grammar checker `Harper`.