### PR TITLE
Keep diagnostics aligned across edits, instead of clearing them

### DIFF
--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -399,19 +399,93 @@ reformat the message in any other way."
                                 (when lsp-auto-configure
                                   (lsp-diagnostics--enable))))
 
-(defun lsp-diagnostics--clear-after-edit (&rest _)
-  "Clear diagnostics for the current buffer after workspace edits.
-This prevents stale diagnostics from appearing at wrong line numbers
-when workspace edits shift line positions (see issue #3888)."
-  (when-let* ((file-path (buffer-file-name))
-              (workspaces (lsp-workspaces)))
-    (let ((path (lsp--fix-path-casing file-path)))
-      (dolist (workspace workspaces)
-        (-let [diagnostics (lsp--workspace-diagnostics workspace)]
-          (remhash path diagnostics))))
-    (run-hooks 'lsp-diagnostics-updated-hook)))
+(defsubst lsp-diagnostics--position< (line-a char-a line-b char-b)
+  "Non-nil if 0-based position (LINE-A, CHAR-A) precedes (LINE-B, CHAR-B)."
+  (or (< line-a line-b)
+      (and (= line-a line-b) (< char-a char-b))))
 
-(add-hook 'lsp-after-apply-edits-hook #'lsp-diagnostics--clear-after-edit)
+(defun lsp-diagnostics--remap-point (line char esl esc oel oec nel nec)
+  "Map 0-based (LINE, CHAR) across an edit; return a cons (NEW-LINE . NEW-CHAR).
+The edit replaced the text from (ESL, ESC) to (OEL, OEC) with text whose
+end is now at (NEL, NEC).  A point before the edit is returned unchanged;
+a point at or after the edit's old end is shifted accordingly.  Callers
+must keep points inside the replaced region away from here (see
+`lsp-diagnostics--remap-diagnostic')."
+  (cond
+   ;; At or before the edit's start: unaffected.
+   ((not (lsp-diagnostics--position< esl esc line char))
+    (cons line char))
+   ;; On the edit's old end line, past the change: rebase onto the new end.
+   ((= line oel)
+    (cons nel (+ nec (- char oec))))
+   ;; On a later line: only the line number shifts.
+   (t
+    (cons (+ line (- nel oel)) char))))
+
+(lsp-defun lsp-diagnostics--remap-diagnostic
+  ((diagnostic &as &Diagnostic
+               :range (&Range :start (start &as &Position :line sl :character sc)
+                              :end (end &as &Position :line el :character ec)))
+   esl esc oel oec nel nec)
+  "Return DIAGNOSTIC with its range remapped across an edit, or nil to drop it.
+The edit replaced the text from 0-based (ESL, ESC) to (OEL, OEC) with
+text now ending at (NEL, NEC).  A diagnostic disjoint from the replaced
+region is shifted to its new location; one that overlaps the replaced
+region is dropped (returns nil) so the server can republish it.  See
+issue #3888."
+  (if (and (lsp-diagnostics--position< sl sc oel oec)
+           (lsp-diagnostics--position< esl esc el ec))
+      ;; Overlaps the replaced region: its text changed, so drop it.
+      nil
+    (-let (((new-start-line . new-start-char)
+            (lsp-diagnostics--remap-point sl sc esl esc oel oec nel nec))
+           ((new-end-line . new-end-char)
+            (lsp-diagnostics--remap-point el ec esl esc oel oec nel nec)))
+      (lsp:set-position-line start new-start-line)
+      (lsp:set-position-character start new-start-char)
+      (lsp:set-position-line end new-end-line)
+      (lsp:set-position-character end new-end-char)
+      diagnostic)))
+
+(defun lsp-diagnostics--update-after-change (esl esc oel oec nel nec)
+  "Remap the current buffer's stored diagnostics after a local edit.
+Keeps diagnostics aligned with the buffer until the server republishes,
+rather than discarding them.  The edit replaced the text from 0-based
+(ESL, ESC) to (OEL, OEC) with text now ending at (NEL, NEC); see
+`lsp-diagnostics--remap-diagnostic' for the remapping rule.  Fixes issue
+#3888 for every edit (typing and workspace edits alike)."
+  (when-let* ((file-path (buffer-file-name)))
+    (let ((path (lsp--fix-path-casing file-path))
+          (changed nil))
+      (dolist (workspace (lsp-workspaces))
+        (let* ((diagnostics (lsp--workspace-diagnostics workspace))
+               (file-diagnostics (gethash path diagnostics)))
+          (when file-diagnostics
+            (setq changed t)
+            (if-let* ((remapped (-keep (lambda (diagnostic)
+                                         (lsp-diagnostics--remap-diagnostic
+                                          diagnostic esl esc oel oec nel nec))
+                                       file-diagnostics)))
+                (puthash path remapped diagnostics)
+              (remhash path diagnostics)))))
+      (when changed
+        (run-hooks 'lsp-diagnostics-updated-hook)))))
+
+(defun lsp-diagnostics--clear-after-edit (&rest _)
+  "Clear the current buffer's diagnostics across all of its workspaces.
+Fallback used when an edit cannot be mapped to a line range (see
+`lsp-on-change'); otherwise diagnostics are remapped in place by
+`lsp-diagnostics--update-after-change'."
+  (when-let* ((file-path (buffer-file-name)))
+    (let ((path (lsp--fix-path-casing file-path))
+          (changed nil))
+      (dolist (workspace (lsp-workspaces))
+        (-let [diagnostics (lsp--workspace-diagnostics workspace)]
+          (when (gethash path diagnostics)
+            (setq changed t)
+            (remhash path diagnostics))))
+      (when changed
+        (run-hooks 'lsp-diagnostics-updated-hook)))))
 
 (lsp-consistency-check lsp-diagnostics)
 

--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -473,9 +473,9 @@ rather than discarding them.  The edit replaced the text from 0-based
 
 (defun lsp-diagnostics--clear-after-edit (&rest _)
   "Clear the current buffer's diagnostics across all of its workspaces.
-Fallback used when an edit cannot be mapped to a line range (see
-`lsp-on-change'); otherwise diagnostics are remapped in place by
-`lsp-diagnostics--update-after-change'."
+Used as the fallback when a `remap' edit cannot be mapped to a line
+range, and as the action for the `clear' value of
+`lsp-diagnostics-on-edit' (see `lsp-diagnostics--clear-on-workspace-edit')."
   (when-let* ((file-path (buffer-file-name)))
     (let ((path (lsp--fix-path-casing file-path))
           (changed nil))
@@ -486,6 +486,16 @@ Fallback used when an edit cannot be mapped to a line range (see
             (remhash path diagnostics))))
       (when changed
         (run-hooks 'lsp-diagnostics-updated-hook)))))
+
+(defun lsp-diagnostics--clear-on-workspace-edit (&rest _)
+  "Clear the buffer's diagnostics after a workspace edit.
+Only acts when `lsp-diagnostics-on-edit' is `clear'; with the default
+`remap' the diagnostics are instead kept and remapped by
+`lsp-on-change'."
+  (when (eq lsp-diagnostics-on-edit 'clear)
+    (lsp-diagnostics--clear-after-edit)))
+
+(add-hook 'lsp-after-apply-edits-hook #'lsp-diagnostics--clear-on-workspace-edit)
 
 (lsp-consistency-check lsp-diagnostics)
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -5098,6 +5098,24 @@ Added to `after-change-functions'."
                                 lsp-debounce-full-sync-notifications-interval
                                 nil
                                 #'lsp--flush-delayed-changes))
+        ;; Keep stored diagnostics aligned with the buffer until the server
+        ;; republishes them, instead of leaving them at stale line numbers
+        ;; (issue #3888).  A bracketed change carries a reliable before/after
+        ;; line range, so remap in place; otherwise fall back to clearing this
+        ;; buffer's diagnostics.
+        (when (fboundp 'lsp-diagnostics--update-after-change)
+          (if (and lsp--before-change-vals
+                   (lsp--bracketed-change-p start length))
+              (let ((edit-start (lsp--point-to-position start))
+                    (edit-old-end (plist-get lsp--before-change-vals :end-pos))
+                    (edit-new-end (lsp--point-to-position end)))
+                ;; These positions are plists built by `lsp--point-to-position'
+                ;; regardless of `lsp-use-plists', so read them with `plist-get'.
+                (lsp-diagnostics--update-after-change
+                 (plist-get edit-start :line) (plist-get edit-start :character)
+                 (plist-get edit-old-end :line) (plist-get edit-old-end :character)
+                 (plist-get edit-new-end :line) (plist-get edit-new-end :character)))
+            (lsp-diagnostics--clear-after-edit)))
         ;; force cleanup overlays after each change
         (lsp--remove-overlays 'lsp-highlight)
         (lsp--after-change (current-buffer))))))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -786,6 +786,30 @@ diagnostics until server publishes the new set of diagnostics"
   :group 'lsp-diagnostics
   :package-version '(lsp-mode . "7.0.1"))
 
+(defcustom lsp-diagnostics-on-edit 'remap
+  "What to do with stored diagnostics when the buffer is edited locally.
+
+After an edit, the buffer no longer matches the diagnostics the server
+last published, and it stays that way until the server re-checks and
+republishes.  This option controls what happens in that window:
+
+- `remap': shift the stored diagnostics to follow the edit, so they stay
+  on the text they describe.  A diagnostic whose text the edit changed is
+  dropped.  This keeps the display correct with no flicker.
+
+- `keep': leave the stored diagnostics untouched.  They may appear at
+  outdated positions until the server republishes.  This does the least
+  work per edit, which can matter in buffers with very many diagnostics.
+
+- `clear': discard the buffer's diagnostics after a workspace edit (for
+  example a code action or a rename) and wait for the server to send a
+  fresh set."
+  :type '(choice (const :tag "Remap to follow the edit" remap)
+                 (const :tag "Keep until the server republishes" keep)
+                 (const :tag "Clear after a workspace edit" clear))
+  :safe (lambda (value) (memq value '(remap keep clear)))
+  :group 'lsp-diagnostics)
+
 (defcustom lsp-server-trace nil
   "Request tracing on the server side.
 The actual trace output at each level depends on the language server in use.
@@ -5102,8 +5126,11 @@ Added to `after-change-functions'."
         ;; republishes them, instead of leaving them at stale line numbers
         ;; (issue #3888).  A bracketed change carries a reliable before/after
         ;; line range, so remap in place; otherwise fall back to clearing this
-        ;; buffer's diagnostics.
-        (when (fboundp 'lsp-diagnostics--update-after-change)
+        ;; buffer's diagnostics.  Other `lsp-diagnostics-on-edit' modes are
+        ;; handled elsewhere: `keep' does nothing here, `clear' acts on
+        ;; `lsp-after-apply-edits-hook'.
+        (when (and (eq lsp-diagnostics-on-edit 'remap)
+                   (fboundp 'lsp-diagnostics--update-after-change))
           (if (and lsp--before-change-vals
                    (lsp--bracketed-change-p start length))
               (let ((edit-start (lsp--point-to-position start))
@@ -10198,6 +10225,8 @@ Returns t if org 9.7+ API is available (property-based), nil otherwise."
 (declare-function flycheck-checker-supports-major-mode-p "ext:flycheck")
 (declare-function flycheck-add-mode "ext:flycheck")
 (declare-function lsp-diagnostics-lsp-checker-if-needed "lsp-diagnostics")
+(declare-function lsp-diagnostics--update-after-change "lsp-diagnostics")
+(declare-function lsp-diagnostics--clear-after-edit "lsp-diagnostics")
 
 (defalias 'lsp-client-download-server-fn 'lsp--client-download-server-fn)
 

--- a/test/lsp-mock-server-test.el
+++ b/test/lsp-mock-server-test.el
@@ -33,6 +33,9 @@
 
 (require 'seq)
 (require 'lsp-mode)
+;; The diagnostics-remap tests exercise behavior that lives in
+;; `lsp-diagnostics', which `lsp-mode' only loads lazily.
+(require 'lsp-diagnostics)
 
 ;; Taken from lsp-integration-tests.el
 (defconst lsp-test-location (file-name-directory (or load-file-name buffer-file-name))
@@ -319,30 +322,30 @@ TEST-BODY can interact with the mock server."
                                        "Line 0 unique word fegam and common"
                                        "                   ^^^^^           ")))))
 
-(ert-deftest lsp-mock-server-updates-diags-with-delay ()
-  "Test demonstrating delay in the diagnostics update.
+(ert-deftest lsp-mock-server-remaps-diags-after-edit ()
+  "Test that diagnostics follow a local edit instead of going stale.
 
-If server takes noticeable time to update diagnostics after a
-document change, and `lsp-diagnostic-clean-after-change' is
-nil (default), diagnostic ranges will be off until server
-publishes the update. This test demonstrates this behavior."
+When the buffer is edited before the server republishes, lsp-mode
+remaps the stored diagnostics to track the change, so they stay on the
+text they describe.  This replaces the stale-position problem from
+issue #3888, where the diagnostics kept the server's old line numbers
+until the next publish arrived."
+  (let ((lsp-diagnostics-on-edit 'remap))
   (lsp-mock-run-with-mock-server
    ;; There are no diagnostics at first
    (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 0))
 
-   ;; Server found diagnostic
+   ;; Server found a diagnostic on the "broming" line
    (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
    (lsp-test-sync-wait (progn (should (lsp-workspaces))
                               (gethash lsp-test-sample-file (lsp-diagnostics t))))
    (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
-
-   ;; The diagnostic is properly received
    (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
                   (lsp-test-range-make (buffer-string)
                                        "line 1 unique word broming + common"
                                        "                   ^^^^^^^         ")))
 
-   ;; Change the text: remove the first line
+   ;; Change the text: remove the first line, shifting "broming" up by one
    (goto-char (point-min))
    (kill-line 1)
    (should (string-equal (buffer-string)
@@ -350,26 +353,14 @@ publishes the update. This test demonstrates this behavior."
 line 2 unique word normalw common here
 line 3 words here and here
 "))
-   ;; Give it some time to update
-   (sleep-for 0.5)
-   ;; The diagnostic is not updated and now points to a wrong line
-   (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
-                  (lsp-test-range-make (buffer-string)
-                                       "line 2 unique word normalw common here"
-                                       "                   ^^^^^^^            ")))
 
-   ;; Server sent an update
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
-
-   (let ((old-line (lsp-mock-get-first-diagnostic-line)))
-     (lsp-test-sync-wait (progn (should (lsp-workspaces))
-                                (not (equal old-line (lsp-mock-get-first-diagnostic-line))))))
-
-   ;; Now the diagnostic is correct again
+   ;; With no server update yet, the diagnostic has already followed the
+   ;; edit: it is still on "broming", now one line higher.
+   (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
    (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
                   (lsp-test-range-make (buffer-string)
                                        "line 1 unique word broming + common"
-                                       "                   ^^^^^^^         ")))))
+                                       "                   ^^^^^^^         "))))))
 
 (ert-deftest lsp-mock-server-updates-diags-clears-up ()
   "Test ensuring diagnostics are cleared after a change."
@@ -411,35 +402,37 @@ line 3 words here and here
                                        "line 1 unique word broming + common"
                                        "                   ^^^^^^^         "))))))
 
-(ert-deftest lsp-mock-server-clears-diags-after-workspace-edit ()
-  "Test ensuring diagnostics are cleared after workspace edits.
+(ert-deftest lsp-mock-server-drops-overlapped-diag-after-edit ()
+  "Test that editing the text under a diagnostic drops only that diagnostic.
 
-Diagnostics should be cleared after workspace edits (like organize
-imports) to prevent stale diagnostics from appearing at wrong line
-numbers. This test verifies the fix for issue #3888."
+When an edit changes the very text a diagnostic covers, that diagnostic
+can no longer be placed and is dropped until the server re-checks.
+Diagnostics the edit did not touch are kept.  This replaces the
+unconditional post-edit clear added in PR #4984, which discarded every
+diagnostic in the buffer."
+  (let ((lsp-diagnostics-on-edit 'remap))
   (lsp-mock-run-with-mock-server
    ;; There are no diagnostics at first
    (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 0))
 
-   ;; Server found diagnostic
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+   ;; Server flags every "unique" -- one on each of lines 0, 1 and 2
+   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "unique")
    (lsp-test-sync-wait (progn (should (lsp-workspaces))
                               (gethash lsp-test-sample-file (lsp-diagnostics t))))
-   (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
+   (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 3))
 
-   ;; Simulate workspace edit (like organize imports) by running the hook
-   (run-hook-with-args 'lsp-after-apply-edits-hook 'code-action)
+   ;; Overwrite the "unique" on line 1 with a same-length word, so only
+   ;; that word's text changes.  The edit overlaps the line-1 diagnostic.
+   (goto-char (point-min))
+   (should (search-forward "unique" nil t))      ; line 0
+   (should (search-forward "unique" nil t))      ; line 1
+   (replace-match "XXXXXX" t t)
 
-   ;; After the hook runs, diagnostics should be cleared
-   (should (null (gethash lsp-test-sample-file (lsp-diagnostics t))))
-
-   ;; Server sent new diagnostics
-   (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
-   (lsp-test-sync-wait (progn (should (lsp-workspaces))
-                              (gethash lsp-test-sample-file (lsp-diagnostics t))))
-
-   ;; Now the diagnostic is available again
-   (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))))
+   ;; The line-1 diagnostic is dropped; the line-0 and line-2 ones survive.
+   (should (equal (sort (mapcar (lambda (d) (plist-get (lsp-test-diag-get d) :line))
+                                (gethash lsp-test-sample-file (lsp-diagnostics t)))
+                        #'<)
+                  '(0 2))))))
 
 (ert-deftest lsp-mock-server-on-edit-clear-clears-after-workspace-edit ()
   "Test that `lsp-diagnostics-on-edit' set to `clear' clears on a workspace edit.

--- a/test/lsp-mock-server-test.el
+++ b/test/lsp-mock-server-test.el
@@ -441,6 +441,56 @@ numbers. This test verifies the fix for issue #3888."
    ;; Now the diagnostic is available again
    (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))))
 
+(ert-deftest lsp-mock-server-on-edit-clear-clears-after-workspace-edit ()
+  "Test that `lsp-diagnostics-on-edit' set to `clear' clears on a workspace edit.
+
+In `clear' mode a workspace edit discards the buffer's diagnostics and
+waits for the server to send a fresh set."
+  (let ((lsp-diagnostics-on-edit 'clear))
+    (lsp-mock-run-with-mock-server
+     ;; There are no diagnostics at first
+     (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 0))
+
+     ;; Server found a diagnostic
+     (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+     (lsp-test-sync-wait (progn (should (lsp-workspaces))
+                                (gethash lsp-test-sample-file (lsp-diagnostics t))))
+     (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
+
+     ;; Simulate a workspace edit (like organize imports or a code action)
+     (run-hook-with-args 'lsp-after-apply-edits-hook 'code-action)
+
+     ;; In `clear' mode the buffer's diagnostics are discarded
+     (should (null (gethash lsp-test-sample-file (lsp-diagnostics t)))))))
+
+(ert-deftest lsp-mock-server-on-edit-keep-leaves-diags-untouched ()
+  "Test that `lsp-diagnostics-on-edit' set to `keep' leaves diagnostics as-is.
+
+In `keep' mode an edit neither remaps nor drops the stored diagnostics,
+so a diagnostic may sit at a stale position until the server republishes."
+  (let ((lsp-diagnostics-on-edit 'keep))
+    (lsp-mock-run-with-mock-server
+     ;; There are no diagnostics at first
+     (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 0))
+
+     ;; Server flagged "broming" on line 1
+     (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+     (lsp-test-sync-wait (progn (should (lsp-workspaces))
+                                (gethash lsp-test-sample-file (lsp-diagnostics t))))
+     (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
+
+     ;; Remove the first line; the text shifts but the diagnostic does not
+     (goto-char (point-min))
+     (kill-line 1)
+
+     ;; The diagnostic is untouched -- still on its original line, which now
+     ;; holds different text (a stale position, as expected in `keep' mode).
+     (should (eq (length (gethash lsp-test-sample-file (lsp-diagnostics t))) 1))
+     (should (equal (lsp-test-diag-get (car (gethash lsp-test-sample-file (lsp-diagnostics t))))
+                    (lsp-test-range-make (buffer-string)
+                                         "line 2 unique word normalw common here"
+                                         "                   ^^^^^^^            "))))))
+
 (defun lsp-test-xref-loc-to-range (xref-loc)
   "Convert XREF-LOC to a range p-list.
 


### PR DESCRIPTION
### The everyday experience this is about

When you work in a buffer managed by lsp-mode, the server sends back
diagnostics: the squiggly underlines for errors, warnings, and — with a
grammar or spell checker — writing mistakes. Normally those underlines just
stay where they are. You read them, you fix them one by one, and each one
disappears as you deal with it. The ones you haven't touched yet sit quietly in
place.

A few months ago, one part of that changed after PR #4984 landed upstream.

Now, whenever lsp-mode applies a *workspace edit* — accepting a quickfix,
renaming a symbol, running organize-imports — **every** diagnostic in the
buffer disappears at once, and then comes back a moment later. The "moment"
is however long it takes the server to re-check the document and send a fresh
set. On a local server that is a quick flicker. On a remote or slow server it
can be a full second or more, and you watch the underlines blink out and
slowly return.

This behavior introduced with PR #4984 had in principle a good motivation and
reason, but it introduces side effects, which are addressed and resolved by
this PR. Before discussing the side effects, however, it helps to give a
short overview of what problem PR #4984 was solving.

### The problem #4984 was solving (#3888)

Issue #3888 describes a real bug, and it's easy to picture.

Imagine a Go file. On save, `goimports` runs and removes an unused `import`
line. Removing a line shifts everything below it up by one. But the server
hasn't re-checked the file yet, so lsp-mode is still holding the *old*
diagnostics, which point at the *old* line numbers. For a moment, the squiggles
sit one line off from the code they describe. The reporter saw error markers
land on the wrong lines, and with a long idle delay configured, the wrong
display lingered for several seconds.

#4984's answer was direct: as soon as a workspace edit happens, throw away the
buffer's diagnostics. Better to show nothing for a moment than to show markers
in the wrong place. The server will send a correct set shortly, and the
squiggles come back where they belong.

That does make the garbled display go away. But it solves the problem by
removing information, and that turns out to cost more than it first appears —
and, as we'll see, it doesn't actually fix the underlying bug.

### Why clearing everything is too much

The catch is that most edits don't invalidate most diagnostics.

Take the most common case: you accept a spelling suggestion, or apply a
one-line quickfix. That changes text *inside a single line*. Nothing below it
moves. Every other diagnostic in the file is still in exactly the right place.
And yet, all of them are cleared, and all of them have to be re-sent by the
server before they reappear.

Now think about how people actually work with a grammar checker. You write the
whole document first, and then you go back and fix the flagged mistakes. Say
there are ten of them. With the current behavior, fixing the first one wipes
the other nine underlines off the screen and triggers a fresh round-trip to
the server before they return. Then you fix the second one, and it happens
again. Ten little bursts of blanking and waiting, where you expected nine
markers to simply stay put while you worked through them.

And there's nothing gained in return. The diagnostics that got cleared weren't
wrong. They were sitting on lines the edit never touched.

### What PR #4984 does: treating the symptom, not the cause

lsp-mode stores each diagnostic at the line and column the server reported, and
holds that copy until the server sends a new one. What it never does is adjust
those stored numbers when you edit the buffer. So the moment an edit shifts
lines, the stored positions are out of date — and they stay that way until the
next set arrives from the server.

#4984 works around this by deleting the stored set as soon as a workspace edit
happens. That clears the wrong-looking markers from view, but it doesn't make
the positions right. It just takes everything off the screen until the server
refills it — and the diagnostics that were perfectly fine, all the ones the
edit never touched, are thrown out along with the few that actually shifted.

So the deletion treats the symptom. The cause is that the stored positions
aren't kept up to date as the buffer changes. Fix that, and there's nothing
stale to hide and nothing to delete. This is what is proposed with this PR.

### What this PR proposes instead

Since the real problem behind issue #3888 is that the stored positions go out
of date, the natural fix is to keep them up to date.

So, when the buffer changes, we move the stored diagnostics to follow the
change — the same kind of bookkeeping the editor already does for its own
markers. We know which region of the buffer the edit touched and how many lines
it added or removed, and that's enough to do the right thing for each
diagnostic:

- A diagnostic located **above** the edit position doesn't move.
- A diagnostic located **below** the edit position shifts by the same amount the
  text shifted.
- A diagnostic that **overlaps** the edited text is dropped. Its text has
  changed, so the server should re-check it. That's the only case where an
  underline disappears — and the only one where it should.

The effect is that diagnostics stay in their correct places across any edit,
for the whole stretch until the server publishes its next set. No flicker, no
blanking, no waiting — and, notably, the original #3888 case comes out *better*
than before: after `goimports` removes a line, the remaining diagnostics simply
shift up to their new lines right away, instead of vanishing for the length of
a round-trip.

It's worth clarifying how long these remapped positions live. The remap
doesn't replace the server — it just keeps the display sensible until the
server catches up. Every edit still triggers the usual re-check, and the
diagnostics the server sends back replace the remapped ones completely, so a
remapped position survives for exactly one round-trip. If the edit changed
more than line numbers — say it removed an import and introduced errors
elsewhere — those new errors arrive with that next publish, and the remapped
set is discarded. Nothing remapped outlives the server's next answer.

Because the stored data is now kept correct on its own, the blanket "clear
everything after a workspace edit" step is no longer needed — and is in fact
undesirable, since it discards existing, perfectly valid diagnostics the user
may still be working through, such as those from a spell checker. So this PR
stops doing it by default — though, as the next section explains, it stays
available for anyone who wants it.

### Choosing the behavior

Not everyone wants the same trade-off, so this is a single option,
`lsp-diagnostics-on-edit`, with three values that together span the whole
history of this corner of lsp-mode:

- **`remap`** (the default) — follow each edit, as described above. This is
  what this PR introduces.
- **`keep`** — leave the stored diagnostics untouched after an edit; they may
  sit at outdated positions until the server republishes. This is how lsp-mode
  behaved *before* #4984.
- **`clear`** — discard the buffer's diagnostics after a workspace edit and wait
  for the server. This is the behavior #4984 introduced.

So if you preferred either of the older behaviors, you can simply ask for it.

There's also a practical reason to keep `keep` around. Remapping does a little
work on every edit, proportional to how many diagnostics the buffer holds — it
walks the list and shifts the ones below the edit. For ordinary files that is
imperceptible. But if you routinely work in buffers with a very large number of
diagnostics and want the absolute minimum work per keystroke, `keep` does
nothing at all on edit; the only cost is that positions can look stale for the
moment until the next publish. It is the escape hatch for that case.

And it needn't be an all-or-nothing global choice: `lsp-diagnostics-on-edit`
can be set per buffer. It is also declared a safe local variable, so it can be
set per project — for example in a `.dir-locals.el` — without a prompt. A huge
backlog of uncorrected diagnostics is usually the exception, not the rule, so
you can keep the default everywhere and switch to `keep` only in the rare
buffer that actually warrants it.

### Compatibility and scope

- With the default (`remap`) nothing changes about how diagnostics are
  requested or rendered; stored diagnostics simply follow edits instead of being
  discarded. The behavior is selectable via `lsp-diagnostics-on-edit` (see
  above) for anyone who prefers one of the older ones.
- The existing opt-in setting for clearing diagnostics on every change keeps its
  current meaning, for anyone who specifically wants that.
- In the uncommon case where the changed region can't be determined reliably,
  the code falls back to the previous behavior of clearing the buffer's
  diagnostics, so nothing regresses there.