### PR TITLE
fix(lsp): guard nil :location in symbols-hierarchy breadcrumb lookup (#5047)

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6680,9 +6680,8 @@ and destructuring `(&Location :range)' off a nil `:location' blew
 up the breadcrumb idle timer with
 `(wrong-type-argument hash-table-p nil)' (issue #5047)."
   (--> symbols-informations
-    (-keep (-lambda ((symbol &as &SymbolInformation :location?))
-             (when-let* ((loc location?)
-                         (range (lsp:location-range loc)))
+    (-keep (-lambda ((symbol &as &SymbolInformation :location))
+             (when-let* ((range (and location (lsp:location-range location))))
                (when (lsp-point-in-range? current-position range)
                  (lsp--symbol-information->document-symbol symbol))))
            it)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6672,11 +6672,19 @@ perform the request synchronously."
                             :detail? container-name?))
 
 (defun lsp--symbols-informations->document-symbols-hierarchy (symbols-informations current-position)
-  "Convert SYMBOLS-INFORMATIONS to symbols hierarchy on CURRENT-POSITION."
+  "Convert SYMBOLS-INFORMATIONS to symbols hierarchy on CURRENT-POSITION.
+
+Skips SymbolInformation entries whose `:location' field is missing
+— pylsp occasionally emits duplicate entries without `:location',
+and destructuring `(&Location :range)' off a nil `:location' blew
+up the breadcrumb idle timer with
+`(wrong-type-argument hash-table-p nil)' (issue #5047)."
   (--> symbols-informations
-    (-keep (-lambda ((symbol &as &SymbolInformation :location (&Location :range)))
-             (when (lsp-point-in-range? current-position range)
-               (lsp--symbol-information->document-symbol symbol)))
+    (-keep (-lambda ((symbol &as &SymbolInformation :location?))
+             (when-let* ((loc location?)
+                         (range (lsp:location-range loc)))
+               (when (lsp-point-in-range? current-position range)
+                 (lsp--symbol-information->document-symbol symbol))))
            it)
     (sort it (-lambda ((&DocumentSymbol :range (&Range :start a-start-position :end a-end-position))
                        (&DocumentSymbol :range (&Range :start b-start-position :end b-end-position)))


### PR DESCRIPTION
## Summary

\`lsp--symbols-informations->document-symbols-hierarchy\` destructured

\`\`\`elisp
(-lambda ((symbol &as &SymbolInformation :location (&Location :range)))
\`\`\`

so a \`SymbolInformation\` entry without a \`:location\` field — pylsp occasionally emits duplicate entries this way — triggered an inner destructure of \`(&Location :range)\` against \`nil\`, which reduced to \`(gethash \"range\" nil)\` and raised

\`\`\`
(wrong-type-argument hash-table-p nil)
\`\`\`

on every \`lsp--on-idle\` tick while \`lsp-headerline-breadcrumb-mode\` had the \`symbols\` segment active.

## Fix

Switch to the optional \`:location?\` binding, then \`when-let*\` the location + range before checking \`lsp-point-in-range?\`. Entries without a location fall out silently — \`-keep\` drops \`nil\` returns already.

\`\`\`elisp
(-keep (-lambda ((symbol &as &SymbolInformation :location?))
         (when-let* ((loc location?)
                     (range (lsp:location-range loc)))
           (when (lsp-point-in-range? current-position range)
             (lsp--symbol-information->document-symbol symbol))))
       it)
\`\`\`

Fixes #5047

## Test plan

- Matches the existing optional-field convention (\`:container-name?\`, \`:deprecated?\`) already in use at \`lsp-mode.el:6664\`, \`7470\`.
- \`lsp:location-range\` is the same helper used elsewhere in the file (e.g. \`lsp-mode.el:5460\`) so no new API surface.
- Local byte-compile not run because \`emacs\` isn't on this workstation; the emacs-lsp CI byte-compile pipeline will validate.