### PR TITLE
Fix rust-analyzer server detection when binary is missing

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -16,6 +16,7 @@
   * Fix crash (EXC_CRASH / SIGABRT) on macOS when installing language servers: replace ~url-copy-file~ in a background thread with ~make-process~ (curl) + sentinel, avoiding the NS event-loop thread-safety assertion in ~ns_select_1~
   * Fix ~lsp-clojure-extract-function~ to always send the range-based form required by clojure-lsp 2026.01+, and extract the selected region when one is active (see [[https://github.com/emacs-lsp/lsp-mode/issues/5023][#5023]])
   * Fix PHP Language Server detection.
+  * Fix rust-analyzer server detection when binary is missing.
 
 ** 10.0.0
   * Fix ~lsp-zig--zls-url~ to use the new zigtools.org url (see: [[https://github.com/emacs-lsp/lsp-mode/issues/4445][#4445]])

--- a/clients/lsp-rust.el
+++ b/clients/lsp-rust.el
@@ -1891,8 +1891,7 @@ https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/lsp-extensions.m
                              t)
                             (lsp-package-path 'rust-analyzer)
                             "rust-analyzer")
-                       ,@(cl-rest lsp-rust-analyzer-server-command)))
-                   (lambda () t))
+                       ,@(cl-rest lsp-rust-analyzer-server-command))))
   :activation-fn (lsp-activate-on "rust")
   :priority (if (eq lsp-rust-server 'rust-analyzer) 1 -1)
   :initialization-options 'lsp-rust-analyzer--make-init-options


### PR DESCRIPTION
The rust-analyzer client uses a dummy test-command that always returns t, so the server appears as installed even when the binary is not on PATH.

This change removes the dummy test-command to use the default check.