### PR TITLE
add biome client

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 10.0.1
+  * Add a built-in Biome client.
   * Add ~lsp-pylsp-plugins-ruff-format-enabled~ to expose python-lsp-ruff's ~formatEnabled~ setting.
   * Fix ~lsp-install-server~ download from the Visual Studio Code Marketplace.
   * Add support for LSP 3.17 InlayHint features: ~textEdits~, ~tooltip~, ~data~, ~InlayHintLabelPart~ (per-part ~tooltip~/~location~/~command~), ~inlayHint/resolve~, interactive mouse handler, and ~lsp-inlay-hint-accept~ command (see [[https://github.com/emacs-lsp/lsp-mode/issues/4775][#4775]])

--- a/clients/lsp-biome.el
+++ b/clients/lsp-biome.el
@@ -1,0 +1,111 @@
+;;; lsp-biome.el --- LSP client for Biome -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Pradyuman Vig
+;; Copyright (C) 2026 emacs-lsp maintainers
+
+;; Author: Pradyuman Vig <me@pmn.co>
+;; Keywords: languages, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP client for Biome, using the `biome lsp-proxy' command.
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-biome nil
+  "LSP support for Biome."
+  :group 'lsp-mode
+  :link '(url-link "https://biomejs.dev"))
+
+(lsp-defcustom lsp-biome-require-configuration nil
+  "Whether Biome requires a configuration file before providing features."
+  :type 'boolean
+  :group 'lsp-biome
+  :lsp-path "biome.requireConfiguration")
+
+(lsp-defcustom lsp-biome-configuration-path nil
+  "Path to a preferred Biome configuration file or its directory."
+  :type '(choice (const :tag "Automatic" nil)
+          string)
+  :group 'lsp-biome
+  :lsp-path "biome.configurationPath")
+
+(lsp-defcustom lsp-biome-inline-config nil
+  "Biome configuration to merge over configuration read from disk."
+  :type '(choice (const :tag "None" nil)
+          sexp)
+  :group 'lsp-biome
+  :lsp-path "biome.inlineConfig")
+
+(lsp-defcustom lsp-biome-go-to-definition nil
+  "Whether Biome provides go-to-definition support."
+  :type 'boolean
+  :group 'lsp-biome
+  :lsp-path "biome.goToDefinition")
+
+(lsp-dependency 'biome
+                '(:system "biome")
+                '(:npm :package "@biomejs/biome"
+                  :path "biome"))
+
+(defun lsp-biome--server-command ()
+  "Return the command used to start the Biome language server."
+  (let* ((local-path (concat "node_modules/.bin/biome"
+                             (when (eq system-type 'windows-nt) ".cmd")))
+         (root (locate-dominating-file default-directory local-path)))
+    (list (if root
+              (expand-file-name local-path root)
+            (lsp-package-path 'biome))
+          "lsp-proxy")))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection
+  (lsp-stdio-connection #'lsp-biome--server-command)
+  :activation-fn
+  (lsp-activate-on
+   "javascript"
+   "javascriptreact"
+   "typescript"
+   "typescriptreact"
+   "json"
+   "jsonc"
+   "css"
+   "graphql"
+   "html"
+   "vue"
+   "svelte"
+   "astro")
+  :server-id 'biome
+  :priority -1
+  :add-on? t
+  :multi-root t
+  :initialized-fn
+  (lambda (workspace)
+    (with-lsp-workspace workspace
+      (lsp--set-configuration
+       (lsp-configuration-section "biome"))))
+  :synchronize-sections '("biome")
+  :download-server-fn
+  (lambda (_client callback error-callback _update?)
+    (lsp-package-ensure 'biome callback error-callback))))
+
+(lsp-consistency-check lsp-biome)
+
+(provide 'lsp-biome)
+;;; lsp-biome.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -91,10 +91,12 @@
   },
   { "name": "biome",
     "full-name": "Biome",
-    "server-name": "biome-language-server",
+    "server-name": "biome",
     "server-url": "https://github.com/biomejs/biome",
-    "installation": "npm install -g @biomejs/biome-language-server",
-    "installation-url": "https://biomejs.dev/guides/getting-started/"
+    "installation": "npm install -g @biomejs/biome",
+    "installation-url": "https://biomejs.dev/guides/getting-started/",
+    "lsp-install-server": "biome",
+    "debugger": "Not available"
   },
   {
     "name": "buf",


### PR DESCRIPTION
## Summary

#5007 added `lsp-biome` to `lsp-client-packages` and the documentation navigation, but did not add a client implementation. Because client packages are loaded optionally, Biome support is otherwise silently skipped unless an external package provides the feature. This PR completes that in-tree integration.

The implementation follows existing in-tree client and dependency APIs and is based on Biome's documented LSP contract. It take a different approach from the external `cxa/lsp-biome` package, and instead aims to match default `biome lsp-proxy` behavior as closely as possible (including relying on `lsp-mode` code action facilities, exposing biome languge server configuration settings, supporting multi-root, etc).

## Testing

- `nix shell nixpkgs#eask-cli -c make compile EASK=eask`
- targeted `package-lint` for `clients/lsp-biome.el`
- targeted `checkdoc` for `clients/lsp-biome.el`
- generated `docs/page/lsp-biome.md` successfully
- initialized Biome 2.5.5 through `lsp-mode` and formatted a TypeScript buffer using the real LSP server