### PR TITLE
feat: append LSP diagnostic codes to flymake messages

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,7 @@
 * Changelog
 ** Unreleased 10.0.1
+  * Add ~lsp-diagnostics-flymake-message-formatter~ defcustom for customizing how an LSP diagnostic is rendered into the flymake text string; the default appends the code in brackets, and users can suppress it, prepend the source tool, add a severity prefix, etc. (see: [[https://github.com/emacs-lsp/lsp-mode/pull/5036][#5036]]).
+  * Append the LSP diagnostic code (e.g. ~reportUnusedExpression~, ~E501~) to flymake messages, mirroring what flycheck already exposes via ~flycheck-error-id~ (see: [[https://github.com/emacs-lsp/lsp-mode/pull/5036][#5036]]).
   * Add support for [[https://github.com/tailwindlabs/tailwindcss-intellisense][Tailwind CSS]] language server.
   * Overhaul ~lsp-face-semhl-*~ faces to cover the full LSP 3.17 semantic token spec (see: [[https://github.com/emacs-lsp/lsp-mode/issues/5040][#5040]])
     - Add dedicated faces ~lsp-face-semhl-enum-member~, ~lsp-face-semhl-modifier~, ~lsp-face-semhl-decorator~.

--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -290,11 +290,14 @@ See https://github.com/emacs-lsp/lsp-mode."
   (funcall lsp-diagnostics--flymake-report-fn
            (-some->> (lsp-diagnostics t)
              (gethash (lsp--fix-path-casing buffer-file-name))
-             (--map (-let* (((&Diagnostic :message :severity?
+             (--map (-let* (((&Diagnostic :message :severity? :code?
                                           :range (range &as &Range
                                                         :start (&Position :line start-line :character)
                                                         :end (&Position :line end-line))) it)
-                            ((start . end) (lsp--range-to-region range)))
+                            ((start . end) (lsp--range-to-region range))
+                            (text (if code?
+                                      (format "%s [%s]" message code?)
+                                    message)))
                       (when (= start end)
                         (if-let* ((region (flymake-diag-region (current-buffer)
                                                               (1+ start-line)
@@ -312,7 +315,7 @@ See https://github.com/emacs-lsp/lsp-mode."
                                                  (1 :error)
                                                  (2 :warning)
                                                  (t :note))
-                                               message))))
+                                               text))))
            ;; This :region keyword forces flymake to delete old diagnostics in
            ;; case the buffer hasn't changed since the last call to the report
            ;; function. See https://github.com/joaotavora/eglot/issues/159

--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -263,6 +263,37 @@ See https://github.com/emacs-lsp/lsp-mode."
 (defvar flymake-mode)
 (defvar-local lsp-diagnostics--flymake-report-fn nil)
 
+(defun lsp-diagnostics-flymake-default-message-formatter (diag)
+  "Default formatter for the flymake text of an LSP `Diagnostic' DIAG.
+Returns the message, appending the code in brackets when present, e.g.
+\"foo is unused [reportUnusedExpression]\"."
+  (-let (((&Diagnostic :message :code?) diag))
+    (if code?
+        (format "%s [%s]" message code?)
+      message)))
+
+(defcustom lsp-diagnostics-flymake-message-formatter
+  #'lsp-diagnostics-flymake-default-message-formatter
+  "Function used to build the flymake text string for an LSP diagnostic.
+
+Flymake stores a single string per diagnostic
+(`flymake-diagnostic-text'), so any presentation choice (whether to
+append the rule code, the source, severity prefix, etc.) must be made
+before the `flymake-diagnostic' is constructed.  This hook provides the
+place to make that choice.
+
+Called with one argument, the LSP `Diagnostic' plist (with fields such
+as `:message', `:code?', `:source?', `:severity?', `:tags?').  Must
+return a string.
+
+The default `lsp-diagnostics-flymake-default-message-formatter' appends
+`[code]' when the diagnostic carries one and returns the bare message
+otherwise.  Override to suppress the code, prepend the source, or
+reformat the message in any other way."
+  :type 'function
+  :group 'lsp-diagnostics
+  :package-version '(lsp-mode . "9.1.0"))
+
 (defun lsp-diagnostics--flymake-setup ()
   "Setup flymake."
   (setq lsp-diagnostics--flymake-report-fn nil)
@@ -290,18 +321,16 @@ See https://github.com/emacs-lsp/lsp-mode."
   (funcall lsp-diagnostics--flymake-report-fn
            (-some->> (lsp-diagnostics t)
              (gethash (lsp--fix-path-casing buffer-file-name))
-             (--map (-let* (((&Diagnostic :message :severity? :code?
+             (--map (-let* (((&Diagnostic :severity?
                                           :range (range &as &Range
                                                         :start (&Position :line start-line :character)
                                                         :end (&Position :line end-line))) it)
                             ((start . end) (lsp--range-to-region range))
-                            (text (if code?
-                                      (format "%s [%s]" message code?)
-                                    message)))
+                            (text (funcall lsp-diagnostics-flymake-message-formatter it)))
                       (when (= start end)
                         (if-let* ((region (flymake-diag-region (current-buffer)
-                                                              (1+ start-line)
-                                                              character)))
+                                                               (1+ start-line)
+                                                               character)))
                             (setq start (car region)
                                   end (cdr region))
                           (lsp-save-restriction-and-excursion

--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -292,7 +292,7 @@ otherwise.  Override to suppress the code, prepend the source, or
 reformat the message in any other way."
   :type 'function
   :group 'lsp-diagnostics
-  :package-version '(lsp-mode . "9.1.0"))
+  :package-version '(lsp-mode . "10.0.1"))
 
 (defun lsp-diagnostics--flymake-setup ()
   "Setup flymake."


### PR DESCRIPTION
Currently, `lsp-diagnostics--flymake-update-diagnostics` extracts `:message` and `:severity?` from each LSP diagnostic but silently drops `:code?`. As a result, flymake displays messages like:

```text
"variable_XYZ" is possibly unbound
```

without the diagnostic rule name that the language server also provides.

This patch binds `:code?` and appends it to the message text when present:

```text
"variable_XYZ" is possibly unbound [reportPossiblyUnbound]
```

This is a small but valuable change. The diagnostic code is the primary handle users need to:
- search for the error online
- look it up in the language server's documentation
- write a precise inline suppression comment (e.g. `# pyright: ignore[reportPossiblyUnbound]`)

Without the code, users must guess the rule name. The fix is a two-line change: bind `:code?` in the existing `-let*` destructuring and conditionally append `[code]` to the message.

The code field is optional in the LSP spec, so the format falls back gracefully to the plain message when absent.