### PR TITLE
Fix lsp-tailwindcss-add-on-mode default

### DIFF
--- a/clients/lsp-tailwindcss.el
+++ b/clients/lsp-tailwindcss.el
@@ -33,7 +33,7 @@
   :group 'lsp-mode
   :link '(url-link "https://github.com/tailwindlabs/tailwindcss-intellisense"))
 
-(defcustom lsp-tailwindcss-add-on-mode nil
+(defcustom lsp-tailwindcss-add-on-mode t
   "Specify lsp-tailwindcss as add-on so it can work with other language servers."
   :type 'boolean
   :group 'lsp-tailwindcss)


### PR DESCRIPTION
Enables lsp-tailwindcss-add-on-mode by default so that the Tailwind CSS language server runs alongside TypeScript language servers instead of blocking them in TypeScript buffers.