### PR TITLE
Fix lsp-xml-bin-download-url to use correct url

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -464,3 +464,4 @@
   - Removed all synchronous calls from the server startup.
   - Improved multi-folder support.
   - added backends for: Bash, C++, CSS, Dart, Elixir, Fortran, Go, Groovy, HTML, Javascript/Typescript, Javascript/Typescript, Ocaml, PHP, Python, Ruby, Rust, Vue, Flow
+  - Fix lsp-xml-bin-download-url to use correct release url as specified at [[https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases][GitHub Docs]]

--- a/clients/lsp-xml.el
+++ b/clients/lsp-xml.el
@@ -341,7 +341,7 @@ The value for `enabled' can be always, never or onValidSchema."
 
 (defcustom lsp-xml-bin-download-url
   ;; This is the version with `latest` tag
-  (format "https://github.com/redhat-developer/vscode-xml/releases/download/latest/%s.zip"
+  (format "https://github.com/redhat-developer/vscode-xml/releases/latest/download/%s.zip"
           lsp-xml-bin-base-name)
   "Automatic download url for lsp-xml's native binary."
   :type 'string


### PR DESCRIPTION
To download a file from the release tagged as latest you can use the format of /releases/latest/download/<FILE>.  This is specified in [github's docs](https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases) and worked when I used it, whereas the previous format did not work (resulting in a 6 byte corrupted lemminx-linux.zip).

Except for a period of 2 weeks last year, the syntax /releases/latest/download/<FILE> has been referenced in the github docs for as far back as I could see; 5 years (first in docs repo, then in archive.org).

Last September somebody pushed the change from the correct form to the incorrect [/releases/download/latest/<FILE>](https://github.com/github/docs/commit/a4e626dd8552e44cbd966d9035f017a0c85b522a). When this incorrect contribution was [corrected](https://github.com/github/docs/commit/a9ee8cb406ac3160924168a19ee29b3e753bca15) 2 weeks later the contributor [mentioned](https://github.com/github/docs/pull/40696#issuecomment-3374032634) that "copilot" got it wrong. 

When looking for more information about the url in lsp-mode I found a commit from [2024](https://github.com/emacs-lsp/lsp-mode/commit/09f548c93477e2c57cf95c54c0beed577413c4df). This was a year before the mistake in github docs, and the commit covered the entire function of lsp-xml-bin-download-url, meaning that there may never have been the correct endpoint, and therefore, was never a working binary download. 

If somebody knows if /releases/download/latest used to work then I would be interested to hear about it. I could not find any reference to /releases/download/latest except for as a desired format in a popular stackoverflow [question](https://stackoverflow.com/questions/24987542/is-there-a-link-to-github-for-downloading-a-file-in-the-latest-release-of-a-repo). Based on the frequency of this mistake I assume the aforementioned "incorrect" endpoint actually may have worked at some point, I just couldn't find any evidence of it doing so. I can only assume that LLM's have consistently confabulated the incorrect form as the right form. 

In any case,  lsp-install-server for xmlls now works. 

Many thanks to all the maintainers of lsp-mode. You are all fantastic. 