### PR TITLE
Add lsp-python-ty-log-level

### DIFF
--- a/clients/lsp-python-ty.el
+++ b/clients/lsp-python-ty.el
@@ -42,7 +42,7 @@
   :type '(choice (const "debug")
                  (const "error")
                  (const "info")
-                 (const "off")
+                 (const "trace")
                  (const "warn"))
   :group 'lsp-ruff)
 

--- a/clients/lsp-python-ty.el
+++ b/clients/lsp-python-ty.el
@@ -37,12 +37,24 @@
   :risky t
   :type '(repeat string))
 
+(defcustom lsp-python-ty-log-level "error"
+  "Tracing level."
+  :type '(choice (const "debug")
+                 (const "error")
+                 (const "info")
+                 (const "off")
+                 (const "warn"))
+  :group 'lsp-ruff)
+
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-stdio-connection (lambda () lsp-python-ty-clients-server-command))
                   :activation-fn (lsp-activate-on "python")
                   :priority -1
                   :add-on? t
                   :server-id 'ty-ls
+                  :initialization-options
+                  (lambda ()
+                    (list :logLevel lsp-python-ty-log-level))
                   :initialized-fn (lambda (workspace)
                                     (let ((caps (lsp--workspace-server-capabilities workspace)))
                                       (unless (lsp-get caps :inlayHintProvider)


### PR DESCRIPTION
Simple addition to change the `logLevel` of the python-ty client. Very useful for debugging and will help further option additions (see https://github.com/astral-sh/ty/blob/main/docs/reference/editor-settings.md for all options)