### PR TITLE
refactor(semantic-tokens): overhaul `lsp-face-semhl-*` family for LSP 3.17

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,13 @@
 * Changelog
 ** Unreleased 10.0.1
+  * Overhaul ~lsp-face-semhl-*~ faces to cover the full LSP 3.17 semantic token spec (see: [[https://github.com/emacs-lsp/lsp-mode/issues/5040][#5040]])
+    - Add dedicated faces ~lsp-face-semhl-enum-member~, ~lsp-face-semhl-modifier~, ~lsp-face-semhl-decorator~.
+    - Fix ~enumMember~ mapping (was ~lsp-face-semhl-constant~, now ~lsp-face-semhl-enum-member~); default rendering unchanged by inheritance.
+    - Map the previously missing ~modifier~ (LSP 3.16) and ~decorator~ (LSP 3.17) token types in the default alist.
+    - Cascade the inheritance hierarchy through ~lsp-face-semhl-*~: setting ~lsp-face-semhl-type~ now propagates to ~struct~/~class~/~interface~/~enum~/~typeParameter~/~namespace~; setting ~lsp-face-semhl-variable~ propagates to ~property~/~event~/~parameter~; ~number~ cascades from ~lsp-face-semhl-constant~, ~regexp~ from ~lsp-face-semhl-string~. *Breaking-adjacent*: users who relied on the previous non-cascading behavior should now override the parent face.
+    - Trim non-spec entries from the default ~lsp-semantic-token-faces~ alist: ~enumConstant~, ~member~, ~label~, ~dependent~, ~concept~. Clangd keeps ~dependent~/~concept~/~member~ via ~:semantic-tokens-faces-overrides~; ~lsp-face-semhl-member~ and ~lsp-face-semhl-label~ remain publicly defined.
+    - Migrate ~lsp-terraform-semantic-token-faces~ to ~lsp-face-semhl-enum-member~.
+    - Migration note: users who previously customized ~lsp-face-semhl-constant~ specifically to recolor enum members should now customize ~lsp-face-semhl-enum-member~ instead. ~lsp-face-semhl-constant~ still cascades to ~number~ and the ~readonly~ token modifier. Users who customized ~lsp-face-semhl-type~ expecting it NOT to propagate to ~struct~/~class~/~interface~/~enum~/~typeParameter~/~namespace~ now need to customize those child faces directly.
 
 ** 10.0.0
   * Fix ~lsp-zig--zls-url~ to use the new zigtools.org url (see: [[https://github.com/emacs-lsp/lsp-mode/issues/4445][#4445]])

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ most popular Emacs packages like `company`, `flycheck` and `projectile`.
   - Consult integration - [consult-lsp](https://github.com/gagbo/consult-lsp)
   - Treemacs integration -
     [lsp-treemacs](https://github.com/emacs-lsp/lsp-treemacs)
-  - Semantic tokens as defined by LSP 3.16 (compatible language servers include recent development builds of clangd and rust-analyzer)
+  - Semantic tokens as defined by LSP 3.17 (compatible language servers include recent development builds of clangd and rust-analyzer)
   - [which-key](https://github.com/justbur/emacs-which-key/) integration
     for better discovery
   - [iedit](https://emacs-lsp.github.io/lsp-mode/page/main-features/#iedit)

--- a/clients/lsp-clangd.el
+++ b/clients/lsp-clangd.el
@@ -254,6 +254,9 @@ This must be set only once after loading the clang client.")
                   :priority -1
                   :server-id 'clangd
                   :library-folders-fn (lambda (_workspace) lsp-clients-clangd-library-directories)
+                  :semantic-tokens-faces-overrides '(:types (("dependent"  . lsp-face-semhl-type)
+                                                             ("concept"    . lsp-face-semhl-interface)
+                                                             ("member"     . lsp-face-semhl-member)))
                   :download-server-fn (lambda (_client callback error-callback _update?)
                                         (lsp-package-ensure 'clangd callback error-callback))))
 

--- a/clients/lsp-terraform.el
+++ b/clients/lsp-terraform.el
@@ -163,7 +163,7 @@ Defaults to side following treemacs default."
     ("parameter" . lsp-face-semhl-parameter)
     ("variable" . lsp-face-semhl-variable)
     ("property" . lsp-face-semhl-property)
-    ("enumMember" . lsp-face-semhl-constant)
+    ("enumMember" . lsp-face-semhl-enum-member)
     ("event" . lsp-face-semhl-event)
     ("function" . lsp-face-semhl-function)
     ("method" . lsp-face-semhl-method)

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -194,7 +194,13 @@ Unless overridden by a more specific face association."
 
 (defface lsp-face-semhl-label
   '((t (:inherit font-lock-comment-face)))
-  "Face used for labels."
+  "Face used for labels.
+
+Obsolete: no longer referenced by the default `lsp-semantic-token-faces'
+alist since 10.0.1 (the LSP 3.17 spec has no `label' token type). Kept
+for backward compatibility with user `set-face-attribute' calls and
+with clients that still register `label' through
+`:semantic-tokens-faces-overrides'. May be removed in a future release."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-enum-member
@@ -254,20 +260,20 @@ Examples: Python `@decorator', Java annotations."
     ("typeParameter" . lsp-face-semhl-type-parameter)
     ("function" . lsp-face-semhl-function)
     ("method" . lsp-face-semhl-method)
-    ("member" . lsp-face-semhl-member)
     ("property" . lsp-face-semhl-property)
     ("event" . lsp-face-semhl-event)
     ("macro" . lsp-face-semhl-macro)
     ("variable" . lsp-face-semhl-variable)
     ("parameter" . lsp-face-semhl-parameter)
-    ("label" . lsp-face-semhl-label)
-    ("enumConstant" . lsp-face-semhl-constant)
     ("enumMember" . lsp-face-semhl-enum-member)
     ("modifier" . lsp-face-semhl-modifier)
-    ("decorator" . lsp-face-semhl-decorator)
-    ("dependent" . lsp-face-semhl-type)
-    ("concept" . lsp-face-semhl-interface))
-  "Faces to use for semantic tokens.")
+    ("decorator" . lsp-face-semhl-decorator))
+  "Faces to use for LSP 3.17 semantic token types.
+Servers that emit non-spec token types (e.g. clangd's `dependent' and
+`concept', or tree-sitter-backed servers emitting `member' / `label')
+should register them through `:semantic-tokens-faces-overrides' on
+their `lsp-client' rather than relying on entries in this default alist.
+See URL `https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokenTypes'.")
 
 (defvar-local lsp-semantic-token-modifier-faces
   '(("declaration" . lsp-face-semhl-interface)

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -197,6 +197,22 @@ Unless overridden by a more specific face association."
   "Face used for labels."
   :group 'lsp-semantic-tokens)
 
+(defface lsp-face-semhl-enum-member
+  '((t :inherit lsp-face-semhl-constant))
+  "Face used for enum members/variants (LSP `enumMember')."
+  :group 'lsp-semantic-tokens)
+
+(defface lsp-face-semhl-modifier
+  '((t :inherit lsp-face-semhl-keyword))
+  "Face used for modifiers (LSP `modifier', e.g. public/private/static)."
+  :group 'lsp-semantic-tokens)
+
+(defface lsp-face-semhl-decorator
+  '((t :inherit lsp-face-semhl-macro))
+  "Face used for decorators (LSP `decorator', since 3.17).
+Examples: Python `@decorator', Java annotations."
+  :group 'lsp-semantic-tokens)
+
 (defface lsp-face-semhl-deprecated
   '((t :strike-through t))
   "Face used for semantic highlighting scopes matching constant scopes."

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -262,7 +262,7 @@ Examples: Python `@decorator', Java annotations."
     ("parameter" . lsp-face-semhl-parameter)
     ("label" . lsp-face-semhl-label)
     ("enumConstant" . lsp-face-semhl-constant)
-    ("enumMember" . lsp-face-semhl-constant)
+    ("enumMember" . lsp-face-semhl-enum-member)
     ("dependent" . lsp-face-semhl-type)
     ("concept" . lsp-face-semhl-interface))
   "Faces to use for semantic tokens.")

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -100,7 +100,7 @@ Unless overridden by a more specific face association."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-namespace
-  '((t :inherit font-lock-type-face :weight bold))
+  '((t :inherit lsp-face-semhl-type :weight bold))
   "Face used for semantic highlighting scopes matching entity.name.namespace.*.
 Unless overridden by a more specific face association."
   :group 'lsp-semantic-tokens)
@@ -121,12 +121,12 @@ Unless overridden by a more specific face association."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-number
-  '((t (:inherit font-lock-constant-face)))
+  '((t (:inherit lsp-face-semhl-constant)))
   "Face used for numbers."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-regexp
-  '((t (:inherit font-lock-string-face :slant italic)))
+  '((t (:inherit lsp-face-semhl-string :slant italic)))
   "Face used for regexps."
   :group 'lsp-semantic-tokens)
 
@@ -141,27 +141,27 @@ Unless overridden by a more specific face association."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-struct
-  '((t (:inherit font-lock-type-face)))
+  '((t (:inherit lsp-face-semhl-type)))
   "Face used for structs."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-class
-  '((t (:inherit font-lock-type-face)))
+  '((t (:inherit lsp-face-semhl-type)))
   "Face used for classes."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-interface
-  '((t (:inherit font-lock-type-face)))
+  '((t (:inherit lsp-face-semhl-type)))
   "Face used for interfaces."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-enum
-  '((t (:inherit font-lock-type-face)))
+  '((t (:inherit lsp-face-semhl-type)))
   "Face used for enums."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-type-parameter
-  '((t (:inherit font-lock-type-face)))
+  '((t (:inherit lsp-face-semhl-type)))
   "Face used for type parameters."
   :group 'lsp-semantic-tokens)
 
@@ -173,12 +173,12 @@ Unless overridden by a more specific face association."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-property
-  '((t (:inherit font-lock-variable-name-face)))
+  '((t (:inherit lsp-face-semhl-variable)))
   "Face used for properties."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-event
-  '((t (:inherit font-lock-variable-name-face)))
+  '((t (:inherit lsp-face-semhl-variable)))
   "Face used for event properties."
   :group 'lsp-semantic-tokens)
 
@@ -188,7 +188,7 @@ Unless overridden by a more specific face association."
   :group 'lsp-semantic-tokens)
 
 (defface lsp-face-semhl-parameter
-  '((t (:inherit font-lock-variable-name-face)))
+  '((t (:inherit lsp-face-semhl-variable)))
   "Face used for parameters."
   :group 'lsp-semantic-tokens)
 

--- a/lsp-semantic-tokens.el
+++ b/lsp-semantic-tokens.el
@@ -263,6 +263,8 @@ Examples: Python `@decorator', Java annotations."
     ("label" . lsp-face-semhl-label)
     ("enumConstant" . lsp-face-semhl-constant)
     ("enumMember" . lsp-face-semhl-enum-member)
+    ("modifier" . lsp-face-semhl-modifier)
+    ("decorator" . lsp-face-semhl-decorator)
     ("dependent" . lsp-face-semhl-type)
     ("concept" . lsp-face-semhl-interface))
   "Faces to use for semantic tokens.")


### PR DESCRIPTION
## Summary

Fixes #5040 and closes the systemic gap the issue exposed: every LSP 3.17 `SemanticTokenType` now has a dedicated `lsp-face-semhl-*` face, inheritance cascades through `lsp-face-semhl-*` before falling back to `font-lock-*`, and the default alist matches the spec exactly.

Split into 8 atomic commits so each step is independently reviewable and byte-compile clean.

## Motivation

Issue #5040 reports that `enumMember` is mapped to the generic `lsp-face-semhl-constant` face, so theme style guides that distinguish constants from enum variants (e.g. Catppuccin) cannot do so through lsp-mode. Auditing the fix revealed the same class of problem across the rest of the family:

- `type`, `struct`, `class`, `interface`, `enum`, `typeParameter` all shared `font-lock-type-face`, which made `set-face-attribute 'lsp-face-semhl-type` useless for overriding "all types".
- LSP 3.16 `modifier` and LSP 3.17 `decorator` had no entry at all.
- The default alist carried five non-spec entries (`enumConstant`, `member`, `label`, `dependent`, `concept`), some dead code, others specific to clangd's C++ dialect.

## Changes

### `lsp-semantic-tokens.el`

- **Add** three new `defface` forms: `lsp-face-semhl-enum-member` (← `constant`), `lsp-face-semhl-modifier` (← `keyword`), `lsp-face-semhl-decorator` (← `macro`, LSP 3.17).
- **Remap** `enumMember` to its dedicated face (fixes #5040; default rendering preserved by inheritance).
- **Cascade**: 11 `defface` parents retargeted so every child inherits from the semantically closest `lsp-face-semhl-*`:
  - type family (`struct`, `class`, `interface`, `enum`, `type-parameter`, `namespace`) → `lsp-face-semhl-type`.
  - variable family (`property`, `event`, `parameter`) → `lsp-face-semhl-variable`.
  - `number` → `lsp-face-semhl-constant`; `regexp` → `lsp-face-semhl-string` (keeps `:slant italic`).
- **Reorder** the type-family `defface` block so `namespace` is declared after its parent `lsp-face-semhl-type`.
- **Trim** default `lsp-semantic-token-faces` to exactly the 23 LSP 3.17 spec types, in spec order. Non-spec entries removed: `enumConstant`, `member`, `label`, `dependent`, `concept`.
- **Keep** `lsp-face-semhl-member` and `lsp-face-semhl-label` as public `defface` forms (users may have customized them; clients may still register them via `:semantic-tokens-faces-overrides`). `lsp-face-semhl-label`'s docstring now documents its obsolete status.

### `clients/lsp-clangd.el`

- Add `:semantic-tokens-faces-overrides` declaring `dependent`, `concept`, `member` on the clangd client so its rendering is preserved after the default-alist trim.

### `clients/lsp-terraform.el`

- Migrate `lsp-terraform-semantic-token-faces`' `enumMember` mapping from `lsp-face-semhl-constant` to `lsp-face-semhl-enum-member`.

### `README.md`

- L76: semantic-tokens feature line bumped from *LSP 3.16* to *LSP 3.17* (for the `decorator` addition). Other LSP-support claims are untouched.

### `CHANGELOG.org`

- Entry under *Unreleased 10.0.1* documenting the additions, the #5040 fix, the inheritance cascade behavior change, the default-alist cleanup, the terraform migration, and a migration note for users who customized `lsp-face-semhl-constant` or `lsp-face-semhl-type` relying on the previous non-cascading behavior.

## Commit list (8 atomic commits)

1. `feat(semantic-tokens): add faces for 'enumMember', 'modifier', 'decorator'`
2. `fix(semantic-tokens): remap 'enumMember' to dedicated face` — closes #5040
3. `feat(semantic-tokens): map 'modifier' and 'decorator' in default alist`
4. `refactor(semantic-tokens): cascade inheritance through 'lsp-face-semhl-*'`
5. `feat(clangd): preserve rendering for 'dependent', 'concept', 'member'`
6. `refactor(semantic-tokens): trim default alist to the LSP 3.17 spec`
7. `refactor(terraform): migrate 'enumMember' to the dedicated face`
8. `docs: bump semantic tokens spec to LSP 3.17 and changelog #5040`

Each commit byte-compiles cleanly in isolation.

## Behavior matrix

| User customization | Before this PR | After this PR |
|---|---|---|
| `set-face-attribute 'lsp-face-semhl-type` | Did not affect `struct`/`class`/`interface`/`enum`/`typeParameter`/`namespace` (they went through `font-lock-type-face`). | Cascades to all type-family tokens. *Intended behavior change.* |
| `set-face-attribute 'lsp-face-semhl-variable` | Did not affect `property`/`event`/`parameter`. | Cascades to those variable-family tokens. |
| `set-face-attribute 'lsp-face-semhl-constant` (to color enum members specifically) | Hit `enumMember` (because of the buggy mapping). | Hits only `number` and `readonly` modifier. Users should customize `lsp-face-semhl-enum-member` instead. Documented in CHANGELOG. |
| `set-face-attribute 'lsp-face-semhl-member` / `-label` | Worked, mapped by default alist. | Still works. `lsp-face-semhl-member` is still reachable via clangd's override; `lsp-face-semhl-label` is no longer mapped by default (docstring marks it obsolete). |
| Client `:semantic-tokens-faces-overrides` | Unchanged API. | Unchanged API. Clangd now uses it for `dependent`/`concept`/`member`; terraform and other clients unaffected. |
| Server emitting `enumConstant` | Highlighted via `lsp-face-semhl-constant`. | No mapping (was dead code, not in any LSP spec version). |

## Test plan

- [x] `emacs -Q --batch -f batch-byte-compile` passes cleanly on `lsp-semantic-tokens.el`, `clients/lsp-clangd.el`, `clients/lsp-terraform.el`.
- [x] Each of the 8 commits byte-compiles independently.
- [x] `rg 'enumConstant' .` returns no hits in source code (only the CHANGELOG entry documenting the removal).
- [x] Grep confirms no other client in `clients/*.el` references the removed tokens (`enumConstant`, `member`, `label`, `dependent`, `concept`) in its default alist.
- [ ] Manual end-to-end (reviewer / maintainer):
  - `jdtls` (Java): `enum` declaration + `MONDAY` enum variant render as distinguishable faces when `lsp-face-semhl-enum-member` is customized.
  - `pyright`/`pylsp` (Python): `@decorator` highlighted via the new `lsp-face-semhl-decorator` face.
  - `rust-analyzer` (Rust): attributes rendered as `decorator` on recent builds.
  - `clangd` (C++20): `concept`/`dependent`/`member` tokens still fontified through the client override.
  - `terraform-ls` (HCL): `enumMember` tokens now reach `lsp-face-semhl-enum-member`.

## Backward compatibility

- Every pre-existing `defface` symbol is preserved; any `set-face-attribute 'lsp-face-semhl-* ...` keeps working.
- The public `:semantic-tokens-faces-overrides` merge API is unchanged.
- Users who customized `font-lock-type-face` / `font-lock-variable-name-face` to drive LSP coloring keep the same visual by inheritance transitivity.
- Known documented-as-breaking deltas: the `lsp-face-semhl-type` / `-variable` / `-constant` cascade (see the behavior matrix and the CHANGELOG migration note).

Fixes: #5040