### PR TITLE
Add lsp-intelephense-phpdoc-use-fully-qualified-names

### DIFF
--- a/clients/lsp-php.el
+++ b/clients/lsp-php.el
@@ -264,6 +264,14 @@ language server."
   :group 'lsp-intelephense
   :package-version '(lsp-mode . "6.1"))
 
+(lsp-defcustom lsp-intelephense-phpdoc-use-fully-qualified-names nil
+  "If non-nil, Intelephense will use fully qualified names in generated PHPDoc.
+This corresponds to the LSP setting `intelephense.phpdoc.useFullyQualifiedNames`."
+  :type 'boolean
+  :group 'lsp-intelephense
+  :package-version '(lsp-mode . "9.0")
+  :lsp-path "intelephense.phpdoc.useFullyQualifiedNames")
+
 (lsp-dependency 'intelephense
                 '(:system "intelephense")
                 '(:npm :package "intelephense"


### PR DESCRIPTION
Add custom option for using fully qualified names (FQCN) in PHPDoc.

This allow to complete FQCN in PHPDoc `@var, @return, @param` declaration

 for example

When nil

`/** @var Person $person */`

When true

`/** @var \App\Model\Entity\Person $person */`

See also [phpdoc](https://docs.phpdoc.org/guide/references/phpdoc/types.html)