### PR TITLE
Fix: starting a language server in a buffer that is not visiting a file errors out

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -8313,7 +8313,8 @@ SESSION is the active session."
       (lsp-request-async
        "initialize"
        (append
-        (list :processId (unless (file-remote-p (buffer-file-name))
+        (list :processId (unless (file-remote-p (or (buffer-file-name)
+                                                    default-directory))
                            (emacs-pid))
               :rootPath (lsp-file-local-name (expand-file-name root))
               :clientInfo (list :name "emacs"
@@ -9077,7 +9078,9 @@ the next question until the queue is empty."
 (defun lsp--supports-buffer? (client)
   (and
    ;; both file and client remote or both local
-   (eq (---truthy? (file-remote-p (buffer-file-name)))
+   ;; Fall back to `default-directory' for buffers with no file name, so
+   ;; `file-remote-p' is never called with nil (which would signal).
+   (eq (---truthy? (file-remote-p (or (buffer-file-name) default-directory)))
        (---truthy? (lsp--client-remote? client)))
 
    ;; activation function or major-mode match.


### PR DESCRIPTION
## Background

I describe below a few Emacs concepts this PR hinges on. They are largely
well-known concepts for anyone familiar with Emacs; however, it is worth spelling
them out explicitly for clarity.

- **Buffers visiting a real file vs. scratch buffers.** Most Emacs buffers
  correspond to a file on disk — the buffer is said to *visit* that file, and
  the variable `buffer-file-name` holds its path. Some buffers are not tied to
  any file (for example `*scratch*`, a capture buffer, or a temporary
  draft). In those buffers `buffer-file-name` is `nil`. I'll call these
  **file-less buffers**.

- **`default-directory`.** Every buffer — including file-less ones — has a
  `default-directory`: the folder the buffer is associated with (used to
  resolve relative paths and to run subprocesses). Unlike `buffer-file-name`,
  it is **always set to a non-nil string**.

- **"Remote" files and `file-remote-p`.** Through TRAMP, Emacs can open files
  that live on another machine (over SSH and similar). Such paths look like
  `/ssh:host:/home/me/notes.txt`. The function `file-remote-p` returns
  non-nil for a remote path and nil for a local one. Important detail: it
  **expects a string**. If you call it on `nil`, it does not return nil — it
  *signals* (i.e., raises) an error: `wrong-type-argument stringp nil`.

## The problem

Two functions in `lsp-mode.el` need to know whether the current buffer lives on
a remote machine. Both functions answer that question the same way — by asking
whether the buffer's *file* is remote:

```elisp
(file-remote-p (buffer-file-name))
```

1. **`lsp--start-workspace`** uses it while building the `initialize` request
   that is sent to a language server when it starts. That request carries the
   editor's operating-system process id (`processId`), which the server uses to
   shut itself down if the editor dies. For a server running on a remote
   machine that local process id is meaningless, so lsp-mode omits it — which
   is why it checks whether the buffer is "remote".

2. **`lsp--supports-buffer?`** uses it to decide whether a given client may
   handle the current buffer: a client configured for remote hosts should only
   match remote buffers, and a local client should only match local buffers.

The trouble is the argument. In a **file-less buffer**, `buffer-file-name` is
`nil`, so the call becomes `(file-remote-p nil)`, which raises
`wrong-type-argument stringp nil`. The result: lsp-mode cannot be used in any
buffer that is not visiting a file — activation aborts with a backtrace before
the server even starts.

## Reproduction (current behavior, before the fix)

With `lsp-mode` loaded and at least one client registered:

```elisp
(with-temp-buffer
  ;; a temp buffer has no buffer-file-name
  (lsp--supports-buffer?
   (gethash (car (hash-table-keys lsp-clients)) lsp-clients)))
;; Debugger entered--Lisp error: (wrong-type-argument stringp nil)
;;   file-remote-p(nil)
```

The same nil reaches `file-remote-p` inside `lsp--start-workspace` when a
client is actually activated in a file-less buffer.

## The fix

When the buffer has no file name, fall back to `default-directory` (which, as
noted above, is always a non-nil string):

```elisp
(file-remote-p (or (buffer-file-name) default-directory))
```

`default-directory` is the right thing to ask about: it describes *where the
buffer lives*, which is exactly the question "is this buffer remote?". A
file-less buffer opened under a TRAMP directory is correctly treated as
remote; an ordinary file-less buffer (whose `default-directory` is a local
path) is correctly treated as local. lsp-mode already relies on
`default-directory` for the connection's working directory elsewhere
(`lsp--default-directory-for-connection`), so this is consistent with how the
rest of the code reasons about location.

Applied at both call sites:

- `lsp--start-workspace` (the `:processId` line of the `initialize` request)
- `lsp--supports-buffer?` (the remote-vs-local match)

## Why is considered low risk

For any buffer that *does* visit a file, `buffer-file-name` is non-nil, so
`(or (buffer-file-name) default-directory)` evaluates to `buffer-file-name` —
exactly the value passed before. Behavior for ordinary file buffers, local or
remote, is therefore unchanged. The only buffers affected are the ones that
previously crashed: they now get a correct, non-erroring answer.

- No behavioral change for file-visiting buffers.
- No new dependencies
- Only a couple of lines changed in two functions

## What led to this PR

I hit this while adding grammar/spell-checking for file-less buffers (such as
`*scratch*` and scratch-like drafts) in an lsp-mode add-on client
(https://github.com/ltex-plus/emacs-ltex-plus). Those buffers are given a
buffer-local document URI so the language server can track them by content,
which is enough for opening the document, sending edits, and receiving
diagnostics — except that `lsp--start-workspace` raises this error on the nil
`buffer-file-name` before the server is ever contacted. As of today, I am forced
to rely on a workaround on the client side; this PR removes the need for it
and lets non-file buffers work directly.
