### PR TITLE
feat: Add support for fortitude, Fortran linter

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 9.0.1
+  * Add support for [[https://github.com/PlasmaFAIR/fortitude][Fortitude]] (Fortran)
   * Clear diagnostics after workspace edits to prevent stale diagnostics at wrong line numbers after operations like ~lsp-organize-imports~ (see [[https://github.com/emacs-lsp/lsp-mode/issues/3888][#3888]])
   * Add support for ~workspace/willRenameFiles~ and ~workspace/didRenameFiles~ when using ~vc-git-rename-file~.
   * Fix documentation to show unevaluated expressions for file/directory defcustom defaults instead of machine-specific paths (see [[https://github.com/emacs-lsp/lsp-mode/issues/4924][#4924]])

--- a/clients/lsp-fortitude.el
+++ b/clients/lsp-fortitude.el
@@ -1,0 +1,77 @@
+;;; lsp-fortitude.el --- fortitude lsp support             -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025 Peter Hill
+;;
+;; Author: Peter Hill <peter.hill@york.ac.uk>
+;; Keywords: language tools
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Fortitude LSP Client for the Fortran programming language
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-fortitude nil
+  "LSP support for Fortran, using fortitude's Fortran Language Server."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/PlasmaFAIR/fortitude"))
+
+(defcustom lsp-fortitude-server-command '("fortitude" "server")
+  "Command to start fortitude lsp."
+  :risky t
+  :type '(repeat string)
+  :group 'lsp-fortitude)
+
+(defcustom lsp-fortitude-fortitude-args '()
+  "Arguments, passed to fortitude."
+  :risky t
+  :type '(repeat string)
+  :group 'lsp-fortitude)
+
+(defcustom lsp-fortitude-log-level "error"
+  "Tracing level."
+  :type '(choice (const "debug")
+                 (const "error")
+                 (const "info")
+                 (const "off")
+                 (const "warn"))
+  :group 'lsp-fortitude)
+
+(defcustom lsp-fortitude-advertize-fix-all t
+  "Whether to report ability to handle source.fixAll actions."
+  :type 'boolean
+  :group 'lsp-fortitude)
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection
+                   (lambda () (append lsp-fortitude-server-command lsp-fortitude-fortitude-args)))
+  :activation-fn (lsp-activate-on "fortran")
+  :server-id 'fortitude
+  :priority -2
+  :add-on? t
+  :initialization-options
+  (lambda ()
+    (list :settings
+          (list :logLevel lsp-fortitude-log-level
+                :fixAll (lsp-json-bool lsp-fortitude-advertize-fix-all))))))
+
+(lsp-consistency-check lsp-fortitude)
+
+(provide 'lsp-fortitude)
+;;; lsp-fortitude.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -361,6 +361,14 @@
     "debugger": "Yes (netcoredbg)"
   },
   {
+    "name": "fortitude",
+    "full-name": "Fortran",
+    "server-name": "fortitude",
+    "server-url": "https://github.com/PlasmaFAIR/fortitude",
+    "installation": "pip install fortitude-lint",
+    "debugger": "Not available"
+  },
+  {
     "name": "fortran",
     "full-name": "Fortran",
     "server-name": "fortls",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -179,7 +179,7 @@ As defined by the Language Server Protocol 3.16."
      lsp-clojure lsp-cmake lsp-cobol lsp-credo lsp-crystal lsp-csharp lsp-c3
      lsp-css lsp-copilot lsp-crates lsp-cucumber lsp-cypher lsp-d lsp-dart
      lsp-dhall lsp-docker lsp-dockerfile lsp-earthly lsp-elixir lsp-elm lsp-emmet
-     lsp-erlang lsp-eslint lsp-fortran lsp-futhark lsp-fsharp lsp-gdscript
+     lsp-erlang lsp-eslint lsp-fortitude lsp-fortran lsp-futhark lsp-fsharp lsp-gdscript
      lsp-gleam lsp-glsl lsp-go lsp-golangci-lint lsp-grammarly lsp-graphql
      lsp-groovy lsp-hack lsp-haskell lsp-haxe lsp-idris lsp-java lsp-javascript
      lsp-just lsp-jq lsp-json lsp-kotlin lsp-kubernetes-helm lsp-latex lsp-lisp

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,8 @@ nav:
     - Erlang (ELP): page/lsp-erlang-elp.md
     - ESLint: page/lsp-eslint.md
     - F#: page/lsp-fsharp.md
-    - Fortran: page/lsp-fortran.md
+    - Fortran (fortls): page/lsp-fortran.md
+    - Fortran (fortitude): page/lsp-fortitude.md
     - Futhark: page/lsp-futhark.md
     - GDScript: page/lsp-gdscript.md
     - GitHub Copilot: page/lsp-copilot.md


### PR DESCRIPTION
See https://github.com/PlasmaFAIR/fortitude

- feat: Add lsp-fortitude.el, based on lsp-ruff.el

- docs: Distinguish between Fortran clients

---

The support for LSP server in fortitude was added in the latest version (0.8.0). Is there something we need to do here to gate on/check the version of `fortitude`? Or should I just make a note of it in the docs for the `lsp-fortitude` group?