### PR TITLE
feat: Drop Emacs 28.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         emacs-version:
-          - 28.2
           - 29.4
           - 30.2
         experimental: [false]

--- a/Eask
+++ b/Eask
@@ -13,9 +13,9 @@
 
 (script "test" "echo \"Error: no test specified\" && exit 1")
 
-(source "gnu")
-(source "jcs-elpa")
-(source "melpa")
+(source 'gnu)
+(source 'jcs-elpa)
+(source 'melpa)
 
 (files
  "lsp-protocol.el"
@@ -31,7 +31,7 @@
  "lsp-semantic-tokens.el"
  "clients/*.el")
 
-(depends-on "emacs" "28.1")
+(depends-on "emacs" "29.1")
 (depends-on "dash")
 (depends-on "f")
 (depends-on "ht")

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: Vibhav Pant, Fangrui Song, Ivan Yonchovski
 ;; Keywords: languages
-;; Package-Requires: ((emacs "28.1") (dash "2.18.0") (f "0.21.0") (ht "2.3") (spinner "1.7.3") (markdown-mode "2.3") (lv "0") (eldoc "1.11"))
+;; Package-Requires: ((emacs "29.1") (dash "2.18.0") (f "0.21.0") (ht "2.3") (spinner "1.7.3") (markdown-mode "2.3") (lv "0") (eldoc "1.11"))
 ;; Version: 10.0.1
 
 ;; URL: https://github.com/emacs-lsp/lsp-mode

--- a/test/downstream/Eask
+++ b/test/downstream/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "lsp-mode"
          "9.0.0"
          "Test downstream packages")
@@ -7,8 +9,8 @@
 
 (package-file "lsp-mode.el")
 
-(source "gnu")
-(source "melpa")
+(source 'gnu)
+(source 'melpa)
 
 (depends-on "emacs" "26.3")
 (depends-on "dash")
@@ -21,7 +23,8 @@
 
 (development
  (depends-on "ccls")
- (depends-on "dap-mode")
+ (when (version<= "29.1" emacs-version)
+   (depends-on "dap-mode"))
  (depends-on "helm-lsp")
  (depends-on "lsp-dart")
  (depends-on "lsp-docker")

--- a/test/downstream/Eask
+++ b/test/downstream/Eask
@@ -23,8 +23,7 @@
 
 (development
  (depends-on "ccls")
- (when (version<= "29.1" emacs-version)
-   (depends-on "dap-mode"))
+ (depends-on "dap-mode")
  (depends-on "helm-lsp")
  (depends-on "lsp-dart")
  (depends-on "lsp-docker")


### PR DESCRIPTION
The downstream package now requires Emacs 29.1.