### PR TITLE
Add lsp-file-watch-respect-gitignore to skip Git-ignored paths

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 10.0.1
+  * Add ~lsp-file-watch-respect-gitignore~ defcustom (default ~nil~): when enabled, paths ignored by Git under a workspace root (resolved via ~git ls-files --others --ignored --exclude-standard --directory~) are excluded from file watchers, in addition to ~lsp-file-watch-ignored-directories~/~lsp-file-watch-ignored-files~. Delegates ~.gitignore~ semantics (negation, nested ignore files, ~core.excludesFile~, ~.git/info/exclude~) to Git itself.
   * Add support for LSP 3.17 InlayHint features: ~textEdits~, ~tooltip~, ~data~, ~InlayHintLabelPart~ (per-part ~tooltip~/~location~/~command~), ~inlayHint/resolve~, interactive mouse handler, and ~lsp-inlay-hint-accept~ command (see [[https://github.com/emacs-lsp/lsp-mode/issues/4775][#4775]])
   * Add ~lsp-diagnostics-flymake-message-formatter~ defcustom for customizing how an LSP diagnostic is rendered into the flymake text string; the default appends the code in brackets, and users can suppress it, prepend the source tool, add a severity prefix, etc. (see: [[https://github.com/emacs-lsp/lsp-mode/pull/5036][#5036]]).
   * Append the LSP diagnostic code (e.g. ~reportUnusedExpression~, ~E501~) to flymake messages, mirroring what flycheck already exposes via ~flycheck-error-id~ (see: [[https://github.com/emacs-lsp/lsp-mode/pull/5036][#5036]]).

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -473,6 +473,31 @@ level or at a root of an lsp workspace."
 ;; Allow lsp-file-watch-ignored-files as a file or directory-local variable
 ;;;###autoload(put 'lsp-file-watch-ignored-files 'safe-local-variable 'lsp--string-listp)
 
+(defcustom lsp-file-watch-respect-gitignore nil
+  "If non-nil, exclude paths ignored by Git from file watchers.
+
+When a workspace root is inside a Git working tree, the paths reported by
+
+  git ls-files --others --ignored --exclude-standard --directory
+
+are added to the file-watch ignore lists, on top of
+`lsp-file-watch-ignored-directories' and `lsp-file-watch-ignored-files'.
+This delegates `.gitignore' semantics -- negation rules, nested ignore
+files, `core.excludesFile' and `.git/info/exclude' -- to Git itself,
+rather than duplicating them as regexps.
+
+Has no effect outside a Git working tree, or when the `git' executable
+is not found.  The Git query runs once per workspace root when watches
+are created, so changes to ignore rules take effect after the workspace
+is restarted.
+
+Customization of this variable is only honored at the global level or at
+a root of an lsp workspace."
+  :group 'lsp-mode
+  :type 'boolean
+  :package-version '(lsp-mode . "10.0.1"))
+;;;###autoload(put 'lsp-file-watch-respect-gitignore 'safe-local-variable #'booleanp)
+
 (defcustom lsp-after-uninitialized-functions nil
   "List of functions to be called after a Language Server has been uninitialized."
   :type 'hook
@@ -4006,6 +4031,43 @@ access dir-local variables."
      (prog1 ,@body
        (setq-local buffer-file-name nil))))
 
+(defun lsp--gitignore-ignored-regexes (workspace-root)
+  "Return ignore regexes for paths Git ignores under WORKSPACE-ROOT.
+The return value is a list (FILES DIRECTORIES) where each element is a
+list of regexps matching absolute paths, suitable for appending to
+`lsp-file-watch-ignored-files' and `lsp-file-watch-ignored-directories'
+respectively.
+
+Paths are obtained from
+
+  git ls-files --others --ignored --exclude-standard --directory
+
+so all `.gitignore' semantics are resolved by Git.  Returns nil when
+WORKSPACE-ROOT is not an accessible directory or when the `git'
+executable cannot be found."
+  (when (and workspace-root
+             (file-accessible-directory-p workspace-root)
+             (executable-find "git"))
+    (let* ((default-directory (file-name-as-directory
+                               (file-truename workspace-root)))
+           (root (directory-file-name default-directory))
+           files directories)
+      (with-temp-buffer
+        (when (eq 0 (process-file "git" nil (list t nil) nil
+                                  "ls-files" "-z" "--others" "--ignored"
+                                  "--exclude-standard" "--directory"))
+          (dolist (entry (split-string (buffer-string) "\0" t))
+            ;; Git appends "/" to whole ignored directories; such entries
+            ;; suppress the directory watch, others only the file events.
+            (let* ((dir-only (string-suffix-p "/" entry))
+                   (relative (if dir-only (substring entry 0 -1) entry))
+                   (absolute (expand-file-name relative root))
+                   (regex (concat "\\`" (regexp-quote absolute)
+                                  (if dir-only "\\(?:/\\|\\'\\)" "\\'"))))
+              (push regex directories)
+              (unless dir-only (push regex files))))))
+      (list (nreverse files) (nreverse directories)))))
+
 (defun lsp--get-ignored-regexes-for-workspace-root (workspace-root)
   "Return a list of the form
 (lsp-file-watch-ignored-files lsp-file-watch-ignored-directories) for the given
@@ -4013,7 +4075,14 @@ WORKSPACE-ROOT."
   ;; The intent of this function is to provide per-root workspace-level customization of the
   ;; lsp-file-watch-ignored-directories and lsp-file-watch-ignored-files variables.
   (lsp--with-workspace-temp-buffer workspace-root
-    (list lsp-file-watch-ignored-files (lsp-file-watch-ignored-directories))))
+    (let ((files lsp-file-watch-ignored-files)
+          (directories (lsp-file-watch-ignored-directories))
+          (gitignore (when lsp-file-watch-respect-gitignore
+                       (lsp--gitignore-ignored-regexes workspace-root))))
+      (if gitignore
+          (list (append files (nth 0 gitignore))
+                (append directories (nth 1 gitignore)))
+        (list files directories)))))
 
 
 (defun lsp--cleanup-hanging-watches ()


### PR DESCRIPTION
## Summary

Adds a `lsp-file-watch-respect-gitignore` defcustom (default `nil`). When enabled, paths ignored by Git under a workspace root are excluded from file watchers, in addition to `lsp-file-watch-ignored-directories` and `lsp-file-watch-ignored-files`.

The ignored paths come from:

```
git ls-files --others --ignored --exclude-standard --directory
```

so full `.gitignore` semantics — negation rules, nested `.gitignore` files, `core.excludesFile`, and `.git/info/exclude` — are resolved by Git itself rather than reimplemented as regexps.

## Motivation

Large repos often keep build artifacts and dependencies in project-specific locations (`node_modules`, `dist`, `target`, `.venv`, `build`, generated output dirs) that are already in `.gitignore` but aren't covered by the curated `lsp-file-watch-ignored-directories` defaults. Watching them wastes file-notification handles and can trip `lsp-file-watch-threshold`. The project's own `.gitignore` is the natural source of truth.

This originated as an `advice-add` workaround in a Spacemacs PR ([syl20bnr/spacemacs#17277](https://github.com/syl20bnr/spacemacs/pull/17277)); a reviewer suggested it belongs upstream, where it can be a first-class option without advice.

## Implementation

- New defcustom `lsp-file-watch-respect-gitignore` (default `nil`, `:safe` `booleanp`), placed next to `lsp-file-watch-ignored-files`.
- New helper `lsp--gitignore-ignored-regexes` returns `(FILES DIRECTORIES)` regex lists for an absolute-anchored match of each Git-ignored path. Directory entries (Git appends `/`) suppress the directory watch; file entries suppress only file-change events, mirroring the existing files/directories split.
- `lsp--get-ignored-regexes-for-workspace-root` appends these when the option is on.

The helper is a no-op outside a Git working tree or when `git` is not on `PATH`, so non-Git workspaces are unaffected. The query runs once per workspace root at watch-creation time; changes to ignore rules take effect on workspace restart (documented in the docstring).

Default is `nil` to keep current behavior unchanged and avoid spawning `git` unless opted in — happy to flip it if maintainers prefer it on by default.

## Testing

- `make checkdoc` / byte-compile clean for the new code.
- Verified against a fixture repo with `node_modules`, `dist/`, `*.log`, `/build`: the generated regexes ignore `node_modules/**` and `build/**` (and the `dist` dir), add `src/a.log` to the files list, and leave real source directories watched. Pre-existing entries in both ignore lists are preserved (the result appends, never replaces).
- No effect confirmed in a non-Git directory and with `git` absent from `PATH`.

I'll happily add an `ert` case under `test/` if you'd like one for the helper.