### PR TITLE
lsp-openscad: replace clang-format settings with Topiary settings

### DIFF
--- a/clients/lsp-openscad.el
+++ b/clients/lsp-openscad.el
@@ -51,20 +51,26 @@
   :type 'string
   :group 'lsp-openscad)
 
-(defcustom lsp-openscad-format-exe "clang-format"
-  "Path to the clang-format executable."
+(defcustom lsp-openscad-indent "    "
+  "Indentation string used by Topiary when formatting."
   :type 'string
   :group 'lsp-openscad)
 
-(defcustom lsp-openscad-format-style "file"
-  "Style argument to use with clang-format."
-  :type 'string
+(defcustom lsp-openscad-query-file ""
+  "Path to a custom Topiary query file for OpenSCAD formatting."
+  :type 'file
+  :group 'lsp-openscad)
+
+(defcustom lsp-openscad-default-param t
+  "Whether to include default parameter values in auto-completion."
+  :type 'boolean
   :group 'lsp-openscad)
 
 (lsp-register-custom-settings
  '(("openscad.search_paths" lsp-openscad-search-paths)
-   ("openscad.fmt_exe" lsp-openscad-format-exe)
-   ("openscad.fmt_style" lsp-openscad-format-style)))
+   ("openscad.indent" lsp-openscad-indent)
+   ("openscad.query_file" lsp-openscad-query-file)
+   ("openscad.default_param" lsp-openscad-default-param t)))
 
 (defun lsp-openscad-server-stdio-start-fun ()
   "Create arguments to start openscad language server in stdio mode."


### PR DESCRIPTION
openscad-lsp changed the way it formats from clang-format to Topiary.

I removed `lsp-openscad-format-exe` and `lsp-openscad-format-style` and added `lsp-openscad-indent`, `lsp-openscad-query-file`, and `lsp-openscad-default-param` based on the README.

From its README.md:

To change the config at runtime, you can send notification `workspace/didChangeConfiguration`
```json
{
  "settings": {
    "openscad": {
      "search_paths": "/libs",
      "indent": "    ",
      "query_file": "path/to/my/openscad.scm",
      "default_param": true
    }
  }
}
```