### PR TITLE
feat: Add configurable symlink following and depth limit for file watchers

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 9.0.1
+  * Add ~lsp-file-watch-follow-symlinks~ (default ~within-root~) and ~lsp-file-watch-max-depth~ (default ~100~) to control symlink handling and recursion depth during file watching. *Breaking change*: symlinks pointing outside the workspace root are no longer followed by default, preventing Emacs freezes (set ~lsp-file-watch-follow-symlinks~ to ~t~ to restore previous behavior). See [[https://github.com/emacs-lsp/lsp-mode/issues/4973][#4973]], [[https://github.com/emacs-lsp/lsp-mode/issues/4287][#4287]]
   * Clear diagnostics after workspace edits to prevent stale diagnostics at wrong line numbers after operations like ~lsp-organize-imports~ (see [[https://github.com/emacs-lsp/lsp-mode/issues/3888][#3888]])
   * Add support for ~workspace/willRenameFiles~ and ~workspace/didRenameFiles~ when using ~vc-git-rename-file~.
   * Fix documentation to show unevaluated expressions for file/directory defcustom defaults instead of machine-specific paths (see [[https://github.com/emacs-lsp/lsp-mode/issues/4924][#4924]])

--- a/docs/page/file-watchers.md
+++ b/docs/page/file-watchers.md
@@ -19,3 +19,32 @@ If you have problems with file watchers, first check what folders are being watc
 - Increase the file watch warning threshold, the default is `1000`: `(setq lsp-file-watch-threshold 2000)`
 - If the folder is some kind of cache folder or something that should always be excluded for everyone, consider [opening a pull request](https://github.com/emacs-lsp/lsp-mode/pulls) or [filing a bug](https://github.com/emacs-lsp/lsp-mode/issues) to add to the [common regex](https://github.com/emacs-lsp/lsp-mode/blob/1b13d7c1b39aaad12073095ef7719952568c45db/lsp-mode.el#L340).
 - As a last resort, disable file watchers with `(setq lsp-enable-file-watchers nil)` (you may use dir-locals).
+
+## Symlink Handling
+
+By default, `lsp-mode` follows symlinks only when their target is within the workspace root directory. This prevents Emacs from freezing when symlinks point to large external directories (e.g., `/usr/include`).
+
+You can control this behavior with `lsp-file-watch-follow-symlinks`:
+
+```emacs-lisp
+;; Never follow symlinks (safest, treats symlinks as leaf directories)
+(setq lsp-file-watch-follow-symlinks nil)
+
+;; Follow symlinks only within workspace root (default, recommended)
+(setq lsp-file-watch-follow-symlinks 'within-root)
+
+;; Always follow symlinks (legacy behavior, may cause freezes)
+(setq lsp-file-watch-follow-symlinks t)
+```
+
+## Directory Depth Limit
+
+To prevent issues with deeply nested directory structures, `lsp-mode` limits recursion depth when setting up file watchers. The default limit is 100 levels.
+
+```emacs-lisp
+;; Adjust the depth limit (default: 100)
+(setq lsp-file-watch-max-depth 50)
+
+;; Disable depth limit (not recommended)
+(setq lsp-file-watch-max-depth nil)
+```


### PR DESCRIPTION
## Summary

- Add `lsp-file-watch-follow-symlinks` (`nil` / `'within-root` / `t`) to control whether symlinks are followed during file watching. Default `'within-root` follows symlinks only when the resolved target is inside the workspace root, preventing Emacs freezes caused by symlinks to large external directories (e.g., `/usr/include`).
- Add `lsp-file-watch-max-depth` (default `100`) to cap recursion depth during watcher setup, preventing stack overflow in deeply nested directory structures.
- Refactor `lsp--all-watchable-directories` into a policy-dispatched function with cycle detection via a visited hash table keyed on truenames.
- Fix runtime callback (`lsp--folder-watch-callback`) to resolve event paths to truenames before file enumeration, ensuring the `within-root` filter compares paths in the same namespace.
- Store truename in `lsp-watch` `root-directory` at the registration site (`lsp--server-register-capability`), eliminating redundant re-resolution in the callback.
- Replace destructive `nconc` with `append` in `lsp--watchable-directories-recurse` for long-term safety.

## Breaking change

Symlinks pointing outside the workspace root are **no longer followed by default**. To restore previous behavior:

```lisp
(setq lsp-file-watch-follow-symlinks t)
```

Additionally, `lsp-watch-root-directory` now always returns a truename-resolved path (previously it could return a raw path with unresolved symlink components).

## Motivation

- Fixes #4973 — lsp-watch-root-folder follows symlinks that point outside the root folder
- Fixes #4287 — excessive-lisp-nesting

## Implementation details

### Callback path-type consistency

The runtime callback `lsp--folder-watch-callback` enumerates files in newly-created directories via `directory-files-recursively`. Under the `within-root` policy, these file paths are filtered using `string-prefix-p` against the workspace root.

Previously, `directory-files-recursively` was called on the raw event path (`file-name`), which could contain unresolved symlink segments. The filter compared these raw paths against a truename-resolved root — a namespace mismatch that could silently drop legitimate file events when the workspace was accessed through a symlink alias.

The fix resolves `file-name` to its truename before enumeration, ensuring all paths share the same resolved prefix.

### Truename storage in `lsp-watch`

`lsp--server-register-capability` previously stored the raw folder path in `lsp-watch :root-directory`. The callback compensated by calling `(file-truename (lsp-watch-root-directory watch))` on every invocation. Now the truename is stored at construction time, and the callback reads it directly.

Note: The `created-watches` hash table key remains the raw folder path (intentional — it must match `folder->servers` key convention for `cl-set-difference` and `lsp--cleanup-hanging-watches`).

## Test plan

- 24 passing tests covering all three symlink policies, depth limits (0, 2, nil), circular symlinks, dangling symlinks, root-as-symlink, file-truename error handling, runtime callback filtering, ignored directory interactions, symlink-alias event paths (inside and outside root), and `lsp-watch-root-folder` truename storage verification
- Byte-compilation clean (0 errors, 0 new warnings)
- 5 pre-existing test failures (confirmed same on master)
- Performance: `file-in-directory-p` replaced with `string-prefix-p` on pre-resolved truenames