### PR TITLE
ZLS build-on-save diagnostics fix

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8138,7 +8138,7 @@ SESSION is the active session."
                       :buffers (list (lsp-current-buffer))
                       :host-root (file-remote-p root)))
           ((&lsp-cln 'server-id 'environment-fn 'new-connection 'custom-capabilities
-                     'multi-root 'initialized-fn) client)
+                     'initialized-fn) client)
           ((proc . cmd-proc) (funcall
                               (or (plist-get new-connection :connect)
                                   (user-error "Client %s is configured incorrectly" client))
@@ -8176,14 +8176,13 @@ SESSION is the active session."
               :workDoneToken "1")
         (when lsp-server-trace
           (list :trace lsp-server-trace))
-        (when multi-root
-          (->> workspace-folders
+        (->> (or workspace-folders (list root))
                (-distinct)
                (-map (lambda (folder)
                        (list :uri (lsp--path-to-uri folder)
                              :name (f-filename folder))))
                (apply 'vector)
-               (list :workspaceFolders))))
+               (list :workspaceFolders)))
        (-lambda ((&InitializeResult :capabilities))
          (pcase server-id
            ;; we know that Rust Analyzer will send {} which will be parsed as null


### PR DESCRIPTION
Previously workspaceFolders was only included when the server was registered as multi-root. Servers like ZLS depend on it to locate build files and enable features like build-on-save which silently failed without it.

Falls back to the project root when no explicit workspace folders are registered in the session. This matches behaviour similar to other editors which send workspaceFolders unconditionally, which is what allows ZLS to function as intended.

This addresses #4516 

