### PR TITLE
feat(lsp): expose server name and version from InitializeResult serverInfo

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3179,6 +3179,12 @@ and end-of-string meta-characters."
   ;; cf. https://microsoft.github.io/language-server-protocol/specification#initialize.
   (server-capabilities nil)
 
+  ;; ‘server-info’ is the LSP ServerInfo object reported by the language server
+  ;; in the InitializeResult, or nil if the server did not provide it.  It holds
+  ;; the server ‘name’ and, optionally, its ‘version’; cf.
+  ;; https://microsoft.github.io/language-server-protocol/specification#initialize.
+  (server-info nil)
+
   ;; ‘registered-server-capabilities’ is a list of hash tables that represent
   ;; dynamically-registered Registration objects.  See
   ;; https://microsoft.github.io/language-server-protocol/specification#client_registerCapability.
@@ -8273,6 +8279,24 @@ should return the command to start the LS server."
                       (push folder result)))))
     result))
 
+(defun lsp-workspace-server-name (&optional workspace)
+  "Return the name reported by WORKSPACE's language server, or nil.
+WORKSPACE defaults to the current workspace.  The name comes from the
+ServerInfo of the InitializeResult and is only available when the server
+provides it."
+  (when-let* ((workspace (or workspace lsp--cur-workspace))
+              (info (lsp--workspace-server-info workspace)))
+    (lsp:server-info-name info)))
+
+(defun lsp-workspace-server-version (&optional workspace)
+  "Return the version reported by WORKSPACE's language server, or nil.
+WORKSPACE defaults to the current workspace.  The version comes from the
+ServerInfo of the InitializeResult and is only available when the server
+provides it."
+  (when-let* ((workspace (or workspace lsp--cur-workspace))
+              (info (lsp--workspace-server-info workspace)))
+    (lsp:server-info-version? info)))
+
 (defun lsp--start-workspace (session client-template root &optional initialization-options)
   "Create new workspace for CLIENT-TEMPLATE with project root ROOT.
 INITIALIZATION-OPTIONS are passed to initialize function.
@@ -8333,7 +8357,7 @@ SESSION is the active session."
                              :name (f-filename folder))))
                (apply 'vector)
                (list :workspaceFolders)))
-       (-lambda ((&InitializeResult :capabilities))
+       (-lambda ((&InitializeResult :capabilities :server-info?))
          (pcase server-id
            ;; we know that Rust Analyzer will send {} which will be parsed as null
            ;; when using plists
@@ -8343,6 +8367,7 @@ SESSION is the active session."
                 (lsp:set-text-document-sync-options-save? t))))
 
          (setf (lsp--workspace-server-capabilities workspace) capabilities
+               (lsp--workspace-server-info workspace) server-info?
                (lsp--workspace-status workspace) 'initialized)
 
          ;; Apply the negotiated position encoding to all workspace buffers.


### PR DESCRIPTION
## Summary

lsp-mode discarded the `serverInfo` object from the `InitializeResult`, so there
was no way to read the connected language server's reported name or version.
This wires it through and exposes it via public accessors.

## Changes

- Add a `server-info` field to the `lsp--workspace` struct.
- Capture `:serverInfo` in the `initialize` response handler (previously only
  `:capabilities` was destructured) and store it on the workspace.
- Add two public accessors, each taking an optional `workspace` that defaults
  to the current workspace:
  - `lsp-workspace-server-name` — the server `name`
  - `lsp-workspace-server-version` — the server `version`

The raw `ServerInfo` object is reachable via the private `lsp--workspace-server-info`
struct accessor, mirroring how `server-capabilities` keeps its raw accessor private
(`lsp--server-capabilities`) and exposes field-level helpers.

The `ServerInfo`/`InitializeResult` protocol interfaces were already declared in
`lsp-protocol.el`; only the plumbing was missing.

## Usage

```elisp
(lsp-workspace-server-version)  ;; => "0.12.0", or nil if the server omits it
(lsp-workspace-server-name)     ;; => "magik-language-server"
```

## Notes

- `serverInfo` and its `version` are optional in the LSP spec; the accessors return nil when the server does not provide them.
- No breaking changes; purely additive.

## Tests

- [x] Tested using the devel branch of [ltex-plus/emacs-ltex-plus](https://github.com/ltex-plus/emacs-ltex-plus/tree/devel) and PR [ltex-plus/ltex-ls-plus#177](https://github.com/ltex-plus/ltex-ls-plus/pull/177)
 
