### PR TITLE
Fix handling of bare array `CompletionItem[]` in completion responses

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -597,9 +597,10 @@ Returns resolved completion item details."
                                      "textDocument/completion"
                                      (plist-put (lsp--text-document-position-params)
                                                 :context (lsp-completion--get-context trigger-chars same-session?))))
-                              (completed (and resp
-                                              (not (and (lsp-completion-list? resp)
-                                                        (lsp:completion-list-is-incomplete resp)))))
+                              ;; If resp is nil (e.g. no server responded), we treat it as complete
+                              ;; to prevent an infinite retry loop.
+                              (completed (not (and (lsp-completion-list? resp)
+                                                   (lsp:completion-list-is-incomplete resp))))
                               (items (lsp--while-no-input
                                        (--> (cond
                                              ((lsp-completion-list? resp)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1509,7 +1509,11 @@ the lists according to METHOD."
                 (-filter #'identity results))
     (`() ())
     ;; only one result - simply return it
-    (`(,fst) fst)
+    (`(,fst) (pcase method
+               ("textDocument/completion"
+                (if (lsp-completion-list? fst) fst
+                  (lsp-make-completion-list :items fst :is-incomplete nil)))
+               (_ fst)))
     ;; multiple results merge it based on strategy
     (results
      (pcase method

--- a/test/lsp-mode-test.el
+++ b/test/lsp-mode-test.el
@@ -39,7 +39,14 @@
                                                                        nil))
                              "textDocument/completion")))
     (should (lsp-completion-list? merged-completions))
-    (should (lsp-completion--sort-completions (lsp:completion-list-items merged-completions)))))
+    (should (lsp-completion--sort-completions (lsp:completion-list-items merged-completions))))
+
+  (let ((merged-completions (lsp--merge-results
+                             `([])
+                             "textDocument/completion")))
+    (should (lsp-completion-list? merged-completions))
+    (should (not (lsp:completion-list-is-incomplete merged-completions)))
+    (should (seq-empty-p (lsp:completion-list-items merged-completions)))))
 
 (defun lsp--json-string-equal? (str1 str2)
   "Roughly compare json string STR1 and STR2."


### PR DESCRIPTION
This PR fixes a bug where `lsp-mode` incorrectly treats bare `CompletionItem[]` responses (specifically empty arrays `[]`) as incomplete. 

### The Problem
When a server returns a bare array `[]`, `lsp-mode` converts this to `nil` during result merging. The completion logic then interpreted this `nil` as an incomplete response, causing it to:
1. Cache the session state as `:incomplete`.
2. Immediately fire a follow-up `textDocument/completion` request with `triggerKind: 3` (`TriggerForIncompleteCompletions`) as soon as the UI (company/corfu) requested candidates again.

Because the server correctly continues to return `[]` for that position, this creates an **infinite retry loop** as long as the completion popup remains active.

### Root Cause
The issue was two-fold:
1. `lsp--merge-results` converted a single result of `[]` into `nil`, losing the "complete by default" semantics of the array.
2. `lsp-completion.el` had a check `(and resp (not ...))` which explicitly required a non-nil response to consider it "complete".

### Specification Reference
The LSP specification for `textDocument/completion` defines the reply as either a plain array `CompletionItem[]` **or** an object called `CompletionList`. 

The official spec says verbatim:

> result: CompletionItem[] | CompletionList | null. 
> If a CompletionItem[] is provided it is interpreted to be complete. 
> So it is the same as { isIncomplete: false, items }

## Changes
- **`lsp-mode.el`**: Refactored the single-result case in `lsp--merge-results` to use `pcase method`. For `textDocument/completion`, bare arrays are now "lifted" into a proper `CompletionList` with `isIncomplete: false`. This maintains symmetry with the multiple-results merging logic.
- **`lsp-completion.el`**: 
    - Removed the `and resp` requirement for the `completed` flag. 
    - Added code comments explaining that treating `nil` (no server) as complete is intentional to prevent infinite loops when no server responds.
- **`test/lsp-mode-test.el`**: Added a unit test case to verify that merging an empty array `[]` for completion correctly returns a complete `CompletionList`.

## Verification
- Added a new unit test: `lsp-mode-test-merging-completion-results`.
- Ran the full test suite (33 tests) and all passed.
- Empirically verified that servers returning `[]` no longer trigger redundant follow-up requests and the infinite retry loop is broken.
