### PR TITLE
ci: Fix downstream test

### DIFF
--- a/test/downstream/Eask
+++ b/test/downstream/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "lsp-mode"
          "9.0.0"
          "Test downstream packages")
@@ -7,8 +9,8 @@
 
 (package-file "lsp-mode.el")
 
-(source "gnu")
-(source "melpa")
+(source 'gnu)
+(source 'melpa)
 
 (depends-on "emacs" "26.3")
 (depends-on "dash")
@@ -21,7 +23,8 @@
 
 (development
  (depends-on "ccls")
- (depends-on "dap-mode")
+ (when (version<= "29.1" emacs-version)
+   (depends-on "dap-mode"))
  (depends-on "helm-lsp")
  (depends-on "lsp-dart")
  (depends-on "lsp-docker")


### PR DESCRIPTION
The `dap-mode` dependency `bui` now requires `29.1`.