### PR TITLE
Add CI validation of all LSP client documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LOAD-FILE = -l $(test-file)
 LOAD-TEST-FILES := $(foreach test-file, $(TEST-FILES), $(LOAD-FILE))
 
 # TODO: add 'checkdoc' and 'lint' here when they pass
-unix-ci: clean build compile prepare_cpp_project unix-test
+unix-ci: clean build compile prepare_cpp_project check-docs unix-test
 # TODO: add 'windows-test' back
 windows-ci: clean build compile prepare_cpp_project
 
@@ -27,6 +27,10 @@ prepare_cpp_project:
 test-downstream-pkgs:
 	@echo "Test downstream packages..."
 	./test/downstream/run.sh
+
+check-docs:
+	@echo "Checking built-in client documentation..."
+	@scripts/check-docs.sh
 
 checkdoc:
 	@echo "Run checkdoc..."
@@ -60,4 +64,4 @@ clean:
 	rm -rf test/fixtures/SampleCppProject/build test/fixtures/SampleCppProject/.cache
 
 
-.PHONY: build ci compile checkdoc lint test docs local-webpage clean
+.PHONY: build ci compile check-docs checkdoc lint test docs local-webpage clean

--- a/clients/lsp-erlang.el
+++ b/clients/lsp-erlang.el
@@ -28,11 +28,6 @@
 (require 'lsp-mode)
 (require 'lsp-semantic-tokens)
 
-(defgroup lsp-erlang nil
-  "LSP support for the Erlang programming language.
-It can use erlang-ls or erlang-language-platform (ELP)."
-  :group 'lsp-mode)
-
 (defgroup lsp-erlang-ls nil
   "LSP support for the Erlang programming language using erlang-ls."
   :group 'lsp-mode
@@ -53,7 +48,7 @@ It can use erlang-ls or erlang-language-platform (ELP)."
   "Choose LSP server."
   :type '(choice (const :tag "erlang-ls" erlang-ls)
                  (const :tag "erlang-language-platform" erlang-language-platform))
-  :group 'lsp-erlang
+  :group 'lsp-mode
   :package-version '(lsp-mode . "6.2"))
 
 ;; ---------------------------------------------------------------------

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -31,12 +31,6 @@
 (require 'lsp-semantic-tokens)
 (require 's)
 
-(defgroup lsp-rust nil
-  "LSP support for Rust, using Rust Language Server or rust-analyzer."
-  :group 'lsp-mode
-  :link '(url-link "https://github.com/rust-lang/rls")
-  :package-version '(lsp-mode . "6.1"))
-
 (defgroup lsp-rust-rls nil
   "LSP support for Rust, using Rust Language Server."
   :group 'lsp-mode
@@ -59,7 +53,7 @@
   "Choose LSP server."
   :type '(choice (const :tag "rls" rls)
                  (const :tag "rust-analyzer" rust-analyzer))
-  :group 'lsp-rust
+  :group 'lsp-mode
   :package-version '(lsp-mode . "6.2"))
 
 ;; RLS

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -89,7 +89,8 @@
     "lsp-install-server": "beancount-ls",
     "debugger": "Not available"
   },
-  { "name": "biome",
+  {
+    "name": "biome",
     "full-name": "Biome",
     "server-name": "biome-language-server",
     "server-url": "https://github.com/biomejs/biome",
@@ -115,31 +116,6 @@
     "debugger": "Not available"
   },
   {
-    "name": "camel",
-    "full-name": "CAMEL",
-    "server-name": "camells",
-    "server-url": "https://github.com/camel-tooling/camel-language-server/",
-    "installation": "Automatic by lsp-mode with `lsp-install-server`",
-    "lsp-install-server": "camells",
-    "debugger": "Not available"
-  },
-  {
-    "name": "copilot",
-    "full-name": "GitHub Copilot",
-    "server-name": "copilot-language-server",
-    "server-url": "https://www.npmjs.com/package/@github/copilot-language-server",
-    "installation-url": "https://www.npmjs.com/package/@github/copilot-language-server",
-    "debugger": "Not available"
-  },
-  {
-    "name": "credo",
-    "full-name": "Credo",
-    "server-name": "credo-ls",
-    "server-url": "https://github.com/elixir-tools/credo-language-server",
-    "installation-url": "https://github.com/elixir-tools/credo-language-server#installation",
-    "debugger": "Not available"
-  },
-  {
     "name": "csharp",
     "common-group-name": "csharp",
     "full-name": "C# (csharp-ls)",
@@ -147,16 +123,6 @@
     "server-url": "https://github.com/razzmatazz/csharp-language-server",
     "installation": "Automatic by lsp-mode with `dotnet tool install -g`",
     "lsp-install-server": "csharp-ls",
-    "debugger": "Yes (netcoredbg)"
-  },
-  {
-    "name": "csharp-omnisharp",
-    "common-group-name": "csharp",
-    "full-name": "C# (Omnisharp-Roslyn)",
-    "server-name": "OmniSharp-Roslyn",
-    "server-url": "https://github.com/OmniSharp/omnisharp-roslyn",
-    "installation": "Supports automatic installation.",
-    "lsp-install-server": "omnisharp",
     "debugger": "Yes (netcoredbg)"
   },
   {
@@ -170,12 +136,14 @@
     "debugger": "Yes (netcoredbg)"
   },
   {
-    "name": "c3",
-    "full-name": "c3 language server",
-    "server-name": "c3lsp",
-    "server-url": "https://github.com/pherrymason/c3-lsp",
-    "installation-url": "https://github.com/pherrymason/c3-lsp",
-    "debugger": "Yes (gdb or lldb)"
+    "name": "csharp-omnisharp",
+    "common-group-name": "csharp",
+    "full-name": "C# (Omnisharp-Roslyn)",
+    "server-name": "OmniSharp-Roslyn",
+    "server-url": "https://github.com/OmniSharp/omnisharp-roslyn",
+    "installation": "Supports automatic installation.",
+    "lsp-install-server": "omnisharp",
+    "debugger": "Yes (netcoredbg)"
   },
   {
     "name": "ccls",
@@ -194,6 +162,23 @@
     "server-url": "https://clangd.llvm.org/",
     "installation-url": "https://clangd.llvm.org/installation.html",
     "debugger": "Yes (gdb or lldb)"
+  },
+  {
+    "name": "c3",
+    "full-name": "c3 language server",
+    "server-name": "c3lsp",
+    "server-url": "https://github.com/pherrymason/c3-lsp",
+    "installation-url": "https://github.com/pherrymason/c3-lsp",
+    "debugger": "Yes (gdb or lldb)"
+  },
+  {
+    "name": "camel",
+    "full-name": "CAMEL",
+    "server-name": "camells",
+    "server-url": "https://github.com/camel-tooling/camel-language-server/",
+    "installation": "Automatic by lsp-mode with `lsp-install-server`",
+    "lsp-install-server": "camells",
+    "debugger": "Not available"
   },
   {
     "name": "clojure",
@@ -228,6 +213,14 @@
     "server-url": "https://github.com/MathiasPius/crates-lsp",
     "installation-url": "https://github.com/MathiasPius/crates-lsp?tab=readme-ov-file#1-installing-crates-lsp",
     "lsp-install-server": "crates-lsp",
+    "debugger": "Not available"
+  },
+  {
+    "name": "credo",
+    "full-name": "Credo",
+    "server-name": "credo-ls",
+    "server-url": "https://github.com/elixir-tools/credo-language-server",
+    "installation-url": "https://github.com/elixir-tools/credo-language-server#installation",
     "debugger": "Not available"
   },
   {
@@ -368,6 +361,16 @@
     "debugger": "Yes (netcoredbg)"
   },
   {
+    "name": "fennel",
+    "common-group-name": "fennel",
+    "full-name": "Fennel",
+    "server-name": "fennel-ls",
+    "installation-url": "https://git.sr.ht/~xerool/fennel-ls",
+    "server-url": "https://git.sr.ht/~xerool/fennel-ls",
+    "installation": "luarocks install fennel-ls",
+    "debugger": "Not available"
+  },
+  {
     "name": "fish",
     "full-name": "Fish shell",
     "server-name": "fish-lsp",
@@ -408,11 +411,28 @@
     "debugger": "Not available"
   },
   {
+    "name": "magik",
+    "full-name": "GE Smallworld Magik",
+    "server-name": "magik-language-server",
+    "server-url": "https://github.com/StevenLooman/magik-tools",
+    "installation": "Automatic by lsp-mode with `lsp-install-server`",
+    "lsp-install-server": "magik-ls",
+    "debugger": "Yes"
+  },
+  {
     "name": "gettext",
     "full-name": "gettext",
     "server-name": "po-language-server",
     "server-url": "https://github.com/JulienPalard/po-language-server",
     "installation-url": "https://github.com/JulienPalard/po-language-server",
+    "debugger": "Not available"
+  },
+  {
+    "name": "copilot",
+    "full-name": "GitHub Copilot",
+    "server-name": "copilot-language-server",
+    "server-url": "https://www.npmjs.com/package/@github/copilot-language-server",
+    "installation-url": "https://www.npmjs.com/package/@github/copilot-language-server",
     "debugger": "Not available"
   },
   {
@@ -432,6 +452,15 @@
     "debugger": "Not available"
   },
   {
+    "name": "gpr",
+    "full-name": "GNAT Project",
+    "server-name": "ada_language_server",
+    "server-url": "https://github.com/AdaCore/ada_language_server",
+    "installation-url": "https://github.com/AdaCore/ada_language_server#install",
+    "lsp-install-server": "gpr-ls",
+    "debugger": "Not available"
+  },
+  {
     "name": "go",
     "full-name": "Go",
     "server-name": "gopls",
@@ -446,15 +475,6 @@
     "server-url": "https://github.com/nametake/golangci-lint-langserver",
     "installation": "go install github.com/nametake/golangci-lint-langserver@latest",
     "installation-url": "https://github.com/nametake/golangci-lint-langserver#installation",
-    "debugger": "Not available"
-  },
-  {
-    "name": "gpr",
-    "full-name": "GNAT Project",
-    "server-name": "ada_language_server",
-    "server-url": "https://github.com/AdaCore/ada_language_server",
-    "installation-url": "https://github.com/AdaCore/ada_language_server#install",
-    "lsp-install-server": "gpr-ls",
     "debugger": "Not available"
   },
   {
@@ -492,6 +512,14 @@
     "debugger": "Not available"
   },
   {
+    "name": "haxe",
+    "full-name": "Haxe",
+    "server-name": "vshaxe",
+    "server-url": "https://github.com/vshaxe/vshaxe",
+    "installation-url": "https://github.com/vshaxe/vshaxe#installation",
+    "debugger": "Not available"
+  },
+  {
     "name": "html",
     "full-name": "HTML",
     "server-name": "html",
@@ -525,6 +553,14 @@
     "debugger": "Yes (Firefox/Chrome)"
   },
   {
+    "name": "deno",
+    "common-group-name": "javascript",
+    "full-name": "Javascript/Typescript (deno)",
+    "server-name": "deno lsp",
+    "server-url": "https://deno.land/#installation",
+    "debugger": "Yes (Chrome)"
+  },
+  {
     "name": "tsgo",
     "common-group-name": "javascript",
     "full-name": "JavaScript/TypeScript (Go native)",
@@ -555,21 +591,13 @@
     "debugger": "Yes (Firefox/Chrome)"
   },
   {
-    "name": "typespec",
-    "full-name": "TypeSpec",
-    "server-name": "tsp server",
-    "server-url": "https://github.com/microsoft/typespec/tree/main/packages/compiler",
-    "installation": "npm i -g @typespec/compiler",
-    "lsp-install-server": "@typespec/compiler",
-    "debugger": "Yes (Firefox/Chrome)"
-  },
-  {
-    "name": "deno",
-    "common-group-name": "javascript",
-    "full-name": "Javascript/Typescript (deno)",
-    "server-name": "deno lsp",
-    "server-url": "https://deno.land/#installation",
-    "debugger": "Yes (Chrome)"
+    "name": "jq",
+    "full-name": "Jq (jq-lsp)",
+    "server-name": "jq-lsp",
+    "server-url": "https://github.com/wader/jq-lsp",
+    "installation": "go install github.com/wader/jq-lsp@master",
+    "installation-url": "https://github.com/wader/jq-lsp#install",
+    "debugger": "Not available"
   },
   {
     "name": "json",
@@ -608,28 +636,11 @@
     "debugger": "Not available"
   },
   {
-    "name": "jq",
-    "full-name": "Jq (jq-lsp)",
-    "server-name": "jq-lsp",
-    "server-url": "https://github.com/wader/jq-lsp",
-    "installation": "go install github.com/wader/jq-lsp@master",
-    "installation-url": "https://github.com/wader/jq-lsp#install",
-    "debugger": "Not available"
-  },
-  {
     "name": "kotlin",
     "full-name": "Kotlin",
     "server-name": "kotlin-language-server",
     "server-url": "https://github.com/fwcd/KotlinLanguageServer",
     "installation-url": "https://github.com/fwcd/kotlin-language-server/blob/master/BUILDING.md",
-    "debugger": "Not available"
-  },
-  {
-    "name": "lisp",
-    "full-name": "Lisp",
-    "server-name": "alive-lsp",
-    "server-url": "https://github.com/nobody-famous/alive-lsp",
-    "installation-url": "https://github.com/nobody-famous/alive-lsp?tab=readme-ov-file#running-the-server",
     "debugger": "Not available"
   },
   {
@@ -646,6 +657,14 @@
     "server-name": "LTEX+",
     "server-url": "https://github.com/ltex-plus/ltex-ls-plus",
     "installation-url": "https://ltex-plus.github.io/ltex-plus/installation-usage.html",
+    "debugger": "Not available"
+  },
+  {
+    "name": "lisp",
+    "full-name": "Lisp",
+    "server-name": "alive-lsp",
+    "server-url": "https://github.com/nobody-famous/alive-lsp",
+    "installation-url": "https://github.com/nobody-famous/alive-lsp?tab=readme-ov-file#running-the-server",
     "debugger": "Not available"
   },
   {
@@ -686,25 +705,6 @@
     "debugger": "Not available"
   },
   {
-    "name": "fennel",
-    "common-group-name": "fennel",
-    "full-name": "Fennel",
-    "server-name": "fennel-ls",
-    "installation-url": "https://git.sr.ht/~xerool/fennel-ls",
-    "server-url": "https://git.sr.ht/~xerool/fennel-ls",
-    "installation": "luarocks install fennel-ls",
-    "debugger": "Not available"
-  },
-  {
-    "name": "magik",
-    "full-name": "GE Smallworld Magik",
-    "server-name": "magik-language-server",
-    "server-url": "https://github.com/StevenLooman/magik-tools",
-    "installation": "Automatic by lsp-mode with `lsp-install-server`",
-    "lsp-install-server": "magik-ls",
-    "debugger": "Yes"
-  },
-  {
     "name": "markdown",
     "full-name": "Markdown",
     "server-name": "unified-language-server (deprecated in favor of remark-language-server)",
@@ -729,19 +729,19 @@
     "debugger": "Not available"
   },
   {
+    "name": "mdx",
+    "full-name": "mdx",
+    "server-name": "mdx-analyzer",
+    "server-url": "https://github.com/mdx-js/mdx-analyzer/tree/main/packages/language-server",
+    "installation": "npm install -g @mdx-js/language-server",
+    "debugger": "Not available"
+  },
+  {
     "name": "meson",
     "full-name": "Meson",
     "server-name": "mesonlsp",
     "server-url": "https://github.com/JCWasmx86/mesonlsp",
     "installation-url": "https://github.com/JCWasmx86/mesonlsp",
-    "debugger": "Not available"
-  },
-  {
-    "name": "sml",
-    "full-name": "Standard ML (Millet)",
-    "server-name": "millet",
-    "server-url": "https://github.com/azdavis/millet",
-    "installation-url": "https://github.com/azdavis/millet",
     "debugger": "Not available"
   },
   {
@@ -753,19 +753,19 @@
     "debugger": "Not available"
   },
   {
+    "name": "mojo",
+    "full-name": "Mojo",
+    "server-name": "mojo-lsp-server",
+    "server-url": "https://mojolang.org/",
+    "installation-url": "https://mojolang.org/docs/manual/quickstart/",
+    "debugger": "Not available"
+  },
+  {
     "name": "move",
     "full-name": "Move Language",
     "server-name": "move-analyzer",
     "server-url": "https://github.com/move-language/move",
     "installation-url": "https://github.com/move-language/move/tree/main/language/move-analyzer",
-    "debugger": "Not available"
-  },
-  {
-    "name": "mdx",
-    "full-name": "mdx",
-    "server-name": "mdx-analyzer",
-    "server-url": "https://github.com/mdx-js/mdx-analyzer/tree/main/packages/language-server",
-    "installation": "npm install -g @mdx-js/language-server",
     "debugger": "Not available"
   },
   {
@@ -801,11 +801,11 @@
     "debugger": "Not available"
   },
   {
-    "name": "ocaml-lsp-server",
-    "full-name": "OCaml",
-    "server-name": "ocaml-lsp-server",
-    "server-url": "https://github.com/ocaml/ocaml-lsp",
-    "installation-url": "https://github.com/ocaml/ocaml-lsp#installation",
+    "name": "nix-nil",
+    "full-name": "Nix",
+    "server-name": "nix-nil",
+    "server-url": "https://github.com/oxalica/nil",
+    "installation": "nix-env -i nil || nix profile install nixpkgs#nil",
     "debugger": "Not available"
   },
   {
@@ -825,11 +825,12 @@
     "debugger": "Not available"
   },
   {
-    "name": "nix-nil",
-    "full-name": "Nix",
-    "server-name": "nix-nil",
-    "server-url": "https://github.com/oxalica/nil",
-    "installation": "nix-env -i nil || nix profile install nixpkgs#nil",
+    "name": "solidity",
+    "full-name": "nomicfoundation/solidity-language-server",
+    "server-name": "solidity-language-server",
+    "installation": "npx @nomicfoundation/solidity-language-server",
+    "server-url": "https://github.com/NomicFoundation/hardhat-vscode/blob/development/server/README.md",
+    "installation-url": "https://github.com/NomicFoundation/hardhat-vscode/blob/development/server/README.md",
     "debugger": "Not available"
   },
   {
@@ -838,6 +839,14 @@
     "server-name": "nu",
     "server-url": "https://github.com/nushell/nushell/tree/main/crates/nu-lsp",
     "installation": "It is included in Nushell >= 0.87.0",
+    "debugger": "Not available"
+  },
+  {
+    "name": "ocaml-lsp-server",
+    "full-name": "OCaml",
+    "server-name": "ocaml-lsp-server",
+    "server-url": "https://github.com/ocaml/ocaml-lsp",
+    "installation-url": "https://github.com/ocaml/ocaml-lsp#installation",
     "debugger": "Not available"
   },
   {
@@ -876,14 +885,6 @@
     "debugger": "Not available"
   },
   {
-    "name": "pls",
-    "full-name": "PLS",
-    "server-name": "Perl Language Server",
-    "server-url": "https://metacpan.org/pod/PLS",
-    "installation": "cpan PLS",
-    "debugger": "Not available"
-  },
-  {
     "name": "perl",
     "full-name": "Perl",
     "server-name": "Perl::LanguageServer",
@@ -910,6 +911,15 @@
     "debugger": "Yes"
   },
   {
+    "name": "serenata",
+    "common-group-name": "php",
+    "full-name": "PHP (Serenata)",
+    "server-name": "Serenata",
+    "server-url": "https://gitlab.com/Serenata/Serenata",
+    "installation-url": "https://gitlab.com/Serenata/Serenata/-/releases",
+    "debugger": "Yes"
+  },
+  {
     "name": "intelephense",
     "common-group-name": "php",
     "full-name": "PHP(recommended)",
@@ -926,6 +936,14 @@
     "server-url": "https://github.com/phpactor/phpactor",
     "installation-url": "https://phpactor.readthedocs.io/en/master/usage/standalone.html#installation-global",
     "debugger": "yes"
+  },
+  {
+    "name": "pls",
+    "full-name": "PLS",
+    "server-name": "Perl Language Server",
+    "server-url": "https://metacpan.org/pod/PLS",
+    "installation": "cpan PLS",
+    "debugger": "Not available"
   },
   {
     "name": "pwsh",
@@ -955,20 +973,20 @@
     "debugger": "Not available"
   },
   {
-    "name": "jedi",
-    "full-name": "Python (Jedi-language-server)",
-    "server-name": "jedi",
-    "server-url": "https://github.com/pappasam/jedi-language-server",
-    "installation-url": "https://github.com/fredcamps/lsp-jedi",
-    "debugger": "Not available"
-  },
-  {
     "name": "pylsp",
     "full-name": "Python",
     "server-name": "pylsp",
     "server-url": "https://github.com/python-lsp/python-lsp-server",
     "installation": "pip install 'python-lsp-server[all]'",
     "debugger": "Yes"
+  },
+  {
+    "name": "ruff",
+    "full-name": "Python",
+    "server-name": "ruff",
+    "server-url": "https://github.com/astral-sh/ruff",
+    "installation": "pip install ruff (previous pip install ruff-lsp)",
+    "debugger": "Not available"
   },
   {
     "name": "pyls",
@@ -979,14 +997,12 @@
     "debugger": "Yes"
   },
   {
-    "name": "pyright",
-    "full-name": "Python (Pyright)",
-    "server-name": "pyright-langserver",
-    "server-url": "https://github.com/microsoft/pyright",
-    "client-name": "lsp-pyright",
-    "client-url": "https://github.com/emacs-lsp/lsp-pyright",
-    "installation-url": "https://github.com/emacs-lsp/lsp-pyright",
-    "debugger": "Yes"
+    "name": "jedi",
+    "full-name": "Python (Jedi-language-server)",
+    "server-name": "jedi",
+    "server-url": "https://github.com/pappasam/jedi-language-server",
+    "installation-url": "https://github.com/fredcamps/lsp-jedi",
+    "debugger": "Not available"
   },
   {
     "name": "python-ms",
@@ -996,6 +1012,16 @@
     "client-name": "lsp-python-ms",
     "client-url": "https://github.com/emacs-lsp/lsp-python-ms",
     "installation-url": "https://github.com/emacs-lsp/lsp-python-ms",
+    "debugger": "Yes"
+  },
+  {
+    "name": "pyright",
+    "full-name": "Python (Pyright)",
+    "server-name": "pyright-langserver",
+    "server-url": "https://github.com/microsoft/pyright",
+    "client-name": "lsp-pyright",
+    "client-url": "https://github.com/emacs-lsp/lsp-pyright",
+    "installation-url": "https://github.com/emacs-lsp/lsp-pyright",
     "debugger": "Yes"
   },
   {
@@ -1051,23 +1077,6 @@
     "debugger": "Not available"
   },
   {
-    "name": "rpm-spec",
-    "full-name": "RPM Spec",
-    "server-name": "rpm-spec-language-server",
-    "server-url": "https://github.com/dcermak/rpm-spec-language-server",
-    "installation": "pip install --user rpm-spec-language-server",
-    "debugger": "Not available"
-  },
-  {
-    "name": "rubocop",
-    "full-name": "Ruby (RuboCop)",
-    "server-name": "rubocop",
-    "server-url": "https://github.com/rubocop/rubocop",
-    "installation-url": "https://docs.rubocop.org/rubocop/installation.html",
-    "installation": "gem install rubocop",
-    "debugger": "Not available"
-  },
-  {
     "name": "rf",
     "full-name": "robot framework",
     "server-name": "rf-intellisense",
@@ -1086,11 +1095,20 @@
     "debugger": "Not available"
   },
   {
-    "name": "ron",
-    "full-name": "Rusty Object Notation",
-    "server-name": "ron-lsp",
-    "server-url": "https://github.com/jasonjmcghee/ron-lsp/",
-    "installation": "cargo install ron-lsp",
+    "name": "rpm-spec",
+    "full-name": "RPM Spec",
+    "server-name": "rpm-spec-language-server",
+    "server-url": "https://github.com/dcermak/rpm-spec-language-server",
+    "installation": "pip install --user rpm-spec-language-server",
+    "debugger": "Not available"
+  },
+  {
+    "name": "rubocop",
+    "full-name": "Ruby (RuboCop)",
+    "server-name": "rubocop",
+    "server-url": "https://github.com/rubocop/rubocop",
+    "installation-url": "https://docs.rubocop.org/rubocop/installation.html",
+    "installation": "gem install rubocop",
     "debugger": "Not available"
   },
   {
@@ -1102,11 +1120,44 @@
     "debugger": "Not available"
   },
   {
-    "name": "ruff",
-    "full-name": "Python",
-    "server-name": "ruff",
-    "server-url": "https://github.com/astral-sh/ruff",
-    "installation": "pip install ruff (previous pip install ruff-lsp)",
+    "name": "solargraph",
+    "full-name": "Ruby (Solargraph)",
+    "server-name": "solargraph",
+    "server-url": "https://github.com/castwide/solargraph",
+    "installation": "gem install solargraph",
+    "debugger": "Yes"
+  },
+  {
+    "name": "sorbet",
+    "full-name": "Ruby (Sorbet)",
+    "server-name": "sorbet",
+    "server-url": "https://github.com/sorbet/sorbet",
+    "installation-url": "https://sorbet.org/docs/adopting#step-1-install-dependencies",
+    "debugger": "Not available"
+  },
+  {
+    "name": "steep",
+    "full-name": "Ruby (Steep)",
+    "server-name": "steep",
+    "server-url": "https://github.com/soutaro/steep",
+    "installation": "gem install steep",
+    "debugger": "Not available"
+  },
+  {
+    "name": "typeprof",
+    "full-name": "Ruby (TypeProf)",
+    "server-name": "typeprof",
+    "server-url": "https://github.com/ruby/typeprof",
+    "installation": "It is included in Ruby >= 3.1",
+    "debugger": "Not available"
+  },
+  {
+    "name": "ruby-syntax-tree",
+    "common-group-name": "Ruby (syntax_tree)",
+    "full-name": "ruby-syntax-tree",
+    "server-name": "stree",
+    "server-url": "https://github.com/ruby-syntax-tree/syntax_tree",
+    "installation-url": "https://github.com/ruby-syntax-tree/syntax_tree#installation",
     "debugger": "Not available"
   },
   {
@@ -1128,21 +1179,20 @@
     "debugger": "Yes"
   },
   {
+    "name": "ron",
+    "full-name": "Rusty Object Notation",
+    "server-name": "ron-lsp",
+    "server-url": "https://github.com/jasonjmcghee/ron-lsp/",
+    "installation": "cargo install ron-lsp",
+    "debugger": "Not available"
+  },
+  {
     "name": "semgrep",
     "full-name": "Semgrep",
     "server-name": "semgrep-ls",
     "server-url": "https://github.com/returntocorp/semgrep",
     "installation": "pip install semgrep --user",
     "debugger": "Not available"
-  },
-  {
-    "name": "serenata",
-    "common-group-name": "php",
-    "full-name": "PHP (Serenata)",
-    "server-name": "Serenata",
-    "server-url": "https://gitlab.com/Serenata/Serenata",
-    "installation-url": "https://gitlab.com/Serenata/Serenata/-/releases",
-    "debugger": "Yes"
   },
   {
     "name": "shader",
@@ -1154,28 +1204,11 @@
     "debugger": "Not available"
   },
   {
-    "name": "solargraph",
-    "full-name": "Ruby (Solargraph)",
-    "server-name": "solargraph",
-    "server-url": "https://github.com/castwide/solargraph",
-    "installation": "gem install solargraph",
-    "debugger": "Yes"
-  },
-  {
-    "name": "solidity",
-    "full-name": "nomicfoundation/solidity-language-server",
-    "server-name": "solidity-language-server",
-    "installation": "npx @nomicfoundation/solidity-language-server",
-    "server-url": "https://github.com/NomicFoundation/hardhat-vscode/blob/development/server/README.md",
-    "installation-url": "https://github.com/NomicFoundation/hardhat-vscode/blob/development/server/README.md",
-    "debugger": "Not available"
-  },
-  {
-    "name": "sorbet",
-    "full-name": "Ruby (Sorbet)",
-    "server-name": "sorbet",
-    "server-url": "https://github.com/sorbet/sorbet",
-    "installation-url": "https://sorbet.org/docs/adopting#step-1-install-dependencies",
+    "name": "postgres",
+    "full-name": "SQL (postgres-ls)",
+    "server-name": "postgres-language-server",
+    "server-url": "https://github.com/supabase-community/postgres-language-server",
+    "installation-url": "https://pgtools.dev/#installation",
     "debugger": "Not available"
   },
   {
@@ -1195,19 +1228,11 @@
     "debugger": "Not available"
   },
   {
-    "name": "postgres",
-    "full-name": "SQL (postgres-ls)",
-    "server-name": "postgres-language-server",
-    "server-url": "https://github.com/supabase-community/postgres-language-server",
-    "installation-url": "https://pgtools.dev/#installation",
-    "debugger": "Not available"
-  },
-  {
-    "name": "steep",
-    "full-name": "Ruby (Steep)",
-    "server-name": "steep",
-    "server-url": "https://github.com/soutaro/steep",
-    "installation": "gem install steep",
+    "name": "sml",
+    "full-name": "Standard ML (Millet)",
+    "server-name": "millet",
+    "server-url": "https://github.com/azdavis/millet",
+    "installation-url": "https://github.com/azdavis/millet",
     "debugger": "Not available"
   },
   {
@@ -1217,24 +1242,6 @@
     "server-url": "https://github.com/sveltejs/language-tools",
     "installation": "npm i -g svelte-language-server",
     "lsp-install-server": "svelte-ls",
-    "debugger": "Not available"
-  },
-  {
-    "name": "svlangserver",
-    "common-group-name": "verilog",
-    "full-name": "Verilog/SystemVerilog",
-    "server-name": "svlangserver",
-    "server-url": "https://github.com/imc-trading/svlangserver",
-    "installation-url": "https://github.com/imc-trading/svlangserver#installation",
-    "debugger": "Not available"
-  },
-  {
-    "name": "ruby-syntax-tree",
-    "common-group-name": "Ruby (syntax_tree)",
-    "full-name": "ruby-syntax-tree",
-    "server-name": "stree",
-    "server-url": "https://github.com/ruby-syntax-tree/syntax_tree",
-    "installation-url": "https://github.com/ruby-syntax-tree/syntax_tree#installation",
     "debugger": "Not available"
   },
   {
@@ -1260,15 +1267,6 @@
     "server-name": "terraform-ls",
     "server-url": "https://github.com/hashicorp/terraform-ls",
     "installation-url": "https://github.com/hashicorp/terraform-ls",
-    "debugger": "Not available"
-  },
-  {
-    "name": "tilt",
-    "full-name": "Tilt LSP",
-    "server-name": "tilt",
-    "installation": "To be used with tilt-mode available in https://github.com/Konubinix/tilt-mode",
-    "server-url": "https://docs.tilt.dev/cli/tilt_lsp.html",
-    "installation-url": "https://docs.tilt.dev/",
     "debugger": "Not available"
   },
   {
@@ -1298,6 +1296,15 @@
     "debugger": "Not available"
   },
   {
+    "name": "tilt",
+    "full-name": "Tilt LSP",
+    "server-name": "tilt",
+    "installation": "To be used with tilt-mode available in https://github.com/Konubinix/tilt-mode",
+    "server-url": "https://docs.tilt.dev/cli/tilt_lsp.html",
+    "installation-url": "https://docs.tilt.dev/",
+    "debugger": "Not available"
+  },
+  {
     "name": "toml",
     "full-name": "TOML",
     "server-name": "taplo",
@@ -1314,15 +1321,6 @@
     "debugger": "Not available"
   },
   {
-    "name": "trunk",
-    "full-name": "Trunk",
-    "server-name": "trunk-lsp",
-    "server-url": "https://docs.trunk.io",
-    "installation": "curl https://get.trunk.io -fsSL | bash -s -- -y; trunk init",
-    "installation-url": "https://docs.trunk.io/check",
-    "debugger": "Not available"
-  },
-  {
     "name": "ts-query",
     "full-name": "Tree-sitter Query",
     "server-name": "ts-query-lsp",
@@ -1330,27 +1328,12 @@
     "debugger": "Not available"
   },
   {
-    "name": "typeprof",
-    "full-name": "Ruby (TypeProf)",
-    "server-name": "typeprof",
-    "server-url": "https://github.com/ruby/typeprof",
-    "installation": "It is included in Ruby >= 3.1",
-    "debugger": "Not available"
-  },
-  {
-    "name": "typst",
-    "full-name": "Typst",
-    "server-name": "tinymist",
-    "server-url": "https://github.com/Myriad-Dreamin/tinymist",
-    "installation": "cargo install tinymist",
-    "debugger": "Not available"
-  },
-  {
-    "name": "typos",
-    "full-name": "Typos source code spell checker",
-    "server-name": "typos-lsp",
-    "server-url": "https://github.com/tekumara/typos-lsp",
-    "installation": "cargo install --git https://github.com/tekumara/typos-lsp typos-lsp",
+    "name": "trunk",
+    "full-name": "Trunk",
+    "server-name": "trunk-lsp",
+    "server-url": "https://docs.trunk.io",
+    "installation": "curl https://get.trunk.io -fsSL | bash -s -- -y; trunk init",
+    "installation-url": "https://docs.trunk.io/check",
     "debugger": "Not available"
   },
   {
@@ -1362,6 +1345,31 @@
     "debugger": "Not available"
   },
   {
+    "name": "typespec",
+    "full-name": "TypeSpec",
+    "server-name": "tsp server",
+    "server-url": "https://github.com/microsoft/typespec/tree/main/packages/compiler",
+    "installation": "npm i -g @typespec/compiler",
+    "lsp-install-server": "@typespec/compiler",
+    "debugger": "Yes (Firefox/Chrome)"
+  },
+  {
+    "name": "typos",
+    "full-name": "Typos source code spell checker",
+    "server-name": "typos-lsp",
+    "server-url": "https://github.com/tekumara/typos-lsp",
+    "installation": "cargo install --git https://github.com/tekumara/typos-lsp typos-lsp",
+    "debugger": "Not available"
+  },
+  {
+    "name": "typst",
+    "full-name": "Typst",
+    "server-name": "tinymist",
+    "server-url": "https://github.com/Myriad-Dreamin/tinymist",
+    "installation": "cargo install tinymist",
+    "debugger": "Not available"
+  },
+  {
     "name": "v",
     "full-name": "V",
     "server-name": "vls",
@@ -1370,11 +1378,28 @@
     "debugger": "Not available"
   },
   {
+    "name": "v-analyzer",
+    "full-name": "V (v-analyzer)",
+    "server-name": "v-analyzer",
+    "server-url": "https://github.com/vlang/v-analyzer",
+    "installation-url": "https://github.com/vlang/v-analyzer",
+    "debugger": "Not available"
+  },
+  {
     "name": "vala",
     "full-name": "Vala",
     "server-name": "vala-language-server",
     "server-url": "https://github.com/benwaffle/vala-language-server",
     "installation": "meson build && ninja -C build install",
+    "debugger": "Not available"
+  },
+  {
+    "name": "svlangserver",
+    "common-group-name": "verilog",
+    "full-name": "Verilog/SystemVerilog",
+    "server-name": "svlangserver",
+    "server-url": "https://github.com/imc-trading/svlangserver",
+    "installation-url": "https://github.com/imc-trading/svlangserver#installation",
     "debugger": "Not available"
   },
   {
@@ -1487,30 +1512,6 @@
     "server-name": "zls",
     "server-url": "https://github.com/zigtools/zls",
     "installation-url": "https://github.com/zigtools/zls#installation",
-    "debugger": "Not available"
-  },
-  {
-    "name": "haxe",
-    "full-name": "Haxe",
-    "server-name": "vshaxe",
-    "server-url": "https://github.com/vshaxe/vshaxe",
-    "installation-url": "https://github.com/vshaxe/vshaxe#installation",
-    "debugger": "Not available"
-  },
-  {
-    "name": "mojo",
-    "full-name": "Mojo",
-    "server-name": "mojo-lsp-server",
-    "server-url": "https://mojolang.org/",
-    "installation-url": "https://mojolang.org/docs/manual/quickstart/",
-    "debugger": "Not available"
-  },
-  {
-    "name": "v-analyzer",
-    "full-name": "V (v-analyzer)",
-    "server-name": "v-analyzer",
-    "server-url": "https://github.com/vlang/v-analyzer",
-    "installation-url": "https://github.com/vlang/v-analyzer",
     "debugger": "Not available"
   }
 ]

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -140,7 +140,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "csharp-ls",
+    "name": "csharp",
     "common-group-name": "csharp",
     "full-name": "C# (csharp-ls)",
     "server-name": "csharp-ls",
@@ -160,7 +160,7 @@
     "debugger": "Yes (netcoredbg)"
   },
   {
-    "name": "csharp-roslyn",
+    "name": "roslyn",
     "common-group-name": "csharp",
     "full-name": "C# (csharp-roslyn)",
     "server-name": "Microsoft.CodeAnalysis.LanguageServer (Roslyn)",
@@ -170,7 +170,7 @@
     "debugger": "Yes (netcoredbg)"
   },
   {
-    "name": "c3-lsp",
+    "name": "c3",
     "full-name": "c3 language server",
     "server-name": "c3lsp",
     "server-url": "https://github.com/pherrymason/c3-lsp",
@@ -231,7 +231,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "crystal",
+    "name": "crystalline",
     "full-name": "Crystal",
     "server-name": "crystalline",
     "server-url": "https://github.com/elbywan/crystalline",
@@ -326,7 +326,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "emmet",
+    "name": "emmet-ls",
     "full-name": "Emmet",
     "server-name": "emmet-ls",
     "server-url": "https://github.com/aca/emmet-ls",
@@ -432,7 +432,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "gopls",
+    "name": "go",
     "full-name": "Go",
     "server-name": "gopls",
     "server-url": "https://github.com/golang/tools/tree/master/gopls",
@@ -440,7 +440,7 @@
     "debugger": "Yes"
   },
   {
-    "name": "golangci-lint-server",
+    "name": "golangci-lint",
     "full-name": "golangci-lint",
     "server-name": "golangci-lint-server",
     "server-url": "https://github.com/nametake/golangci-lint-langserver",
@@ -501,7 +501,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "hyuga",
+    "name": "hy",
     "full-name": "Hy",
     "server-name": "hyuga",
     "server-url": "https://github.com/sakuraiyuta/hyuga",
@@ -525,7 +525,7 @@
     "debugger": "Yes (Firefox/Chrome)"
   },
   {
-    "name": "typescript-go",
+    "name": "tsgo",
     "common-group-name": "javascript",
     "full-name": "JavaScript/TypeScript (Go native)",
     "server-name": "typescript-go",
@@ -677,7 +677,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "lua-roblox",
+    "name": "lua-roblox-language-server",
     "common-group-name": "lua",
     "full-name": "Lua Roblox",
     "server-name": "lua-roblox-language-server",
@@ -737,7 +737,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "millet",
+    "name": "sml",
     "full-name": "Standard ML (Millet)",
     "server-name": "millet",
     "server-url": "https://github.com/azdavis/millet",
@@ -785,7 +785,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "nim",
+    "name": "nimlsp",
     "full-name": "Nim",
     "server-name": "nimlsp",
     "server-url": "https://github.com/PMunch/nimlsp",
@@ -849,7 +849,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "ols",
+    "name": "odin-ols",
     "full-name": "Odin Language Server",
     "server-name": "ols",
     "server-url": "https://github.com/DanielGavin/ols",
@@ -1068,7 +1068,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "robot",
+    "name": "rf",
     "full-name": "robot framework",
     "server-name": "rf-intellisense",
     "server-url": "https://github.com/tomi/vscode-rf-language-server",
@@ -1229,7 +1229,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "syntax_tree",
+    "name": "ruby-syntax-tree",
     "common-group-name": "Ruby (syntax_tree)",
     "full-name": "ruby-syntax-tree",
     "server-name": "stree",
@@ -1306,7 +1306,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "toml-tombi",
+    "name": "tombi-toml",
     "full-name": "TOML",
     "server-name": "tombi",
     "server-url": "https://github.com/tombi-toml/tombi",
@@ -1404,7 +1404,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "vimscript",
+    "name": "vim",
     "full-name": "Vimscript",
     "server-name": "vim-language-server",
     "server-url": "https://github.com/iamcco/vim-language-server",
@@ -1431,7 +1431,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "wasm-language-tools",
+    "name": "wat",
     "common-group-name": "wat",
     "full-name": "WebAssembly",
     "server-name": "wat_server",
@@ -1440,7 +1440,7 @@
     "debugger": "Not available"
   },
   {
-    "name": "wgsl-analyzer",
+    "name": "wgsl",
     "full-name": "wgsl",
     "server-name": "wgsl-analyzer",
     "server-url": "https://github.com/wgsl-analyzer/wgsl-analyzer",
@@ -1487,6 +1487,30 @@
     "server-name": "zls",
     "server-url": "https://github.com/zigtools/zls",
     "installation-url": "https://github.com/zigtools/zls#installation",
+    "debugger": "Not available"
+  },
+  {
+    "name": "haxe",
+    "full-name": "Haxe",
+    "server-name": "vshaxe",
+    "server-url": "https://github.com/vshaxe/vshaxe",
+    "installation-url": "https://github.com/vshaxe/vshaxe#installation",
+    "debugger": "Not available"
+  },
+  {
+    "name": "mojo",
+    "full-name": "Mojo",
+    "server-name": "mojo-lsp-server",
+    "server-url": "https://mojolang.org/",
+    "installation-url": "https://mojolang.org/docs/manual/quickstart/",
+    "debugger": "Not available"
+  },
+  {
+    "name": "v-analyzer",
+    "full-name": "V (v-analyzer)",
+    "server-name": "v-analyzer",
+    "server-url": "https://github.com/vlang/v-analyzer",
+    "installation-url": "https://github.com/vlang/v-analyzer",
     "debugger": "Not available"
   }
 ]

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -30,7 +30,7 @@
     "full-name": "Ansible",
     "server-name": "ansible-language-server",
     "server-url": "https://github.com/ansible/ansible-language-server",
-    "installation": "npm i -g @ansible/ansible-language-server",
+    "installation": "npm install -g @ansible/ansible-language-server",
     "lsp-install-server": "ansible-ls",
     "debugger": "Not available"
   },
@@ -48,7 +48,7 @@
     "full-name": "Astro",
     "server-name": "astro-ls",
     "server-url": "https://github.com/withastro/language-tools",
-    "installation": "npm i -g @astrojs/language-server",
+    "installation": "npm install -g @astrojs/language-server",
     "lsp-install-server": "astro-ls",
     "debugger": "Not available"
   },
@@ -66,7 +66,7 @@
     "full-name": "AWK",
     "server-name": "awk-language-server",
     "server-url": "https://github.com/Beaglefoot/awk-language-server",
-    "installation": "npm i -g awk-language-server",
+    "installation": "npm install -g awk-language-server",
     "lsp-install-server": "awkls",
     "debugger": "Not available"
   },
@@ -75,7 +75,7 @@
     "full-name": "Bash",
     "server-name": "bash-language-server",
     "server-url": "https://github.com/mads-hartmann/bash-language-server",
-    "installation": "npm i -g bash-language-server",
+    "installation": "npm install -g bash-language-server",
     "lsp-install-server": "bash-ls",
     "debugger": "Not available"
   },
@@ -121,7 +121,6 @@
     "full-name": "C# (csharp-ls)",
     "server-name": "csharp-ls",
     "server-url": "https://github.com/razzmatazz/csharp-language-server",
-    "installation": "Automatic by lsp-mode with `dotnet tool install -g`",
     "lsp-install-server": "csharp-ls",
     "debugger": "Yes (netcoredbg)"
   },
@@ -131,7 +130,6 @@
     "full-name": "C# (csharp-roslyn)",
     "server-name": "Microsoft.CodeAnalysis.LanguageServer (Roslyn)",
     "server-url": "https://github.com/dotnet/roslyn/tree/main/src/LanguageServer",
-    "installation": "Supports automatic installation via NuGet",
     "lsp-install-server": "csharp-roslyn",
     "debugger": "Yes (netcoredbg)"
   },
@@ -141,7 +139,6 @@
     "full-name": "C# (omnisharp-roslyn)",
     "server-name": "OmniSharp-Roslyn",
     "server-url": "https://github.com/OmniSharp/omnisharp-roslyn",
-    "installation": "Supports automatic installation.",
     "lsp-install-server": "omnisharp",
     "debugger": "Yes (netcoredbg)"
   },
@@ -176,7 +173,6 @@
     "full-name": "Camel",
     "server-name": "camells",
     "server-url": "https://github.com/camel-tooling/camel-language-server/",
-    "installation": "Automatic by lsp-mode with `lsp-install-server`",
     "lsp-install-server": "camells",
     "debugger": "Not available"
   },
@@ -314,7 +310,7 @@
     "full-name": "Elm",
     "server-name": "elmLS",
     "server-url": "https://github.com/elm-tooling/elm-language-server",
-    "installation": "npm i -g @elm-tooling/elm-language-server, or clone the repository and follow installation instructions",
+    "installation": "npm install -g @elm-tooling/elm-language-server, or clone the repository and follow installation instructions",
     "lsp-install-server": "elm-ls",
     "debugger": "Not available"
   },
@@ -323,7 +319,7 @@
     "full-name": "Emmet",
     "server-name": "emmet-ls",
     "server-url": "https://github.com/aca/emmet-ls",
-    "installation": "npm i -g emmet-ls",
+    "installation": "npm install -g emmet-ls",
     "lsp-install-server": "emmet-ls",
     "debugger": "Not available"
   },
@@ -356,7 +352,6 @@
     "full-name": "F#",
     "server-name": "fsautocomplete",
     "server-url": "https://github.com/fsharp/FsAutoComplete",
-    "installation": "Automatic by lsp-mode",
     "lsp-install-server": "fsac",
     "debugger": "Yes (netcoredbg)"
   },
@@ -474,7 +469,7 @@
     "server-name": "@emacs-grammarly/grammarly-languageserver",
     "server-url": "https://github.com/emacs-grammarly/grammarly-language-server",
     "installation-url": "https://github.com/emacs-grammarly/grammarly-language-server",
-    "installation": "npm i -g @emacs-grammarly/grammarly-languageserver",
+    "installation": "npm install -g @emacs-grammarly/grammarly-languageserver",
     "debugger": "Not available"
   },
   {
@@ -483,7 +478,7 @@
     "server-name": "graphql-language-service-cli",
     "server-url": "https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service-cli#readme",
     "installation-url": "https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service-cli#installation-and-usage",
-    "installation": "npm i -g graphql-language-service-cli",
+    "installation": "npm install -g graphql-language-service-cli",
     "debugger": "Not available"
   },
   {
@@ -567,7 +562,7 @@
     "full-name": "JavaScript/TypeScript (sourcegraph)",
     "server-name": "javascript-typescript-stdio",
     "server-url": "https://github.com/sourcegraph/javascript-typescript-langserver",
-    "installation": "npm i -g javascript-typescript-langserver",
+    "installation": "npm install -g javascript-typescript-langserver",
     "lsp-install-server": "jsts-ls",
     "debugger": "Yes (Firefox/Chrome)"
   },
@@ -577,7 +572,7 @@
     "full-name": "JavaScript/TypeScript (theia-ide, RECOMMENDED)",
     "server-name": "typescript-language-server (formerly theia-ide / TypeFox)",
     "server-url": "https://github.com/typescript-language-server/typescript-language-server",
-    "installation": "npm i -g typescript-language-server; npm i -g typescript",
+    "installation": "npm install -g typescript-language-server; npm install -g typescript",
     "lsp-install-server": "ts-ls",
     "debugger": "Yes (Firefox/Chrome)"
   },
@@ -595,7 +590,7 @@
     "full-name": "Json",
     "server-name": "vscode-json-languageserver",
     "server-url": "https://github.com/microsoft/vscode/tree/main/extensions/json-language-features/server",
-    "installation": "Automatic or manual by npm i -g vscode-langservers-extracted",
+    "installation": "npm install -g vscode-langservers-extracted",
     "lsp-install-server": "json-ls",
     "debugger": "Not available"
   },
@@ -700,7 +695,6 @@
     "full-name": "Magik",
     "server-name": "magik-language-server",
     "server-url": "https://github.com/StevenLooman/magik-tools",
-    "installation": "Automatic by lsp-mode with `lsp-install-server`",
     "lsp-install-server": "magik-ls",
     "debugger": "Yes"
   },
@@ -709,7 +703,7 @@
     "full-name": "Markdown",
     "server-name": "unified-language-server (deprecated in favor of remark-language-server)",
     "server-url": "https://github.com/unifiedjs/unified-language-server",
-    "installation": "npm i -g unified-language-server",
+    "installation": "npm install -g unified-language-server",
     "debugger": "Not available"
   },
   {
@@ -924,7 +918,7 @@
     "full-name": "PHP (intelephense, RECOMMENDED)",
     "server-name": "intelephense",
     "server-url": "https://github.com/bmewburn/vscode-intelephense",
-    "installation": "Automatic or manual by `npm i intelephense -g`",
+    "installation": "npm install -g intelephense",
     "debugger": "Yes"
   },
   {
@@ -950,7 +944,6 @@
     "full-name": "Powershell",
     "server-name": "PowerShellEditorServices",
     "server-url": "https://github.com/PowerShell/PowerShellEditorServices",
-    "installation": "Automatic",
     "lsp-install-server": "pwsh-ls",
     "debugger": "Yes"
   },
@@ -968,7 +961,7 @@
     "server-name": "purescript-language-server",
     "server-url": "https://github.com/nwolverson/purescript-language-server",
     "installation-url": "https://github.com/nwolverson/purescript-language-server#usage",
-    "installation": "npm i -g purescript-language-server",
+    "installation": "npm install -g purescript-language-server",
     "lsp-install-server": "pursls",
     "debugger": "Not available"
   },
@@ -1073,7 +1066,7 @@
     "full-name": "Remark",
     "server-name": "remark-language-server",
     "server-url": "https://github.com/remarkjs/remark-language-server",
-    "installation": "npm i -g remark-language-server",
+    "installation": "npm install -g remark-language-server",
     "debugger": "Not available"
   },
   {
@@ -1216,7 +1209,7 @@
     "full-name": "SQL (sql)",
     "server-name": "sql-language-server",
     "server-url": "https://github.com/joe-re/sql-language-server",
-    "installation": "npm i -g sql-language-server",
+    "installation": "npm install -g sql-language-server",
     "debugger": "Not available"
   },
   {
@@ -1240,7 +1233,7 @@
     "full-name": "Svelte",
     "server-name": "svelteserver",
     "server-url": "https://github.com/sveltejs/language-tools",
-    "installation": "npm i -g svelte-language-server",
+    "installation": "npm install -g svelte-language-server",
     "lsp-install-server": "svelte-ls",
     "debugger": "Not available"
   },
@@ -1349,7 +1342,7 @@
     "full-name": "TypeSpec",
     "server-name": "tsp server",
     "server-url": "https://github.com/microsoft/typespec/tree/main/packages/compiler",
-    "installation": "npm i -g @typespec/compiler",
+    "installation": "npm install -g @typespec/compiler",
     "lsp-install-server": "@typespec/compiler",
     "debugger": "Yes (Firefox/Chrome)"
   },
@@ -1477,7 +1470,6 @@
     "full-name": "XML",
     "server-name": "lsp4xml",
     "server-url": "https://github.com/eclipse/lemminx",
-    "installation": "Automatic by lsp-mode",
     "lsp-install-server": "xmlls",
     "debugger": "Not available"
   },

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -99,7 +99,7 @@
   },
   {
     "name": "buf",
-    "full-name": "buf CLI (Beta)",
+    "full-name": "Buf/Protocol Buffers (Buf CLI)",
     "server-name": "buf",
     "server-url": "https://github.com/bufbuild/buf",
     "installation": "npm install -g @bufbuild/buf",
@@ -108,7 +108,7 @@
   },
   {
     "name": "bufls",
-    "full-name": "buf-language-server",
+    "full-name": "Buf/Protocol Buffers (Buf Language Server)",
     "server-name": "bufls",
     "server-url": "https://github.com/bufbuild/buf-language-server",
     "installation": "go install github.com/bufbuild/buf-language-server/cmd/bufls@latest",
@@ -138,7 +138,7 @@
   {
     "name": "csharp-omnisharp",
     "common-group-name": "csharp",
-    "full-name": "C# (Omnisharp-Roslyn)",
+    "full-name": "C# (omnisharp-roslyn)",
     "server-name": "OmniSharp-Roslyn",
     "server-url": "https://github.com/OmniSharp/omnisharp-roslyn",
     "installation": "Supports automatic installation.",
@@ -147,7 +147,7 @@
   },
   {
     "name": "ccls",
-    "full-name": "C++",
+    "full-name": "C++ (ccls)",
     "server-name": "ccls",
     "server-url": "https://github.com/MaskRay/ccls",
     "client-name": "emacs-ccls",
@@ -157,7 +157,7 @@
   },
   {
     "name": "clangd",
-    "full-name": "C++",
+    "full-name": "C++ (clangd)",
     "server-name": "clangd",
     "server-url": "https://clangd.llvm.org/",
     "installation-url": "https://clangd.llvm.org/installation.html",
@@ -165,7 +165,7 @@
   },
   {
     "name": "c3",
-    "full-name": "c3 language server",
+    "full-name": "C3 (c3-lsp)",
     "server-name": "c3lsp",
     "server-url": "https://github.com/pherrymason/c3-lsp",
     "installation-url": "https://github.com/pherrymason/c3-lsp",
@@ -173,7 +173,7 @@
   },
   {
     "name": "camel",
-    "full-name": "CAMEL",
+    "full-name": "Camel",
     "server-name": "camells",
     "server-url": "https://github.com/camel-tooling/camel-language-server/",
     "installation": "Automatic by lsp-mode with `lsp-install-server`",
@@ -294,7 +294,7 @@
   },
   {
     "name": "earthly",
-    "full-name": "Earthfile language server",
+    "full-name": "Earthfile",
     "server-name": "earthlyls",
     "server-url": "https://github.com/glehmann/earthlyls",
     "installation": "cargo install earthlyls",
@@ -328,24 +328,24 @@
     "debugger": "Not available"
   },
   {
-    "name": "erlang-ls",
-    "full-name": "Erlang",
-    "server-name": "erlang_ls",
-    "server-url": "https://github.com/erlang-ls/erlang_ls",
-    "installation-url": "https://github.com/erlang-ls/erlang_ls",
-    "debugger": "Not available"
-  },
-  {
     "name": "erlang-elp",
-    "full-name": "Erlang",
+    "full-name": "Erlang (ELP)",
     "server-name": "elp",
     "server-url": "https://github.com/WhatsApp/erlang-language-platform",
     "installation-url": "https://github.com/WhatsApp/erlang-language-platform",
     "debugger": "Not available"
   },
   {
+    "name": "erlang-ls",
+    "full-name": "Erlang (Erlang LS)",
+    "server-name": "erlang_ls",
+    "server-url": "https://github.com/erlang-ls/erlang_ls",
+    "installation-url": "https://github.com/erlang-ls/erlang_ls",
+    "debugger": "Not available"
+  },
+  {
     "name": "eslint",
-    "full-name": "ESlint",
+    "full-name": "ESLint",
     "server-name": "eslint",
     "server-url": "https://github.com/microsoft/vscode-eslint",
     "lsp-install-server": "eslint",
@@ -372,7 +372,7 @@
   },
   {
     "name": "fish",
-    "full-name": "Fish shell",
+    "full-name": "Fish (fish-lsp)",
     "server-name": "fish-lsp",
     "server-url": "https://fish-lsp.dev/",
     "installation-url": "https://github.com/ndonfris/fish-lsp#installation",
@@ -380,7 +380,7 @@
   },
   {
     "name": "fortitude",
-    "full-name": "Fortran",
+    "full-name": "Fortran (fortitude)",
     "server-name": "fortitude",
     "server-url": "https://github.com/PlasmaFAIR/fortitude",
     "installation": "pip install fortitude-lint",
@@ -388,7 +388,7 @@
   },
   {
     "name": "fortran",
-    "full-name": "Fortran",
+    "full-name": "Fortran (fortls)",
     "server-name": "fortls",
     "server-url": "https://gnikit.github.io/fortls",
     "installation": "pip install fortls",
@@ -409,15 +409,6 @@
     "server-url": "https://github.com/godotengine/godot",
     "installation-url": "https://github.com/godotengine/godot",
     "debugger": "Not available"
-  },
-  {
-    "name": "magik",
-    "full-name": "GE Smallworld Magik",
-    "server-name": "magik-language-server",
-    "server-url": "https://github.com/StevenLooman/magik-tools",
-    "installation": "Automatic by lsp-mode with `lsp-install-server`",
-    "lsp-install-server": "magik-ls",
-    "debugger": "Yes"
   },
   {
     "name": "gettext",
@@ -462,7 +453,7 @@
   },
   {
     "name": "go",
-    "full-name": "Go",
+    "full-name": "Go (gopls)",
     "server-name": "gopls",
     "server-url": "https://github.com/golang/tools/tree/master/gopls",
     "installation-url": "https://github.com/golang/tools/tree/master/gopls#installation",
@@ -530,7 +521,7 @@
   },
   {
     "name": "hy",
-    "full-name": "Hy",
+    "full-name": "Hy (hyuga)",
     "server-name": "hyuga",
     "server-url": "https://github.com/sakuraiyuta/hyuga",
     "installation": "pip install hyuga --user",
@@ -571,23 +562,23 @@
     "debugger": "Not available"
   },
   {
-    "name": "typescript",
-    "common-group-name": "javascript",
-    "full-name": "JavaScript/TypeScript (RECOMMENDED)",
-    "server-name": "typescript-language-server (formerly theia-ide / TypeFox)",
-    "server-url": "https://github.com/typescript-language-server/typescript-language-server",
-    "installation": "npm i -g typescript-language-server; npm i -g typescript",
-    "lsp-install-server": "ts-ls",
-    "debugger": "Yes (Firefox/Chrome)"
-  },
-  {
     "name": "typescript-javascript",
     "common-group-name": "javascript",
-    "full-name": "JavaScript/TypeScript (sourcegraph - UNMAINTAINED)",
+    "full-name": "JavaScript/TypeScript (sourcegraph)",
     "server-name": "javascript-typescript-stdio",
     "server-url": "https://github.com/sourcegraph/javascript-typescript-langserver",
     "installation": "npm i -g javascript-typescript-langserver",
     "lsp-install-server": "jsts-ls",
+    "debugger": "Yes (Firefox/Chrome)"
+  },
+  {
+    "name": "typescript",
+    "common-group-name": "javascript",
+    "full-name": "JavaScript/TypeScript (theia-ide, RECOMMENDED)",
+    "server-name": "typescript-language-server (formerly theia-ide / TypeFox)",
+    "server-url": "https://github.com/typescript-language-server/typescript-language-server",
+    "installation": "npm i -g typescript-language-server; npm i -g typescript",
+    "lsp-install-server": "ts-ls",
     "debugger": "Yes (Firefox/Chrome)"
   },
   {
@@ -645,7 +636,7 @@
   },
   {
     "name": "ltex",
-    "full-name": "LanguageTool",
+    "full-name": "LanguageTool (LTEX)",
     "server-name": "LTEX",
     "server-url": "https://github.com/valentjn/ltex-ls",
     "installation-url": "https://github.com/valentjn/ltex-ls#installation",
@@ -653,7 +644,7 @@
   },
   {
     "name": "ltex-plus",
-    "full-name": "LanguageTool",
+    "full-name": "LanguageTool (LTEX+)",
     "server-name": "LTEX+",
     "server-url": "https://github.com/ltex-plus/ltex-ls-plus",
     "installation-url": "https://ltex-plus.github.io/ltex-plus/installation-usage.html",
@@ -670,7 +661,7 @@
   {
     "name": "emmy-lua",
     "common-group-name": "lua",
-    "full-name": "Lua",
+    "full-name": "Lua (EmmyLua)",
     "server-name": "EmmyLua",
     "server-url": "https://github.com/EmmyLua/EmmyLua-LanguageServer",
     "installation-url": "https://github.com/emacs-lsp/lsp-mode/wiki/Install-EmmyLua-Language-server",
@@ -679,7 +670,7 @@
   {
     "name": "lua-language-server",
     "common-group-name": "lua",
-    "full-name": "Lua",
+    "full-name": "Lua (lua-language-server)",
     "server-name": "lua-language-server",
     "installation-url": "https://github.com/LuaLS/lua-language-server/wiki/Getting-Started#build",
     "server-url": "https://github.com/LuaLS/lua-language-server",
@@ -688,7 +679,7 @@
   {
     "name": "lua-lsp",
     "common-group-name": "lua",
-    "full-name": "Lua",
+    "full-name": "Lua (lua-lsp)",
     "server-name": "lua-lsp",
     "installation-url": "https://luarocks.org/modules/alloyed/lua-lsp",
     "server-url": "https://github.com/Alloyed/lua-lsp",
@@ -703,6 +694,15 @@
     "installation-url": "https://github.com/NightrainsRbx/RobloxLsp",
     "server-url": "https://github.com/NightrainsRbx/RobloxLsp",
     "debugger": "Not available"
+  },
+  {
+    "name": "magik",
+    "full-name": "Magik",
+    "server-name": "magik-language-server",
+    "server-url": "https://github.com/StevenLooman/magik-tools",
+    "installation": "Automatic by lsp-mode with `lsp-install-server`",
+    "lsp-install-server": "magik-ls",
+    "debugger": "Yes"
   },
   {
     "name": "markdown",
@@ -730,7 +730,7 @@
   },
   {
     "name": "mdx",
-    "full-name": "mdx",
+    "full-name": "MDX",
     "server-name": "mdx-analyzer",
     "server-url": "https://github.com/mdx-js/mdx-analyzer/tree/main/packages/language-server",
     "installation": "npm install -g @mdx-js/language-server",
@@ -762,7 +762,7 @@
   },
   {
     "name": "move",
-    "full-name": "Move Language",
+    "full-name": "Move",
     "server-name": "move-analyzer",
     "server-url": "https://github.com/move-language/move",
     "installation-url": "https://github.com/move-language/move/tree/main/language/move-analyzer",
@@ -794,7 +794,7 @@
   },
   {
     "name": "nim",
-    "full-name": "nimlangserver",
+    "full-name": "Nim (nimlangserver)",
     "server-name": "nimlangserver",
     "server-url": "https://github.com/nim-lang/langserver",
     "installation": "nimble install nimlangserver",
@@ -802,7 +802,7 @@
   },
   {
     "name": "nix-nil",
-    "full-name": "Nix",
+    "full-name": "Nix (nil)",
     "server-name": "nix-nil",
     "server-url": "https://github.com/oxalica/nil",
     "installation": "nix-env -i nil || nix profile install nixpkgs#nil",
@@ -810,7 +810,7 @@
   },
   {
     "name": "nix-nixd",
-    "full-name": "Nix (nixd language server)",
+    "full-name": "Nix (nixd)",
     "server-name": "nixd",
     "server-url": "https://github.com/nix-community/nixd",
     "installation": "nix profile install github:nixos/nixpkgs#nixd",
@@ -818,7 +818,7 @@
   },
   {
     "name": "nix-rnix",
-    "full-name": "Nix (rnix language server)",
+    "full-name": "Nix (rnix-lsp)",
     "server-name": "rnix-lsp",
     "server-url": "https://github.com/nix-community/rnix-lsp",
     "installation": "nix profile install github:nixos/nixpkgs#rnix-lsp",
@@ -842,24 +842,24 @@
     "debugger": "Not available"
   },
   {
-    "name": "ocaml-lsp-server",
-    "full-name": "OCaml",
-    "server-name": "ocaml-lsp-server",
-    "server-url": "https://github.com/ocaml/ocaml-lsp",
-    "installation-url": "https://github.com/ocaml/ocaml-lsp#installation",
-    "debugger": "Not available"
-  },
-  {
     "name": "ocaml",
-    "full-name": "OCaml",
+    "full-name": "OCaml (ocaml-language-server)",
     "server-name": "ocaml-language-server",
     "server-url": "https://github.com/ocaml-lsp/ocaml-language-server",
     "installation-url": "https://github.com/ocaml-lsp/ocaml-language-server#server",
     "debugger": "Not available"
   },
   {
+    "name": "ocaml-lsp-server",
+    "full-name": "OCaml (ocaml-lsp)",
+    "server-name": "ocaml-lsp-server",
+    "server-url": "https://github.com/ocaml/ocaml-lsp",
+    "installation-url": "https://github.com/ocaml/ocaml-lsp#installation",
+    "debugger": "Not available"
+  },
+  {
     "name": "odin-ols",
-    "full-name": "Odin Language Server",
+    "full-name": "Odin (ols)",
     "server-name": "ols",
     "server-url": "https://github.com/DanielGavin/ols",
     "installation-url": "https://github.com/DanielGavin/ols",
@@ -885,30 +885,56 @@
     "debugger": "Not available"
   },
   {
-    "name": "perl",
-    "full-name": "Perl",
-    "server-name": "Perl::LanguageServer",
-    "server-url": "https://github.com/richterger/Perl-LanguageServer",
-    "installation": "cpan Perl::LanguageServer",
-    "debugger": "Not available"
-  },
-  {
     "name": "perlnavigator",
-    "full-name": "Perl Navigator",
+    "full-name": "Perl (Navigator)",
     "server-name": "perlnavigator",
     "server-url": "https://github.com/bscan/PerlNavigator",
     "installation": "https://github.com/bscan/PerlNavigator/releases",
     "debugger": "Not available"
   },
   {
+    "name": "perl",
+    "full-name": "Perl (Perl::LanguageServer)",
+    "server-name": "Perl::LanguageServer",
+    "server-url": "https://github.com/richterger/Perl-LanguageServer",
+    "installation": "cpan Perl::LanguageServer",
+    "debugger": "Not available"
+  },
+  {
+    "name": "pls",
+    "full-name": "Perl (PLS)",
+    "server-name": "Perl Language Server",
+    "server-url": "https://metacpan.org/pod/PLS",
+    "installation": "cpan PLS",
+    "debugger": "Not available"
+  },
+  {
     "name": "php",
     "common-group-name": "php",
-    "full-name": "PHP",
+    "full-name": "PHP (felixbecker)",
     "server-name": "php-language-server",
     "server-url": "https://github.com/felixfbecker/php-language-server",
     "installation-url": "https://github.com/felixfbecker/php-language-server#installation",
     "installation": "composer require felixfbecker/language-server",
     "debugger": "Yes"
+  },
+  {
+    "name": "intelephense",
+    "common-group-name": "php",
+    "full-name": "PHP (intelephense, RECOMMENDED)",
+    "server-name": "intelephense",
+    "server-url": "https://github.com/bmewburn/vscode-intelephense",
+    "installation": "Automatic or manual by `npm i intelephense -g`",
+    "debugger": "Yes"
+  },
+  {
+    "name": "phpactor",
+    "common-group-name": "php",
+    "full-name": "PHP (phpactor)",
+    "server-name": "phpactor",
+    "server-url": "https://github.com/phpactor/phpactor",
+    "installation-url": "https://phpactor.readthedocs.io/en/master/usage/standalone.html#installation-global",
+    "debugger": "yes"
   },
   {
     "name": "serenata",
@@ -918,32 +944,6 @@
     "server-url": "https://gitlab.com/Serenata/Serenata",
     "installation-url": "https://gitlab.com/Serenata/Serenata/-/releases",
     "debugger": "Yes"
-  },
-  {
-    "name": "intelephense",
-    "common-group-name": "php",
-    "full-name": "PHP(recommended)",
-    "server-name": "intelephense",
-    "server-url": "https://github.com/bmewburn/vscode-intelephense",
-    "installation": "Automatic or manual by `npm i intelephense -g`",
-    "debugger": "Yes"
-  },
-  {
-    "name": "phpactor",
-    "common-group-name": "php",
-    "full-name": "Phpactor",
-    "server-name": "phpactor",
-    "server-url": "https://github.com/phpactor/phpactor",
-    "installation-url": "https://phpactor.readthedocs.io/en/master/usage/standalone.html#installation-global",
-    "debugger": "yes"
-  },
-  {
-    "name": "pls",
-    "full-name": "PLS",
-    "server-name": "Perl Language Server",
-    "server-url": "https://metacpan.org/pod/PLS",
-    "installation": "cpan PLS",
-    "debugger": "Not available"
   },
   {
     "name": "pwsh",
@@ -973,32 +973,8 @@
     "debugger": "Not available"
   },
   {
-    "name": "pylsp",
-    "full-name": "Python",
-    "server-name": "pylsp",
-    "server-url": "https://github.com/python-lsp/python-lsp-server",
-    "installation": "pip install 'python-lsp-server[all]'",
-    "debugger": "Yes"
-  },
-  {
-    "name": "ruff",
-    "full-name": "Python",
-    "server-name": "ruff",
-    "server-url": "https://github.com/astral-sh/ruff",
-    "installation": "pip install ruff (previous pip install ruff-lsp)",
-    "debugger": "Not available"
-  },
-  {
-    "name": "pyls",
-    "full-name": "Python (deprecated Palantir version)",
-    "server-name": "pyls",
-    "server-url": "https://github.com/palantir/python-language-server",
-    "installation": "pip install 'python-language-server[all]'",
-    "debugger": "Yes"
-  },
-  {
     "name": "jedi",
-    "full-name": "Python (Jedi-language-server)",
+    "full-name": "Python (Jedi Language Server)",
     "server-name": "jedi",
     "server-url": "https://github.com/pappasam/jedi-language-server",
     "installation-url": "https://github.com/fredcamps/lsp-jedi",
@@ -1015,6 +991,22 @@
     "debugger": "Yes"
   },
   {
+    "name": "pyls",
+    "full-name": "Python (Palantir deprecated)",
+    "server-name": "pyls",
+    "server-url": "https://github.com/palantir/python-language-server",
+    "installation": "pip install 'python-language-server[all]'",
+    "debugger": "Yes"
+  },
+  {
+    "name": "pylsp",
+    "full-name": "Python (pylsp)",
+    "server-name": "pylsp",
+    "server-url": "https://github.com/python-lsp/python-lsp-server",
+    "installation": "pip install 'python-lsp-server[all]'",
+    "debugger": "Yes"
+  },
+  {
     "name": "pyright",
     "full-name": "Python (Pyright)",
     "server-name": "pyright-langserver",
@@ -1023,6 +1015,14 @@
     "client-url": "https://github.com/emacs-lsp/lsp-pyright",
     "installation-url": "https://github.com/emacs-lsp/lsp-pyright",
     "debugger": "Yes"
+  },
+  {
+    "name": "ruff",
+    "full-name": "Python (Ruff)",
+    "server-name": "ruff",
+    "server-url": "https://github.com/astral-sh/ruff",
+    "installation": "pip install ruff (previous pip install ruff-lsp)",
+    "debugger": "Not available"
   },
   {
     "name": "python-ty",
@@ -1036,7 +1036,7 @@
   },
   {
     "name": "qml-ls",
-    "full-name": "QML (Qt Modeling Language)",
+    "full-name": "QML",
     "server-name": "QML Language Server",
     "server-url": "https://doc.qt.io/qt-6/qtquick-tool-qmlls.html",
     "client-name": "lsp-qml",
@@ -1092,6 +1092,14 @@
     "server-url": "https://github.com/roc-lang/roc/tree/main/crates/language_server",
     "installation-url": "https://github.com/roc-lang/roc/tree/main/crates/language_server",
     "installation": "Along with the compiler",
+    "debugger": "Not available"
+  },
+  {
+    "name": "ron",
+    "full-name": "RON",
+    "server-name": "ron-lsp",
+    "server-url": "https://github.com/jasonjmcghee/ron-lsp/",
+    "installation": "cargo install ron-lsp",
     "debugger": "Not available"
   },
   {
@@ -1161,29 +1169,21 @@
     "debugger": "Not available"
   },
   {
-    "name": "rust-analyzer",
-    "common-group-name": "rust",
-    "full-name": "Rust",
-    "server-name": "rust-analyzer",
-    "server-url": "https://github.com/rust-analyzer/rust-analyzer",
-    "installation-url": "https://github.com/rust-analyzer/rust-analyzer#language-server-quick-start",
-    "debugger": "Not available"
-  },
-  {
     "name": "rust-rls",
     "common-group-name": "rust",
-    "full-name": "Rust",
+    "full-name": "Rust (rls)",
     "server-name": "rls",
     "server-url": "https://github.com/rust-lang/rls",
     "installation-url": "https://github.com/rust-lang/rls",
     "debugger": "Yes"
   },
   {
-    "name": "ron",
-    "full-name": "Rusty Object Notation",
-    "server-name": "ron-lsp",
-    "server-url": "https://github.com/jasonjmcghee/ron-lsp/",
-    "installation": "cargo install ron-lsp",
+    "name": "rust-analyzer",
+    "common-group-name": "rust",
+    "full-name": "Rust (rust-analyzer)",
+    "server-name": "rust-analyzer",
+    "server-url": "https://github.com/rust-analyzer/rust-analyzer",
+    "installation-url": "https://github.com/rust-analyzer/rust-analyzer#language-server-quick-start",
     "debugger": "Not available"
   },
   {
@@ -1254,24 +1254,40 @@
     "debugger": "Not available"
   },
   {
-    "name": "terraform",
-    "full-name": "Terraform",
-    "server-name": "terraform-lsp",
-    "server-url": "https://github.com/juliosueiras/terraform-lsp",
-    "installation": "Git clone outside of $GOPATH; go install",
-    "debugger": "Not available"
-  },
-  {
     "name": "terraform-ls",
-    "full-name": "Terraform LSP",
+    "full-name": "Terraform (terraform-ls)",
     "server-name": "terraform-ls",
     "server-url": "https://github.com/hashicorp/terraform-ls",
     "installation-url": "https://github.com/hashicorp/terraform-ls",
     "debugger": "Not available"
   },
   {
+    "name": "terraform",
+    "full-name": "Terraform (terraform-lsp)",
+    "server-name": "terraform-lsp",
+    "server-url": "https://github.com/juliosueiras/terraform-lsp",
+    "installation": "Git clone outside of $GOPATH; go install",
+    "debugger": "Not available"
+  },
+  {
+    "name": "tex",
+    "full-name": "TeX, LaTeX, etc (digestif)",
+    "server-name": "Digestif",
+    "server-url": "https://github.com/astoff/digestif",
+    "installation": "luarocks --server http://luarocks.org/dev install digestif",
+    "debugger": "Not available"
+  },
+  {
+    "name": "texlab",
+    "full-name": "TeX, LaTeX, etc (texlab)",
+    "server-name": "texlab",
+    "server-url": "https://github.com/latex-lsp/texlab",
+    "installation": "cargo install --locked --git https://github.com/latex-lsp/texlab.git",
+    "debugger": "Not available"
+  },
+  {
     "name": "latex",
-    "full-name": "TeX, LaTeX, etc.",
+    "full-name": "TeX, LaTeX, etc (texlab, external)",
     "server-name": "texlab",
     "server-url": "https://github.com/latex-lsp/texlab",
     "client-name": "lsp-latex",
@@ -1280,24 +1296,8 @@
     "debugger": "Not available"
   },
   {
-    "name": "tex",
-    "full-name": "TeX, LaTeX, etc.",
-    "server-name": "Digestif",
-    "server-url": "https://github.com/astoff/digestif",
-    "installation": "luarocks --server http://luarocks.org/dev install digestif",
-    "debugger": "Not available"
-  },
-  {
-    "name": "texlab",
-    "full-name": "TeX, LaTeX, etc.",
-    "server-name": "texlab",
-    "server-url": "https://github.com/latex-lsp/texlab",
-    "installation": "cargo install --locked --git https://github.com/latex-lsp/texlab.git",
-    "debugger": "Not available"
-  },
-  {
     "name": "tilt",
-    "full-name": "Tilt LSP",
+    "full-name": "Tilt",
     "server-name": "tilt",
     "installation": "To be used with tilt-mode available in https://github.com/Konubinix/tilt-mode",
     "server-url": "https://docs.tilt.dev/cli/tilt_lsp.html",
@@ -1306,7 +1306,7 @@
   },
   {
     "name": "toml",
-    "full-name": "TOML",
+    "full-name": "TOML (Taplo)",
     "server-name": "taplo",
     "server-url": "https://github.com/tamasfe/taplo",
     "installation": "cargo install taplo-cli --features lsp",
@@ -1314,7 +1314,7 @@
   },
   {
     "name": "tombi-toml",
-    "full-name": "TOML",
+    "full-name": "TOML (Tombi)",
     "server-name": "tombi",
     "server-url": "https://github.com/tombi-toml/tombi",
     "installation-url": "https://tombi-toml.github.io/tombi/docs/installation",
@@ -1394,9 +1394,18 @@
     "debugger": "Not available"
   },
   {
+    "name": "verilog",
+    "common-group-name": "verilog",
+    "full-name": "Verilog/SystemVerilog (hdl-checker)",
+    "server-name": "hdl_checker",
+    "server-url": "https://github.com/suoto/hdl_checker",
+    "installation": "pip install hdl-checker --upgrade",
+    "debugger": "Not available"
+  },
+  {
     "name": "svlangserver",
     "common-group-name": "verilog",
-    "full-name": "Verilog/SystemVerilog",
+    "full-name": "Verilog/SystemVerilog (svlangserver)",
     "server-name": "svlangserver",
     "server-url": "https://github.com/imc-trading/svlangserver",
     "installation-url": "https://github.com/imc-trading/svlangserver#installation",
@@ -1405,19 +1414,10 @@
   {
     "name": "verible",
     "common-group-name": "verilog",
-    "full-name": "Verilog/SystemVerilog",
+    "full-name": "Verilog/SystemVerilog (verible)",
     "server-name": "verible-verilog-ls",
     "server-url": "https://github.com/chipsalliance/verible",
     "installation": "https://github.com/chipsalliance/verible#installation",
-    "debugger": "Not available"
-  },
-  {
-    "name": "verilog",
-    "common-group-name": "verilog",
-    "full-name": "Verilog/SystemVerilog",
-    "server-name": "hdl_checker",
-    "server-url": "https://github.com/suoto/hdl_checker",
-    "installation": "pip install hdl-checker --upgrade",
     "debugger": "Not available"
   },
   {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,14 +62,14 @@ nav:
     - C++ (ccls): page/lsp-ccls.md
     - C++ (clangd): page/lsp-clangd.md
     - C# (omnisharp-roslyn): page/lsp-csharp-omnisharp.md
-    - C# (csharp-roslyn): page/lsp-csharp-roslyn.md
-    - C# (csharp-ls): page/lsp-csharp-ls.md
-    - C3 (c3-lsp): page/lsp-c3-lsp.md
+    - C# (csharp-roslyn): page/lsp-roslyn.md
+    - C# (csharp-ls): page/lsp-csharp.md
+    - C3 (c3-lsp): page/lsp-c3.md
     - Clojure: page/lsp-clojure.md
     - CMake: page/lsp-cmake.md
     - COBOL: page/lsp-cobol.md
     - Crates: page/lsp-crates.md
-    - Crystal: page/lsp-crystal.md
+    - Crystal: page/lsp-crystalline.md
     - CSS/LessCSS/SASS/SCSS: page/lsp-css.md
     - Cucumber: page/lsp-cucumber.md
     - Cypher: page/lsp-cypher.md
@@ -82,7 +82,7 @@ nav:
     - Elm: page/lsp-elm.md
     - Emacs Lisp (Ellsp): https://github.com/elisp-lsp/ellsp
     - Emacs Lisp (Elsa): https://github.com/emacs-elsa/Elsa
-    - Emmet: page/lsp-emmet.md
+    - Emmet: page/lsp-emmet-ls.md
     - Erlang (Erlang Language Server): page/lsp-erlang-ls.md
     - Erlang (ELP): page/lsp-erlang-elp.md
     - ESLint: page/lsp-eslint.md
@@ -96,7 +96,7 @@ nav:
     - Gleam: page/lsp-gleam.md
     - GLSL: page/lsp-glsl.md
     - GNAT Project: page/lsp-gpr.md
-    - Go (gopls): manual-language-docs/lsp-gopls.md
+    - Go (gopls): manual-language-docs/lsp-go.md
     - Grammarly: page/lsp-grammarly.md
     - GraphQL: page/lsp-graphql.md
     - Groovy: page/lsp-groovy.md
@@ -109,7 +109,7 @@ nav:
     - Javascript/Typescript (deno): page/lsp-deno.md
     - JavaScript/TypeScript (sourcegraph): page/lsp-typescript-javascript.md
     - JavaScript/TypeScript (theia-ide): page/lsp-typescript.md
-    - JavaScript/TypeScript (Go native): page/lsp-typescript-go.md
+    - JavaScript/TypeScript (Go native): page/lsp-tsgo.md
     - JavaScript Flow: page/lsp-flow.md
     - Json: page/lsp-json.md
     - Jsonnet: page/lsp-jsonnet.md
@@ -133,13 +133,13 @@ nav:
     - MSSQL: https://emacs-lsp.github.io/lsp-mssql
     - Nextflow: page/lsp-nextflow.md
     - Nginx: page/lsp-nginx.md
-    - Nim: page/lsp-nim.md
+    - Nim: page/lsp-nimlsp.md
     - Nix (nixd-lsp): page/lsp-nix-nixd.md
     - Nix (rnix-lsp): page/lsp-nix-rnix.md
     - Nix (nil): page/lsp-nix-nil.md
     - Nushell: page/lsp-nushell.md
     - OCaml (ocaml-lsp): page/lsp-ocaml-lsp-server.md
-    - Odin (ols): page/lsp-odin-ols-server.md
+    - Odin (ols): page/lsp-odin-ols.md
     - OpenSCAD: page/lsp-openscad.md
     - Pascal/Object Pascal: page/lsp-pascal.md
     - Perl (PLS): page/lsp-pls.md
@@ -191,7 +191,7 @@ nav:
     - TeX, LaTeX, etc (texlab, external): page/lsp-latex.md
     - Tilt: page/lsp-tilt.md
     - TOML (Taplo): page/lsp-toml.md
-    - TOML (Tombi): page/lsp-toml-tombi.md
+    - TOML (Tombi): page/lsp-tombi-toml.md
     - Tree-sitter Query: page/lsp-ts-query.md
     - Trunk: page/lsp-trunk.md
     - TTCN3: page/lsp-ttcn3.md
@@ -203,10 +203,10 @@ nav:
     - Verilog/SystemVerilog (svlangserver): page/lsp-svlangserver.md
     - Verilog/SystemVerilog (verible): page/lsp-verible.md
     - VHDL: page/lsp-vhdl.md
-    - Vimscript: page/lsp-vimscript.md
+    - Vimscript: page/lsp-vim.md
     - Vue 2: page/lsp-vetur.md
     - Vue 3: page/lsp-volar.md
-    - WebAssembly: page/lsp-wasm-language-tools.md
+    - WebAssembly: page/lsp-wat.md
     - wgsl: page/lsp-wgsl.md
     - XML: page/lsp-xml.md
     - YAML: page/lsp-yaml.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
     - CMake: page/lsp-cmake.md
     - COBOL: page/lsp-cobol.md
     - Crates: page/lsp-crates.md
+    - Credo: page/lsp-credo.md
     - Crystal: page/lsp-crystalline.md
     - CSS/LessCSS/SASS/SCSS: page/lsp-css.md
     - Cucumber: page/lsp-cucumber.md
@@ -77,6 +78,7 @@ nav:
     - Dart: https://emacs-lsp.github.io/lsp-dart
     - Dhall: page/lsp-dhall.md
     - Dockerfile: page/lsp-dockerfile.md
+    - DOT: page/lsp-dot.md
     - Earthfile: page/lsp-earthly.md
     - Elixir: page/lsp-elixir.md
     - Elm: page/lsp-elm.md
@@ -84,7 +86,7 @@ nav:
     - Emacs Lisp (Elsa): https://github.com/emacs-elsa/Elsa
     - Emmet: page/lsp-emmet-ls.md
     - Erlang (ELP): page/lsp-erlang-elp.md
-    - Erlang (Erlang Language Server): page/lsp-erlang-ls.md
+    - Erlang (Erlang LS): page/lsp-erlang-ls.md
     - ESLint: page/lsp-eslint.md
     - F#: page/lsp-fsharp.md
     - Fennel: page/lsp-fennel.md
@@ -93,25 +95,29 @@ nav:
     - Fortran (fortls): page/lsp-fortran.md
     - Futhark: page/lsp-futhark.md
     - GDScript: page/lsp-gdscript.md
+    - gettext: page/lsp-gettext.md
     - GitHub Copilot: page/lsp-copilot.md
     - Gleam: page/lsp-gleam.md
     - GLSL: page/lsp-glsl.md
     - GNAT Project: page/lsp-gpr.md
     - Go (gopls): manual-language-docs/lsp-go.md
+    - golangci-lint: page/lsp-golangci-lint.md
     - Grammarly: page/lsp-grammarly.md
     - GraphQL: page/lsp-graphql.md
     - Groovy: page/lsp-groovy.md
     - Hack: page/lsp-hack.md
     - Haskell: https://emacs-lsp.github.io/lsp-haskell
+    - Haxe: page/lsp-haxe.md
     - HTML: page/lsp-html.md
     - Hy (hyuga): page/lsp-hy.md
     - Idris: page/lsp-idris.md
     - Java: https://emacs-lsp.github.io/lsp-java
     - JavaScript Flow: page/lsp-flow.md
     - Javascript/Typescript (deno): page/lsp-deno.md
-    - JavaScript/TypeScript (sourcegraph): page/lsp-typescript-javascript.md
-    - JavaScript/TypeScript (theia-ide): page/lsp-typescript.md
     - JavaScript/TypeScript (Go native): page/lsp-tsgo.md
+    - JavaScript/TypeScript (sourcegraph): page/lsp-typescript-javascript.md
+    - JavaScript/TypeScript (theia-ide, RECOMMENDED): page/lsp-typescript.md
+    - Jq (jq-lsp): page/lsp-jq.md
     - Json: page/lsp-json.md
     - Jsonnet: page/lsp-jsonnet.md
     - Julia: page/lsp-julia.md
@@ -121,23 +127,29 @@ nav:
     - LanguageTool (LTEX+): page/lsp-ltex-plus.md
     - Lisp: page/lsp-lisp.md
     - Lua (EmmyLua): page/lsp-emmy-lua.md
-    - Lua (Lua Language Server): page/lsp-lua-language-server.md
-    - Lua (Lua-Lsp): page/lsp-lua-lsp.md
+    - Lua (lua-language-server): page/lsp-lua-language-server.md
+    - Lua (lua-lsp): page/lsp-lua-lsp.md
+    - Lua Roblox: page/lsp-lua-roblox-language-server.md
     - Magik: page/lsp-magik.md
     - Markdown: page/lsp-markdown.md
     - Marksman: page/lsp-marksman.md
     - MATLAB: page/lsp-matlab.md
     - MDX: page/lsp-mdx.md
     - Meson: page/lsp-meson.md
+    - mint-lang: page/lsp-mint.md
+    - Mojo: page/lsp-mojo.md
     - Move: page/lsp-move.md
     - MSSQL: https://emacs-lsp.github.io/lsp-mssql
     - Nextflow: page/lsp-nextflow.md
     - Nginx: page/lsp-nginx.md
     - Nim: page/lsp-nimlsp.md
+    - Nim (nimlangserver): page/lsp-nim.md
     - Nix (nil): page/lsp-nix-nil.md
-    - Nix (nixd-lsp): page/lsp-nix-nixd.md
+    - Nix (nixd): page/lsp-nix-nixd.md
     - Nix (rnix-lsp): page/lsp-nix-rnix.md
+    - nomicfoundation/solidity-language-server: page/lsp-solidity.md
     - Nushell: page/lsp-nushell.md
+    - OCaml (ocaml-language-server): page/lsp-ocaml.md
     - OCaml (ocaml-lsp): page/lsp-ocaml-lsp-server.md
     - Odin (ols): page/lsp-odin-ols.md
     - OpenSCAD: page/lsp-openscad.md
@@ -146,7 +158,7 @@ nav:
     - Perl (Perl::LanguageServer): page/lsp-perl.md
     - Perl (PLS): page/lsp-pls.md
     - PHP (felixbecker): page/lsp-php.md
-    - PHP (intelephense): page/lsp-intelephense.md
+    - PHP (intelephense, RECOMMENDED): page/lsp-intelephense.md
     - PHP (phpactor): page/lsp-phpactor.md
     - PHP (Serenata): page/lsp-serenata.md
     - Powershell: page/lsp-pwsh.md
@@ -155,7 +167,7 @@ nav:
     - Python (Jedi Language Server): page/lsp-jedi.md
     - Python (Microsoft): https://emacs-lsp.github.io/lsp-python-ms
     - Python (Palantir deprecated): page/lsp-pyls.md
-    - Python (Pylsp): page/lsp-pylsp.md
+    - Python (pylsp): page/lsp-pylsp.md
     - Python (Pyright): https://emacs-lsp.github.io/lsp-pyright
     - Python (Ruff): page/lsp-ruff.md
     - Python (ty): page/lsp-python-ty.md
@@ -163,6 +175,8 @@ nav:
     - R: page/lsp-r.md
     - Racket (jeapostrophe): page/lsp-racket-langserver.md
     - Racket (Theia): page/lsp-racket-language-server.md
+    - Remark: page/lsp-remark.md
+    - robot framework: page/lsp-rf.md
     - Roc: page/lsp-roc.md
     - RON: page/ron-lsp.md
     - RPM Spec: page/lsp-rpm-spec.md
@@ -172,6 +186,7 @@ nav:
     - Ruby (Sorbet): page/lsp-sorbet.md
     - Ruby (Steep): page/lsp-steep.md
     - Ruby (TypeProf): page/lsp-typeprof.md
+    - ruby-syntax-tree: page/lsp-ruby-syntax-tree.md
     - Rust (rls): page/lsp-rust-rls.md
     - Rust (rust-analyzer): page/lsp-rust-analyzer.md
     - Scala: https://emacs-lsp.github.io/lsp-metals
@@ -196,8 +211,10 @@ nav:
     - Trunk: page/lsp-trunk.md
     - TTCN3: page/lsp-ttcn3.md
     - TypeSpec: page/lsp-typespec.md
+    - Typos source code spell checker: page/lsp-typos.md
     - Typst: page/lsp-typst.md
     - V: page/lsp-v.md
+    - V (v-analyzer): page/lsp-v-analyzer.md
     - Vala: page/lsp-vala.md
     - Verilog/SystemVerilog (hdl-checker): page/lsp-verilog.md
     - Verilog/SystemVerilog (svlangserver): page/lsp-svlangserver.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,13 +58,13 @@ nav:
     - Biome: page/lsp-biome.md
     - Buf/Protocol Buffers (Buf CLI): page/lsp-buf.md
     - Buf/Protocol Buffers (Buf Language Server): page/lsp-bufls.md
-    - Camel: page/lsp-camel.md
+    - C# (csharp-ls): page/lsp-csharp.md
+    - C# (csharp-roslyn): page/lsp-roslyn.md
+    - C# (omnisharp-roslyn): page/lsp-csharp-omnisharp.md
     - C++ (ccls): page/lsp-ccls.md
     - C++ (clangd): page/lsp-clangd.md
-    - C# (omnisharp-roslyn): page/lsp-csharp-omnisharp.md
-    - C# (csharp-roslyn): page/lsp-roslyn.md
-    - C# (csharp-ls): page/lsp-csharp.md
     - C3 (c3-lsp): page/lsp-c3.md
+    - Camel: page/lsp-camel.md
     - Clojure: page/lsp-clojure.md
     - CMake: page/lsp-cmake.md
     - COBOL: page/lsp-cobol.md
@@ -83,13 +83,14 @@ nav:
     - Emacs Lisp (Ellsp): https://github.com/elisp-lsp/ellsp
     - Emacs Lisp (Elsa): https://github.com/emacs-elsa/Elsa
     - Emmet: page/lsp-emmet-ls.md
-    - Erlang (Erlang Language Server): page/lsp-erlang-ls.md
     - Erlang (ELP): page/lsp-erlang-elp.md
+    - Erlang (Erlang Language Server): page/lsp-erlang-ls.md
     - ESLint: page/lsp-eslint.md
     - F#: page/lsp-fsharp.md
+    - Fennel: page/lsp-fennel.md
     - Fish (fish-lsp): page/lsp-fish.md
-    - Fortran (fortls): page/lsp-fortran.md
     - Fortran (fortitude): page/lsp-fortitude.md
+    - Fortran (fortls): page/lsp-fortran.md
     - Futhark: page/lsp-futhark.md
     - GDScript: page/lsp-gdscript.md
     - GitHub Copilot: page/lsp-copilot.md
@@ -101,16 +102,16 @@ nav:
     - GraphQL: page/lsp-graphql.md
     - Groovy: page/lsp-groovy.md
     - Hack: page/lsp-hack.md
-    - HTML: page/lsp-html.md
     - Haskell: https://emacs-lsp.github.io/lsp-haskell
+    - HTML: page/lsp-html.md
     - Hy (hyuga): page/lsp-hy.md
     - Idris: page/lsp-idris.md
     - Java: https://emacs-lsp.github.io/lsp-java
+    - JavaScript Flow: page/lsp-flow.md
     - Javascript/Typescript (deno): page/lsp-deno.md
     - JavaScript/TypeScript (sourcegraph): page/lsp-typescript-javascript.md
     - JavaScript/TypeScript (theia-ide): page/lsp-typescript.md
     - JavaScript/TypeScript (Go native): page/lsp-tsgo.md
-    - JavaScript Flow: page/lsp-flow.md
     - Json: page/lsp-json.md
     - Jsonnet: page/lsp-jsonnet.md
     - Julia: page/lsp-julia.md
@@ -122,41 +123,40 @@ nav:
     - Lua (EmmyLua): page/lsp-emmy-lua.md
     - Lua (Lua Language Server): page/lsp-lua-language-server.md
     - Lua (Lua-Lsp): page/lsp-lua-lsp.md
-    - Fennel: page/lsp-fennel.md
     - Magik: page/lsp-magik.md
     - Markdown: page/lsp-markdown.md
     - Marksman: page/lsp-marksman.md
     - MATLAB: page/lsp-matlab.md
+    - MDX: page/lsp-mdx.md
     - Meson: page/lsp-meson.md
     - Move: page/lsp-move.md
-    - MDX: page/lsp-mdx.md
     - MSSQL: https://emacs-lsp.github.io/lsp-mssql
     - Nextflow: page/lsp-nextflow.md
     - Nginx: page/lsp-nginx.md
     - Nim: page/lsp-nimlsp.md
+    - Nix (nil): page/lsp-nix-nil.md
     - Nix (nixd-lsp): page/lsp-nix-nixd.md
     - Nix (rnix-lsp): page/lsp-nix-rnix.md
-    - Nix (nil): page/lsp-nix-nil.md
     - Nushell: page/lsp-nushell.md
     - OCaml (ocaml-lsp): page/lsp-ocaml-lsp-server.md
     - Odin (ols): page/lsp-odin-ols.md
     - OpenSCAD: page/lsp-openscad.md
     - Pascal/Object Pascal: page/lsp-pascal.md
-    - Perl (PLS): page/lsp-pls.md
-    - Perl (Perl::LanguageServer): page/lsp-perl.md
     - Perl (Navigator): page/lsp-perlnavigator.md
-    - PHP (intelephense): page/lsp-intelephense.md
-    - PHP (Serenata): page/lsp-serenata.md
+    - Perl (Perl::LanguageServer): page/lsp-perl.md
+    - Perl (PLS): page/lsp-pls.md
     - PHP (felixbecker): page/lsp-php.md
+    - PHP (intelephense): page/lsp-intelephense.md
     - PHP (phpactor): page/lsp-phpactor.md
+    - PHP (Serenata): page/lsp-serenata.md
     - Powershell: page/lsp-pwsh.md
     - Prolog: page/lsp-prolog.md
     - PureScript: page/lsp-purescript.md
-    - Python (Pylsp): page/lsp-pylsp.md
     - Python (Jedi Language Server): page/lsp-jedi.md
-    - Python (Palantir deprecated): page/lsp-pyls.md
-    - Python (Pyright): https://emacs-lsp.github.io/lsp-pyright
     - Python (Microsoft): https://emacs-lsp.github.io/lsp-python-ms
+    - Python (Palantir deprecated): page/lsp-pyls.md
+    - Python (Pylsp): page/lsp-pylsp.md
+    - Python (Pyright): https://emacs-lsp.github.io/lsp-pyright
     - Python (Ruff): page/lsp-ruff.md
     - Python (ty): page/lsp-python-ty.md
     - QML: page/lsp-qml.md
@@ -172,20 +172,20 @@ nav:
     - Ruby (Sorbet): page/lsp-sorbet.md
     - Ruby (Steep): page/lsp-steep.md
     - Ruby (TypeProf): page/lsp-typeprof.md
-    - Rust (rust-analyzer): page/lsp-rust-analyzer.md
     - Rust (rls): page/lsp-rust-rls.md
+    - Rust (rust-analyzer): page/lsp-rust-analyzer.md
     - Scala: https://emacs-lsp.github.io/lsp-metals
     - Semgrep: page/lsp-semgrep.md
     - ShaderLab: page/lsp-shader.md
+    - SQL (postgres-ls): page/lsp-postgres.md
     - SQL (sql): page/lsp-sql.md
     - SQL (sqls): page/lsp-sqls.md
-    - SQL (postgres-ls): page/lsp-postgres.md
     - Standard ML (Millet): page/lsp-sml.md
     - Svelte: page/lsp-svelte.md
     - Swift: https://emacs-lsp.github.io/lsp-sourcekit
     - Tailwind CSS: page/lsp-tailwindcss.md
-    - Terraform (terraform-lsp): page/lsp-terraform.md
     - Terraform (terraform-ls): page/lsp-terraform-ls.md
+    - Terraform (terraform-lsp): page/lsp-terraform.md
     - TeX, LaTeX, etc (digestif): page/lsp-tex.md
     - TeX, LaTeX, etc (texlab): page/lsp-texlab.md
     - TeX, LaTeX, etc (texlab, external): page/lsp-latex.md

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# Validates that every built-in client is documented.
+set -euo pipefail
+
+readonly CLIENTS_DIR='clients/'
+readonly METADATA_FILE='docs/lsp-clients.json'
+readonly SIDEBAR_FILE='mkdocs.yml'
+readonly DOCS_URL='https://emacs-lsp.github.io/lsp-mode'
+
+check_jq() {
+  command -v jq &>/dev/null || { echo "jq is required" >&2; exit 1; }
+}
+
+get_sidebar_items() {
+  awk '
+    /^  - Languages:/, /^  - [^ ]/ && !/^  - Languages:/ {
+      if (/^    - .*: /) { gsub(/^    - |: .*/, ""); print }
+    }
+  ' "${SIDEBAR_FILE}"
+}
+
+sort_lines() {
+  python3 -c '
+import sys
+lines = sys.stdin.read().splitlines()
+lines.sort(key=str.lower)
+print("\n".join(lines))
+'
+}
+
+check_rule_1() {
+  # Rule 1: Every defgroup in ${CLIENTS_DIR} has a matching name in ${METADATA_FILE}.
+  local errors=0
+  local names
+  names="$(jq -r '.[].name' "${METADATA_FILE}")"
+  readonly names
+  while read -r client; do
+    echo "ERROR: ${client} (from ${CLIENTS_DIR}) missing from ${METADATA_FILE} (\"name\": \"${client}\")" >&2
+    ((++errors))
+  done < <(comm -23 \
+                <(awk '
+                    /^\(defgroup lsp-/ { name = $2; sub(/^lsp-/, "", name) }
+                    name && /^ *:group '"'"'lsp-mode/ { print name; name = "" }
+                    /^\(/ && !/^\(defgroup/ { name = "" }
+                  ' ${CLIENTS_DIR}*.el | sort) \
+                    <(echo "${names}" | sort))
+  return "${errors}"
+}
+
+check_rule_2() {
+  # Rule 2: ${METADATA_FILE} is sorted by full-name (case-insensitive).
+  local names sorted
+  names="$(jq -r '.[]."full-name"' "${METADATA_FILE}")"
+  sorted="$(echo "${names}" | sort_lines)"
+  readonly names sorted
+  if [[ "${names}" != "${sorted}" ]]; then
+    echo "ERROR: ${METADATA_FILE} is not sorted by full-name" >&2
+    git diff --no-index <(echo "${names}") <(echo "${sorted}") >&2 || true
+    return 1
+  fi
+  return 0
+}
+
+check_rule_3() {
+  # Rule 3: ${SIDEBAR_FILE} Languages section is sorted (case-insensitive).
+  local items sorted
+  items="$(get_sidebar_items)"
+  sorted="$(echo "${items}" | sort_lines)"
+  readonly items sorted
+  if [[ "${items}" != "${sorted}" ]]; then
+    echo "ERROR: ${SIDEBAR_FILE} clients list is not sorted" >&2
+    git diff --no-index <(echo "${items}") <(echo "${sorted}") >&2 || true
+    return 1
+  fi
+  return 0
+}
+
+check_rule_4() {
+  # Rule 4: Every full-name in ${METADATA_FILE} has a matching item in ${SIDEBAR_FILE}.
+  local errors=0
+  local names
+  names="$(jq -r '.[]."full-name"' "${METADATA_FILE}")"
+  readonly names
+  while read -r name; do
+    echo "ERROR: ${name} (from ${METADATA_FILE}) missing from ${SIDEBAR_FILE}" >&2
+    ((++errors))
+  done < <(comm -23 <(echo "${names}" | sort) <(get_sidebar_items | sort))
+  return "${errors}"
+}
+
+check_rule_5() {
+  # Rule 5: No absolute links to ${DOCS_URL} in ${SIDEBAR_FILE} Languages section.
+  local errors=0
+  local bad_sidebar
+  bad_sidebar="$(awk -v url="${DOCS_URL}" '
+    /^  - Languages:/, /^  - [^ ]/ && !/^  - Languages:/ {
+      if (index($0, url)) { sub(/:$/, "", $2); print $2 }
+    }
+  ' "${SIDEBAR_FILE}")"
+  readonly bad_sidebar
+  if [[ -n "${bad_sidebar}" ]]; then
+    while read -r item; do
+      echo "ERROR: ${item} in ${SIDEBAR_FILE} has a absolute link" >&2
+    done <<< "${bad_sidebar}"
+    ((++errors))
+  fi
+  return "${errors}"
+}
+
+check_rule_6() {
+  # Rule 6: Every installation in ${METADATA_FILE} only gives manual steps.
+  local errors=0
+  local bad_metadata
+  bad_metadata="$(jq -r \
+                    '.[] | select(."installation" | strings | test("(?i)auto[^t]")) | .name' \
+                    "${METADATA_FILE}")"
+  readonly bad_metadata
+  if [[ -n "${bad_metadata}" ]]; then
+    while read -r name; do
+      echo "ERROR: ${name} installation in ${METADATA_FILE} contains \"auto\", only give manual steps" >&2
+    done <<< "${bad_metadata}"
+    ((++errors))
+  fi
+  return "${errors}"
+}
+
+main() {
+  check_jq
+  local errors=0
+  check_rule_1; errors=$((errors + $?))
+  check_rule_2; errors=$((errors + $?))
+  check_rule_3; errors=$((errors + $?))
+  check_rule_4; errors=$((errors + $?))
+  check_rule_5; errors=$((errors + $?))
+  check_rule_6; errors=$((errors + $?))
+  exit "${errors}"
+}
+main "$@"


### PR DESCRIPTION
Establishes a validated documentation pipeline for all LSP clients. This ensures documentation is generated for each built-in client and is reliably discoverable for every client.

It renames and sorts client metadata entries in `docs/lsp-clients.json` so they reliably link to their client implementations and are ordered consistently. The `mkdocs.yml` sidebar is similarly sorted and synchronised with the metadata file. Automatic installation hints are stripped from the metadata, since the generated documentation already covers that.

A new CI validation script (`scripts/check-docs.sh`) enforces six rules: every client defgroup has metadata, the JSON is sorted by `full-name`, the sidebar is sorted, every metadata entry appears in the sidebar, the sidebar contains no absolute links to this repository's documentation site and installation instructions describe only manual steps.