### PR TITLE
feat: add lsp-prisma client for Prisma Schema Language

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -16,6 +16,7 @@
   * Fix crash (EXC_CRASH / SIGABRT) on macOS when installing language servers: replace ~url-copy-file~ in a background thread with ~make-process~ (curl) + sentinel, avoiding the NS event-loop thread-safety assertion in ~ns_select_1~
   * Fix ~lsp-clojure-extract-function~ to always send the range-based form required by clojure-lsp 2026.01+, and extract the selected region when one is active (see [[https://github.com/emacs-lsp/lsp-mode/issues/5023][#5023]])
   * Fix PHP Language Server detection.
+  * Add support for [[https://github.com/prisma/language-tools][Prisma Schema Language]] via ~@prisma/language-server~ (see [[https://github.com/emacs-lsp/lsp-mode/pull/5095][#5095]]).
 
 ** 10.0.0
   * Fix ~lsp-zig--zls-url~ to use the new zigtools.org url (see: [[https://github.com/emacs-lsp/lsp-mode/issues/4445][#4445]])

--- a/clients/lsp-prisma.el
+++ b/clients/lsp-prisma.el
@@ -1,0 +1,59 @@
+;;; lsp-prisma.el --- LSP client for Prisma Schema Language  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 ChuYanLon
+;; Copyright (C) 2026 emacs-lsp maintainers
+
+;; Author: ChuYanLon <a1008611abcd@126.com>
+;; Keywords: languages, prisma
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP client for Prisma Schema Language, using prisma-language-server
+;; from @prisma/language-server (https://github.com/prisma/language-tools).
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-prisma nil
+  "LSP support for Prisma Schema Language."
+  :group 'lsp-mode
+  :link '(url-link "https://github.com/prisma/language-tools"))
+
+(lsp-dependency 'prisma-language-server
+                '(:system "prisma-language-server")
+                '(:npm :package "@prisma/language-server"
+                       :path "prisma-language-server"))
+
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection
+                                   (lambda ()
+                                     `(,(lsp-package-path 'prisma-language-server)
+                                       "--stdio")))
+                  :activation-fn (lambda (filename _mode)
+                                   (string= (file-name-extension filename) "prisma"))
+                  :language-id "prisma"
+                  :server-id 'prisma-ls
+                  :multi-root t
+                  :download-server-fn
+                  (lambda (_client callback error-callback _update?)
+                    (lsp-package-ensure 'prisma-language-server
+                                        callback error-callback))))
+
+(lsp-consistency-check lsp-prisma)
+
+(provide 'lsp-prisma)
+;;; lsp-prisma.el ends here

--- a/clients/lsp-prisma.el
+++ b/clients/lsp-prisma.el
@@ -53,6 +53,8 @@
                     (lsp-package-ensure 'prisma-language-server
                                         callback error-callback))))
 
+(add-to-list 'lsp-language-id-configuration '(prisma-mode . "prisma"))
+
 (lsp-consistency-check lsp-prisma)
 
 (provide 'lsp-prisma)

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -928,6 +928,15 @@
     "debugger": "yes"
   },
   {
+    "name": "prisma",
+    "full-name": "Prisma",
+    "server-name": "prisma-language-server",
+    "server-url": "https://github.com/prisma/language-tools",
+    "installation": "npm i -g @prisma/language-server",
+    "lsp-install-server": "prisma-ls",
+    "debugger": "Not available"
+  },
+  {
     "name": "pwsh",
     "full-name": "Powershell",
     "server-name": "PowerShellEditorServices",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -187,7 +187,7 @@ As defined by the Language Server Protocol 3.16."
      lsp-marksman lsp-matlab lsp-mdx lsp-meson lsp-metals lsp-mint lsp-mojo
      lsp-move lsp-mssql lsp-nextflow lsp-nginx lsp-nim lsp-nix lsp-nushell
      lsp-ocaml lsp-odin lsp-openscad lsp-pascal lsp-perl lsp-perlnavigator
-     lsp-php lsp-pls lsp-postgres lsp-purescript lsp-pwsh lsp-pyls lsp-pylsp
+      lsp-php lsp-pls lsp-postgres lsp-prisma lsp-purescript lsp-pwsh lsp-pyls lsp-pylsp
      lsp-pyright lsp-python-ms lsp-python-ty lsp-qml lsp-r lsp-racket lsp-remark
      lsp-rf lsp-roc lsp-ron lsp-roslyn lsp-rubocop lsp-ruby-lsp
      lsp-ruby-syntax-tree lsp-ruff lsp-rust lsp-semgrep lsp-shader

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,6 +150,7 @@ nav:
     - PHP (felixbecker): page/lsp-php.md
     - PHP (phpactor): page/lsp-phpactor.md
     - Powershell: page/lsp-pwsh.md
+    - Prisma: page/lsp-prisma.md
     - Prolog: page/lsp-prolog.md
     - PureScript: page/lsp-purescript.md
     - Python (Pylsp): page/lsp-pylsp.md


### PR DESCRIPTION
Provides LSP support for Prisma schema files (.prisma) via the @prisma/language-server npm package.

- New client: `clients/lsp-prisma.el`
- Added to `lsp-clients.json`, `mkdocs.yml`, `lsp-client-packages`

The client activates based on file extension (.prisma) and supports automatic installation through `lsp-install-server`.