### PR TITLE
Replace (not (null x)) with (and x t) in parser-on-message

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -7394,9 +7394,9 @@ server. WORKSPACE is the active workspace."
         (let* ((client (lsp--workspace-client workspace))
                (method (json-get json-data "method"))
                (raw-id (json-get json-data "id"))
-               (has-method (not (null method)))
-               (has-id (not (null raw-id)))
-               (has-error (not (null (json-get json-data "error"))))
+               (has-method (and method t))
+               (has-id (and raw-id t))
+               (has-error (and (json-get json-data "error") t))
                ;; Kind-First routing: if a method exists, it's a server-initiated
                ;; message (request/notification) regardless of ID collisions.
                (message-type (cond


### PR DESCRIPTION
This is a small follow-up to PR #5055 to implement a small cosmetic fix—after the recommendation
by `melpazoid` package-review tool.

The `has-method', `has-id', and `has-error' bindings in the `lsp--parser-on-message' patch were
originally `(not (null x))' to coerce a boolean instead of a truthy value.

The fix in this PR preserves the intent of an explicit boolean coercion, so each `has-*' binding holds
strictly t/nil to match its predicate-style name, but it avoids a confusing double-negation. It silences
the melpazoid double-negation warning.

Discovered using the MELPA review tool `melpazoid'.