### PR TITLE
fix: zls download support zigtools.org

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 9.0.1
+  * Fix ~lsp-zig--zls-url~ to use the new zigtools.org url (see: [[https://github.com/emacs-lsp/lsp-mode/issues/4445][#4445]])
   * Fix ~lsp--npm-dependency-path~ to return correct executable path and improve error message
   * Add support for [[https://github.com/PlasmaFAIR/fortitude][Fortitude]] (Fortran)
   * Clear diagnostics after workspace edits to prevent stale diagnostics at wrong line numbers after operations like ~lsp-organize-imports~ (see [[https://github.com/emacs-lsp/lsp-mode/issues/3888][#3888]])


### PR DESCRIPTION
This PR should resolve the issue: https://github.com/emacs-lsp/lsp-mode/issues/4445.

It adds a new function to get the latest version tag from the GitHub api for ZLS and then formats the download URL for ZLS to use the "new" zigtools.org download page. If any of these changes are improperly formatted or need to be done differently please let me know and I'd be glad to fix it!