### PR TITLE
Handle multiple configs in lsp-generate-settings

### DIFF
--- a/scripts/lsp-generate-settings.el
+++ b/scripts/lsp-generate-settings.el
@@ -58,8 +58,13 @@ FILE-NAME is path to package.json vscode manifest."
          cl-rest
          (assoc 'configuration)
          cl-rest
-         (assoc 'properties)
-         cl-rest
+         (funcall
+          (lambda (configs)
+            (if (alist-get 'properties configs)
+                (list configs)
+              configs)))
+         (--map (alist-get 'properties it))
+         (apply #'append)
          (-keep
           (-lambda ((prop-name . (&alist 'type 'default 'enum 'description 'markdownDescription)))
             (let ((type (lsp--convert-type type enum))


### PR DESCRIPTION
Some VSCode language server `package.json` files have `configuration` as an array of objects, it seems, whereas the code in `lsp-generate-settings.el` was expecting it to be a single object. [vscode-swift](https://github.com/swiftlang/vscode-swift/blob/ae9a1c1e77d257883a60818d39e011e1156775c5/package.json#L495) is one example. To get that one converted into defcustoms, I made the change in this PR so that either a single object or a list of objects are handled. I distinguished the cases by checking if the `configuration` key has a `properties` key. If it does, I add an enclosing list. Otherwise, I assume it's a list of configs. Then I grab the `properties` key from each config in the list, and concatenate the alists through `append`.