### PR TITLE
add oxlint client

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 10.0.1
+  * Add support for [[https://oxc.rs/docs/guide/usage/linter/editors][Oxlint]] through its built-in language server.
   * Add ~lsp-pylsp-plugins-ruff-format-enabled~ to expose python-lsp-ruff's ~formatEnabled~ setting.
   * Fix ~lsp-install-server~ download from the Visual Studio Code Marketplace.
   * Add support for LSP 3.17 InlayHint features: ~textEdits~, ~tooltip~, ~data~, ~InlayHintLabelPart~ (per-part ~tooltip~/~location~/~command~), ~inlayHint/resolve~, interactive mouse handler, and ~lsp-inlay-hint-accept~ command (see [[https://github.com/emacs-lsp/lsp-mode/issues/4775][#4775]])

--- a/clients/lsp-oxlint.el
+++ b/clients/lsp-oxlint.el
@@ -1,0 +1,159 @@
+;;; lsp-oxlint.el --- LSP client for Oxlint -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Pradyuman Vig
+;; Copyright (C) 2026 emacs-lsp maintainers
+
+;; Author: Pradyuman Vig <me@pmn.co>
+;; Keywords: languages, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP client for Oxlint, using the `oxlint --lsp' command.
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-oxlint nil
+  "LSP support for Oxlint."
+  :group 'lsp-mode
+  :link '(url-link "https://oxc.rs/docs/guide/usage/linter/editors"))
+
+(lsp-defcustom lsp-oxlint-config-path nil
+  "Path to an Oxlint configuration file.
+When set, Oxlint disables automatic configuration discovery."
+  :type '(choice (const :tag "Automatic" nil)
+                 string)
+  :group 'lsp-oxlint
+  :lsp-path "oxc.configPath")
+
+(lsp-defcustom lsp-oxlint-tsconfig-path nil
+  "Path to the TypeScript configuration file used for import resolution."
+  :type '(choice (const :tag "Automatic" nil)
+                 string)
+  :group 'lsp-oxlint
+  :lsp-path "oxc.tsConfigPath")
+
+(lsp-defcustom lsp-oxlint-unused-disable-directives nil
+  "Severity for unused Oxlint disable directives.
+When nil, use the language server default."
+  :type '(choice (const :tag "Server default" nil)
+                 (const "allow")
+                 (const "warn")
+                 (const "deny"))
+  :group 'lsp-oxlint
+  :lsp-path "oxc.unusedDisableDirectives")
+
+(lsp-defcustom lsp-oxlint-type-aware nil
+  "Whether to enable type-aware linting.
+When nil, use the setting from the root Oxlint configuration."
+  :type '(choice (const :tag "Use project configuration" nil)
+                 (const :tag "Enabled" t)
+                 (const :tag "Disabled" :json-false))
+  :group 'lsp-oxlint
+  :lsp-path "oxc.typeAware")
+
+(lsp-defcustom lsp-oxlint-disable-nested-config nil
+  "Whether to disable nested Oxlint configuration discovery.
+When nil, use the language server default."
+  :type '(choice (const :tag "Server default" nil)
+                 (const :tag "Enabled" t)
+                 (const :tag "Disabled" :json-false))
+  :group 'lsp-oxlint
+  :lsp-path "oxc.disableNestedConfig")
+
+(lsp-defcustom lsp-oxlint-fix-kind nil
+  "Maximum class of fixes offered by Oxlint.
+When nil, use the language server default."
+  :type '(choice (const :tag "Server default" nil)
+                 (const "safe_fix")
+                 (const "safe_fix_or_suggestion")
+                 (const "dangerous_fix")
+                 (const "dangerous_fix_or_suggestion")
+                 (const "none")
+                 (const "all"))
+  :group 'lsp-oxlint
+  :lsp-path "oxc.fixKind")
+
+(lsp-defcustom lsp-oxlint-rules-customization nil
+  "Per-rule diagnostic severity and automatic-fix overrides.
+The value is an alist or hash table keyed by Oxlint rule name."
+  :type '(choice (const :tag "None" nil)
+                 sexp)
+  :group 'lsp-oxlint
+  :lsp-path "oxc.rulesCustomization")
+
+(lsp-defcustom lsp-oxlint-run nil
+  "When Oxlint publishes diagnostics.
+When nil, use the language server default."
+  :type '(choice (const :tag "Server default" nil)
+                 (const "onType")
+                 (const "onSave"))
+  :group 'lsp-oxlint
+  :lsp-path "oxc.run")
+
+(lsp-dependency 'oxlint
+                '(:system "oxlint")
+                '(:npm :package "oxlint"
+                       :path "oxlint"))
+
+(defun lsp-oxlint--server-command ()
+  "Return the command used to start the Oxlint language server."
+  (let* ((local-path (concat "node_modules/.bin/oxlint"
+                             (when (eq system-type 'windows-nt) ".cmd")))
+         (root (locate-dominating-file default-directory local-path)))
+    (list (if root
+              (expand-file-name local-path root)
+            (lsp-package-path 'oxlint))
+          "--lsp")))
+
+(defun lsp-oxlint-fix-all ()
+  "Apply all safe Oxlint fixes to the current buffer."
+  (interactive)
+  (lsp-send-execute-command
+   "oxc.fixAll"
+   (vector (list :uri (lsp--buffer-uri)))))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection #'lsp-oxlint--server-command)
+  :activation-fn
+  (lsp-activate-on
+   "javascript"
+   "javascriptreact"
+   "typescript"
+   "typescriptreact"
+   "vue"
+   "svelte"
+   "astro")
+  :server-id 'oxlint
+  :priority -1
+  :add-on? t
+  :multi-root t
+  :initialized-fn
+  (lambda (workspace)
+    (with-lsp-workspace workspace
+      (lsp--set-configuration
+       (lsp-configuration-section "oxc"))))
+  :synchronize-sections '("oxc")
+  :download-server-fn
+  (lambda (_client callback error-callback _update?)
+    (lsp-package-ensure 'oxlint callback error-callback))))
+
+(lsp-consistency-check lsp-oxlint)
+
+(provide 'lsp-oxlint)
+;;; lsp-oxlint.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -867,6 +867,16 @@
     "debugger": "Not available"
   },
   {
+    "name": "oxlint",
+    "full-name": "Oxlint",
+    "server-name": "oxlint",
+    "server-url": "https://github.com/oxc-project/oxc",
+    "installation": "npm install -g oxlint",
+    "installation-url": "https://oxc.rs/docs/guide/usage/linter/editors",
+    "lsp-install-server": "oxlint",
+    "debugger": "Not available"
+  },
+  {
     "name": "pascal",
     "full-name": "Pascal/Object Pascal",
     "server-name": "pascal-language-server",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -186,8 +186,9 @@ As defined by the Language Server Protocol 3.16."
      lsp-ltex lsp-ltex-plus lsp-lua lsp-fennel lsp-magik lsp-markdown
      lsp-marksman lsp-matlab lsp-mdx lsp-meson lsp-metals lsp-mint lsp-mojo
      lsp-move lsp-mssql lsp-nextflow lsp-nginx lsp-nim lsp-nix lsp-nushell
-     lsp-ocaml lsp-odin lsp-openscad lsp-pascal lsp-perl lsp-perlnavigator
-      lsp-php lsp-pls lsp-postgres lsp-prisma lsp-purescript lsp-pwsh lsp-pyls lsp-pylsp
+     lsp-ocaml lsp-odin lsp-openscad lsp-oxlint lsp-pascal lsp-perl
+     lsp-perlnavigator lsp-php lsp-pls lsp-postgres lsp-prisma lsp-purescript
+     lsp-pwsh lsp-pyls lsp-pylsp
      lsp-pyright lsp-python-ms lsp-python-ty lsp-qml lsp-r lsp-racket lsp-remark
      lsp-rf lsp-roc lsp-ron lsp-roslyn lsp-rubocop lsp-ruby-lsp
      lsp-ruby-syntax-tree lsp-ruff lsp-rust lsp-semgrep lsp-shader

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,7 @@ nav:
     - OCaml (ocaml-lsp): page/lsp-ocaml-lsp-server.md
     - Odin (ols): page/lsp-ols.md
     - OpenSCAD: page/lsp-openscad.md
+    - Oxlint: page/lsp-oxlint.md
     - Pascal/Object Pascal: page/lsp-pascal.md
     - Perl (PLS): page/lsp-pls.md
     - Perl (Perl::LanguageServer): page/lsp-perl.md


### PR DESCRIPTION
## Summary

This PR adds an oxlint client that can run alongside JavaScript and TypeScript language servers (via `oxlint --lsp`). It supports project-local executable resolution, multi-root workspaces, native `oxc` configuration settings, diagnostics, and fix-all actions.

## Testing

- `nix shell nixpkgs#eask-cli -c make compile EASK=eask`
- targeted `package-lint` for `clients/lsp-oxlint.el`
- targeted `checkdoc` for `clients/lsp-oxlint.el`
- generated `docs/page/lsp-oxlint.md` successfully
- initialized Oxlint 1.73.0 through lsp-mode using a project-local installation and verified that lsp actions work (including `fix-all`)