### PR TITLE
Preserve empty-object capabilities under `lsp-use-plists`

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4825,14 +4825,43 @@ Only works when mode is `tick or `alive."
      (lambda ()
        (remove-hook 'before-change-functions func t)))))
 
+(defvar lsp--empty-options-sentinel '(:lsp-empty-object t)
+  "Stand-in value for an empty JSON options object \"{}\" in capabilities.
+
+A server may advertise e.g. `\"completionProvider\": {}' to mean
+\"supported, with no specific options set — take all defaults.\"
+Under `lsp-use-plists', `json-parse-string' parses the empty `{}' to
+Elisp nil, which is indistinguishable from the field being absent, so
+the feature ends up silently disabled.  `lsp--capability' returns this
+sentinel in that case to restore the distinction.
+
+The sentinel is truthy, so capability checks recognize the feature as
+supported.  It contains no LSP option keys, so any subsequent option
+lookup — for example `(lsp:completion-options-trigger-characters? ...)'
+— returns nil, which matches what an empty options object actually
+means on the wire: no specific options were set, take defaults.
+
+Caveat: JSON `false' also parses to nil under `lsp-use-plists', so a
+server explicitly advertising e.g. `\"foo\": false' (\"not supported\")
+is also treated by this fix as supported.  Rare in practice — servers
+usually omit unsupported capabilities rather than send `false'.
+Distinguishing the two would require parsing JSON `false' to a non-nil
+value, a much wider change.")
+
 (defun lsp--capability (cap &optional capabilities)
-  "Get the value of capability CAP.  If CAPABILITIES is non-nil, use them instead."
+  "Return the value of capability CAP.
+If CAPABILITIES is non-nil, look up CAP there; otherwise use the
+current server\\='s capabilities.  When CAP is present in the
+capabilities plist with a nil value — typically because the server
+advertised `{}' on the wire — return `lsp--empty-options-sentinel'
+instead of nil, so the feature is recognized as supported.  See that
+variable\\='s docstring for the rationale."
   (when (stringp cap)
     (setq cap (intern (concat ":" cap))))
 
-  (lsp-get (or capabilities
-               (lsp--server-capabilities))
-           cap))
+  (let ((src (or capabilities (lsp--server-capabilities))))
+    (or (lsp-get src cap)
+        (and (lsp-member? src cap) lsp--empty-options-sentinel))))
 
 (defun lsp--registered-capability (method)
   "Check whether there is workspace providing METHOD."


### PR DESCRIPTION
## Problem

When `lsp-use-plists` is non-nil, `json-parse-string` collapses JSON `{}`, `null`, and `false` all to Elisp `nil`. For server capabilities, this means `"foo": {}` (LSP semantics: *supported, default options*) is indistinguishable from `"foo"` being absent. The feature is silently treated as unsupported.

This affects any capability the LSP spec allows a server to advertise as bare `{}` — `hoverProvider`, `completionProvider`, `definitionProvider`, `referencesProvider`, `documentSymbolProvider`, `workspaceSymbolProvider`, `codeLensProvider`, `colorProvider`, `foldingRangeProvider`, and others. Whenever a server actually uses that form (very common with LSP4J-based servers that default-construct an options object), the corresponding feature is silently disabled under plist mode.

## Concrete reproducer

`ltex-ls-plus` advertises `completionProvider: {}`. Under `lsp-use-plists`:

- `(lsp-feature? "textDocument/completion")` returns nil.
- Any completion request fails with *"the connected server(s) does not support method textDocument/completion"*.

An existing server-specific workaround for rust-analyzer lives in `lsp--start-workspace`, inside the `InitializeResult` callback; search for the comment:

> ;; we know that Rust Analyzer will send {} which will be parsed as null
> ;; when using plists

It manually re-sets `text-document-sync.save` after the parse collapses `{}` to nil. That is a hack for this same bug class. This PR fixes the underlying cause; once it lands, that workaround can be removed.

## Fix

Patch `lsp--capability` to distinguish *"key absent from plist"* from *"key present with value nil"* using `lsp-member?`. When the key is present with nil value, return `lsp--empty-options-sentinel` — a truthy single-key plist that:

- is non-nil, so capability-presence checks recognize the feature as supported;
- contains no LSP option keys, so any subsequent option lookup like `(lsp:completion-options-trigger-characters? sentinel)` returns nil. This matches what an empty options object actually means: no specific options were set, take defaults.

**Hash-table mode is unaffected**; `lsp-member?` for hash tables already distinguishes the cases correctly.

## Compromise / open question for maintainers

This patch treats any present-with-nil value as supported, regardless of whether the original JSON was `{}`, `null`, or `false`. JSON `null` and `false` are also collapsed to nil by `json-parse-string` and are indistinguishable post-parse. So a server that explicitly advertises e.g. `"hoverProvider": false` will be treated as supporting hover after this patch — incorrect.

In practice the regression is rare: most LSP servers omit unsupported capabilities rather than write `false` explicitly. The patch trades a common, currently-broken case (`{}`) for a rare new wrong case (`false`).

A more principled fix would distinguish JSON `false` from `{}` at the parser boundary by setting `:false-object` to a non-nil sentinel (e.g. `'lsp-false`) in `lsp--read-json` / `lsp-json-read-buffer`. Every consumer of a JSON boolean (`(if foo ...)`, `(when foo ...)`, `(plist-get ...)`-truthiness checks) across `lsp-mode` and downstream client packages would then need to be audited and updated to use `(eq foo t)` or an `lsp-true?` helper. Broad churn, but no architectural special case: every message keeps going through a single uniform parse.

This PR ships the smaller compromise as the immediate fix; I am happy to rework toward the principled fix if you'd prefer.

## Impact

The behavior is relevant for any `lsp-use-plists` user of a server that advertises a capability as bare `{}`. A focused unit test for `lsp--capability`:

```elisp
(ert-deftest lsp--capability-distinguishes-present-nil-from-absent ()
  (let ((caps '(:completionProvider nil
                :hoverProvider t
                :definitionProvider nil
                :colorProvider 42)))
    ;; Present-with-nil → truthy sentinel (was {} on the wire)
    (should (lsp--capability :completionProvider caps))
    (should (lsp--capability :definitionProvider caps))
    ;; Present non-nil → value as-is
    (should (eq t  (lsp--capability :hoverProvider caps)))
    (should (eq 42 (lsp--capability :colorProvider caps)))
    ;; Absent → nil
    (should-not (lsp--capability :referencesProvider caps))))
```

Happy to add this `ert-deftest` to the PR if you'd like regression coverage.