### PR TITLE
Fix Magik indent strategy options to match language server

### DIFF
--- a/clients/lsp-magik.el
+++ b/clients/lsp-magik.el
@@ -157,9 +157,10 @@ The next update resets the delay."
   :lsp-path "magik.typing.cacheIndexedDefinitions")
 
 (lsp-defcustom lsp-magik-formatting-indent-strategy "null"
-  "The strategy used for indentation, \"null\" or \"relative\"."
+  "The strategy used for indentation: \"null\", \"block\", or \"visual\"."
   :type '(choice (const "null")
-                 (const "relative"))
+                 (const "block")
+                 (const "visual"))
   :group 'lsp-magik
   :package-version '(lsp-mode . "10.0.0")
   :lsp-path "magik.formatting.indentStrategy")


### PR DESCRIPTION
## Summary

- The `lsp-magik-formatting-indent-strategy` custom variable exposed `"null"` and `"relative"` as valid choices, but `"relative"` does not exist in the Magik language server.
- The valid strategy names (as defined in [`MagikFormattingSettings.java`](https://github.com/StevenLooman/magik-tools/blob/main/magik-squid/src/main/java/nl/ramsolutions/sw/magik/formatting/MagikFormattingSettings.java)) are `"null"` (`NullIndentWalker`), `"block"` (`BlockIndentWalker`), and `"visual"` (`VisualIndentWalker`).
- Selecting `"relative"` caused the language server to throw `IllegalArgumentException: Unknown indent strategy: relative`, resulting in an internal server error on every `textDocument/codeAction` request.

Fixes the same issue as https://github.com/StevenLooman/magik-tools/issues/596.

## Test plan

- [ ] Open an Emacs buffer with a `.magik` file and lsp-mode active
- [ ] Set `lsp-magik-formatting-indent-strategy` to `"block"` or `"visual"` and trigger formatting — confirm no server error