### PR TITLE
Fix Magik server detection when JAR is missing

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -16,6 +16,7 @@
   * Fix crash (EXC_CRASH / SIGABRT) on macOS when installing language servers: replace ~url-copy-file~ in a background thread with ~make-process~ (curl) + sentinel, avoiding the NS event-loop thread-safety assertion in ~ns_select_1~
   * Fix ~lsp-clojure-extract-function~ to always send the range-based form required by clojure-lsp 2026.01+, and extract the selected region when one is active (see [[https://github.com/emacs-lsp/lsp-mode/issues/5023][#5023]])
   * Fix PHP Language Server detection.
+  * Fix Magik server detection when JAR is missing.
 
 ** 10.0.0
   * Fix ~lsp-zig--zls-url~ to use the new zigtools.org url (see: [[https://github.com/emacs-lsp/lsp-mode/issues/4445][#4445]])

--- a/clients/lsp-magik.el
+++ b/clients/lsp-magik.el
@@ -277,7 +277,10 @@ The next update resets the delay."
                       (substitute-in-file-name (lsp-resolve-value lsp-magik-java-path))
                       "-jar"
                       (substitute-in-file-name lsp-magik-ls-path)
-                      "--debug")))
+                      "--debug"))
+                   (lambda ()
+                     (and (executable-find (lsp-resolve-value lsp-magik-java-path) t)
+                          (file-exists-p (substitute-in-file-name lsp-magik-ls-path)))))
   :activation-fn (lsp-activate-on "magik" "sw-product-def" "sw-module-def" "sw-load-list")
   :initialized-fn (lambda (workspace)
                     (with-lsp-workspace workspace


### PR DESCRIPTION
The Magik client requires both a Java runtime and a downloaded JAR at `lsp-magik-ls-path`. The default installation check only verifies that Java is on PATH via `executable-find`, so the server appears as installed even when the JAR has never been downloaded.

This change adds a test-command to check both.