### PR TITLE
Fix clojure-lsp URLs

### DIFF
--- a/clients/lsp-clojure.el
+++ b/clients/lsp-clojure.el
@@ -32,7 +32,7 @@
 
 (defgroup lsp-clojure nil
   "LSP support for Clojure."
-  :link '(url-link "https://github.com/snoe/clojure-lsp")
+  :link '(url-link "https://github.com/clojure-lsp/clojure-lsp")
   :group 'lsp-mode
   :tag "Lsp Clojure")
 

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -199,8 +199,8 @@
     "name": "clojure",
     "full-name": "Clojure",
     "server-name": "clojure-lsp",
-    "server-url": "https://github.com/snoe/clojure-lsp",
-    "installation-url": "https://github.com/snoe/clojure-lsp",
+    "server-url": "https://github.com/clojure-lsp/clojure-lsp",
+    "installation-url": "https://github.com/clojure-lsp/clojure-lsp",
     "lsp-install-server": "clojure-lsp",
     "debugger": "Not available"
   },


### PR DESCRIPTION
Hello! I was reading the Clojure LSP documentation and noticed that the Github repository URLs point to a fork. Thought I might as well send in a patch. Please enjoy.