### PR TITLE
fix: changing lsp-zig path defcustoms default to nil

### DIFF
--- a/clients/lsp-zig.el
+++ b/clients/lsp-zig.el
@@ -165,42 +165,42 @@ If no extra argument is given `record_session_path` is used as the default path.
   :group 'lsp-zig
   :type 'string)
 
-(defcustom lsp-zig-builtin-path ""
+(defcustom lsp-zig-builtin-path nil
   "Path to `builtin'; useful for debugging, automatically set if let null."
   :group 'lsp-zig
-  :type 'string)
+  :type '(choice (const nil) string))
 
-(defcustom lsp-zig-zig-lib-path ""
+(defcustom lsp-zig-zig-lib-path nil
   "Zig library path.
 e.g. `/path/to/zig/lib/zig`, used to analyze std library imports."
   :group 'lsp-zig
-  :type 'string)
+  :type '(choice (const nil) string))
 
-(defcustom lsp-zig-zig-exe-path ""
+(defcustom lsp-zig-zig-exe-path nil
   "	Zig executable path.
 e.g. /path/to/zig/zig, used to run the custom build runner.  If null, zig is
 looked up in PATH.  Will be used to infer the zig standard library path if none
 is provided."
   :group 'lsp-zig
-  :type 'string)
+  :type '(choice (const nil) string))
 
-(defcustom lsp-zig-build-runner-path ""
+(defcustom lsp-zig-build-runner-path nil
   "Path to the `build_runner.zig` file provided by zls.
 null is equivalent to `${executable_directory}/build_runner.zig`."
   :group 'lsp-zig
-  :type 'string)
+  :type '(choice (const nil) string))
 
-(defcustom lsp-zig-global-cache-path ""
+(defcustom lsp-zig-global-cache-path nil
   "Path to a directory that will be used as zig's cache.
 null is equivalent to `${KnownFolders.Cache}/zls`."
   :group 'lsp-zig
-  :type 'string)
+  :type '(choice (const nil) string))
 
-(defcustom lsp-zig-build-runner-global-cache-path ""
+(defcustom lsp-zig-build-runner-global-cache-path nil
   "Path to a directory that will be used as the global cache path when executing
 a projects build.zig.  null is equivalent to the path shown by `zig env`."
   :group 'lsp-zig
-  :type 'string)
+  :type '(choice (const nil) string))
 
 (defcustom lsp-zig-completions-with-replace nil
   "Completions confirm behavior.


### PR DESCRIPTION
This PR should resolve the issue: https://github.com/emacs-lsp/lsp-mode/issues/4998

The linked issue already describes what needs to be fixed in that the following variables need to be defaulted to `nil` to satisfy the assumptions of ZLS:
- lsp-zig-builtin-path
- lsp-zig-zig-lib-path
- lsp-zig-zig-exe-path
- lsp-zig-build-runner-path
- lsp-zig-global-cache-path
- lsp-zig-build-runner-global-cache-path

The changes in this PR just default this defcustoms to nil and all the type to be either `nil` or `string` as to not break the existing logic of setting the types to `string`