### PR TITLE
Fix Tailwind CSS server detection and download

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 10.0.1
+  * Fix ~lsp-install-server~ download from the Visual Studio Code Marketplace.
   * Add support for LSP 3.17 InlayHint features: ~textEdits~, ~tooltip~, ~data~, ~InlayHintLabelPart~ (per-part ~tooltip~/~location~/~command~), ~inlayHint/resolve~, interactive mouse handler, and ~lsp-inlay-hint-accept~ command (see [[https://github.com/emacs-lsp/lsp-mode/issues/4775][#4775]])
   * Add ~lsp-diagnostics-flymake-message-formatter~ defcustom for customizing how an LSP diagnostic is rendered into the flymake text string; the default appends the code in brackets, and users can suppress it, prepend the source tool, add a severity prefix, etc. (see: [[https://github.com/emacs-lsp/lsp-mode/pull/5036][#5036]]).
   * Append the LSP diagnostic code (e.g. ~reportUnusedExpression~, ~E501~) to flymake messages, mirroring what flycheck already exposes via ~flycheck-error-id~ (see: [[https://github.com/emacs-lsp/lsp-mode/pull/5036][#5036]]).

--- a/clients/lsp-tailwindcss.el
+++ b/clients/lsp-tailwindcss.el
@@ -335,9 +335,12 @@ Workaround for company-mode completion not working when typing \"-\" in classnam
 
 (lsp-register-client
  (make-lsp-client
-  :new-connection (lsp-stdio-connection
-                   (lambda ()
-                     `("node" ,(lsp-tailwindcss--server-path) "--stdio")))
+   :new-connection (lsp-stdio-connection
+                    (lambda ()
+                      `("node" ,(lsp-tailwindcss--server-path) "--stdio"))
+                    (lambda ()
+                      (when-let* ((server-path (lsp-tailwindcss--server-path)))
+                        (file-exists-p server-path))))
   :activation-fn #'lsp-tailwindcss--activate-p
   :server-id 'tailwindcss
   :priority -1

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8831,7 +8831,7 @@ The caller is responsible for ensuring curl is available."
   (make-process
    :name (format "lsp-download-%s" (file-name-nondirectory path))
    :noquery t
-   :command (list "curl" "--silent" "--location" "--output" path url)
+   :command (list "curl" "--silent" "--location" "--compressed" "--output" path url)
    :sentinel (lambda (_proc event)
                (if (string= event "finished\n")
                    (progn


### PR DESCRIPTION
A prompt to automatically install the language server is never shown when node is found. lsp-mode checks for node instead of the server package. lsp-install-server also fails because curl does not decompress gzip from the Visual Studio Code Marketplace.

Checks for the server package instead of node. Uses --compressed with curl to decompress gzip on save.