### PR TITLE
Rust-Analyzer fix resolve failure on imports.as_underscore value being null

### DIFF
--- a/lsp-completion.el
+++ b/lsp-completion.el
@@ -180,6 +180,13 @@ See #2675"
     (when (lsp-member? data :import_for_trait_assoc_item)
       (unless (lsp-get data :import_for_trait_assoc_item)
         (lsp-put data :import_for_trait_assoc_item :json-false)))
+    (when (lsp-member? data :imports)
+      (when-let* ((imports (lsp-get data :imports)))
+        (->> imports
+             (mapc (lambda (import)
+                     (when (lsp-member? import :as_underscore)
+                       (unless (lsp-get import :as_underscore)
+                         (lsp-put import :as_underscore :json-false))))))))
     (when (lsp-member? data :for_ref)
       (unless (lsp-get data :for_ref)
          (lsp-put data :for_ref :json-false)))))


### PR DESCRIPTION
Client side fix for rust-lang/rust-analyzer#22284.