### PR TITLE
Remove mouse highlight in log buffer

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3399,7 +3399,6 @@ TYPE can either be `incoming' or `outgoing'"
                     "Params: ")
                   (lsp--log-font-lock-json (json-encode body))
                   "\n\n\n"))
-    (setq str (propertize str 'mouse-face 'highlight 'read-only t))
     (insert str)))
 
 (defvar-local lsp--log-io-ewoc nil)


### PR DESCRIPTION
I find the mouse highlight in the log buffer particularly annoying as it blinks on and off while scrolling in the buffer. I also do not see the point of it, clicking on log messages doesn’t seem to do anything, unless I’m missing something. So I would suggest to remove it.
The `read-only` property seems useless as well as the whole buffer is read only anyway.