### PR TITLE
Add pylsp ruff formatEnabled setting

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 10.0.1
+  * Add ~lsp-pylsp-plugins-ruff-format-enabled~ to expose python-lsp-ruff's ~formatEnabled~ setting.
   * Fix ~lsp-install-server~ download from the Visual Studio Code Marketplace.
   * Add support for LSP 3.17 InlayHint features: ~textEdits~, ~tooltip~, ~data~, ~InlayHintLabelPart~ (per-part ~tooltip~/~location~/~command~), ~inlayHint/resolve~, interactive mouse handler, and ~lsp-inlay-hint-accept~ command (see [[https://github.com/emacs-lsp/lsp-mode/issues/4775][#4775]])
   * Add ~lsp-diagnostics-flymake-message-formatter~ defcustom for customizing how an LSP diagnostic is rendered into the flymake text string; the default appends the code in brackets, and users can suppress it, prepend the source tool, add a severity prefix, etc. (see: [[https://github.com/emacs-lsp/lsp-mode/pull/5036][#5036]]).

--- a/clients/lsp-pylsp.el
+++ b/clients/lsp-pylsp.el
@@ -237,14 +237,14 @@ Drastically increases startup time."
   :group 'lsp-pylsp)
 
 (defcustom lsp-pylsp-plugins-rope-autoimport-completions-enabled nil
-    "Enable or disable completions from rope-autoimport."
-    :type 'boolean
-    :group 'lsp-pylsp)
+  "Enable or disable completions from rope-autoimport."
+  :type 'boolean
+  :group 'lsp-pylsp)
 
 (defcustom lsp-pylsp-plugins-rope-autoimport-code-actions-enabled nil
-    "Enable or disable code actions from rope-autoimport."
-    :type 'boolean
-    :group 'lsp-pylsp)
+  "Enable or disable code actions from rope-autoimport."
+  :type 'boolean
+  :group 'lsp-pylsp)
 
 (defcustom lsp-pylsp-plugins-rope-completion-enabled nil
   "Enable or disable the plugin."
@@ -400,6 +400,11 @@ Requires pylsp >= 0.33.0"
 
 Note each rule must additionally be marked as fixable by ruff."
   :type 'lsp-string-vector
+  :group 'lsp-pylsp)
+
+(defcustom lsp-pylsp-plugins-ruff-format-enabled t
+  "Enable formatting using ruff's formatter."
+  :type 'boolean
   :group 'lsp-pylsp)
 
 (defcustom lsp-pylsp-plugins-ruff-severities nil
@@ -635,6 +640,7 @@ So it will rename only references it can find."
    ("pylsp.plugins.ruff.extendSelect" lsp-pylsp-plugins-ruff-extend-select)
    ("pylsp.plugins.ruff.extendIgnore" lsp-pylsp-plugins-ruff-extend-ignore)
    ("pylsp.plugins.ruff.format" lsp-pylsp-plugins-ruff-format)
+   ("pylsp.plugins.ruff.formatEnabled" lsp-pylsp-plugins-ruff-format-enabled t)
    ("pylsp.plugins.ruff.severities" lsp-pylsp-plugins-ruff-severities)
    ("pylsp.plugins.ruff.unsafeFixes" lsp-pylsp-plugins-ruff-unsafe-fixes t)
    ("pylsp.plugins.ruff.lineLength" lsp-pylsp-plugins-ruff-line-length)


### PR DESCRIPTION
## Summary

Add the missing `lsp-pylsp-plugins-ruff-format-enabled` defcustom and register it as `pylsp.plugins.ruff.formatEnabled` for `python-lsp-ruff`.

This complements the existing `python-lsp-ruff` settings added for `lsp-pylsp`: `enabled`, `executable`, `config`, `format`, `severities`, etc. The new defcustom defaults to `t`, matching `python-lsp-ruff`'s current default, while still allowing users to set it to `nil` to send JSON `false` and disable Ruff formatter support.

This is only for the `pylsp` plugin configuration; it does not change the standalone `lsp-ruff` client.

## Motivation

`python-lsp-ruff` documents `formatEnabled`, but `lsp-pylsp` did not expose/register that setting. This surfaced while investigating `pylsp` Ruff configuration from a downstream Spacemacs report. In a clean setup, the existing `executable`, `config`, and `severities` settings already serialize correctly; `formatEnabled` was the missing lsp-mode option.

## Validation

- Verified current `lsp-pylsp` lacks `lsp-pylsp-plugins-ruff-format-enabled` and does not serialize `formatEnabled`.
- Verified patched `lsp-pylsp` serializes `formatEnabled=t` by default and `:json-false` when explicitly set to `nil`.
- Ran an end-to-end test with real `pylsp v1.14.0`, `python-lsp-ruff`, and `ruff 0.15.20`; `workspace/didChangeConfiguration` included `"formatEnabled": true`, `textDocument/formatting` returned `format: ruff`, and Emacs applied the Ruff formatting edit.
- Byte-compiled `clients/lsp-pylsp.el` locally; only an unrelated pre-existing docstring-width warning was reported.
- Ran the changed-file indentation check equivalent locally.

## Checklist

- [x] I added a new entry to `CHANGELOG.org`.
- [x] I updated documentation if applicable (`docs` folder). Not applicable; this adds a defcustom and changelog entry.


