### PR TITLE
Fix Odin doc link

### DIFF
--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -851,6 +851,7 @@
   {
     "name": "ols",
     "full-name": "Odin Language Server",
+    "common-group-name": "odin-ols",
     "server-name": "ols",
     "server-url": "https://github.com/DanielGavin/ols",
     "installation-url": "https://github.com/DanielGavin/ols",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,7 +139,7 @@ nav:
     - Nix (nil): page/lsp-nix-nil.md
     - Nushell: page/lsp-nushell.md
     - OCaml (ocaml-lsp): page/lsp-ocaml-lsp-server.md
-    - Odin (ols): page/lsp-odin-ols-server.md
+    - Odin (ols): page/lsp-ols.md
     - OpenSCAD: page/lsp-openscad.md
     - Pascal/Object Pascal: page/lsp-pascal.md
     - Perl (PLS): page/lsp-pls.md


### PR DESCRIPTION
The link to Odin in the navigation on the doc page was broken.

<img width="787" height="267" alt="pic" src="https://github.com/user-attachments/assets/5820984b-3a7f-4d28-9a5e-18ce8b25ba7d" />

Tested locally with my fix:

<img width="904" height="363" alt="pic2" src="https://github.com/user-attachments/assets/dbb3893d-da89-4802-a738-a7abfbd4ab15" />
