### PR TITLE
add oxfmt client

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 10.0.1
+  * Add support for [[https://oxc.rs/docs/guide/usage/formatter/editors][Oxfmt]] through its built-in language server.
   * Add ~lsp-pylsp-plugins-ruff-format-enabled~ to expose python-lsp-ruff's ~formatEnabled~ setting.
   * Fix ~lsp-install-server~ download from the Visual Studio Code Marketplace.
   * Add support for LSP 3.17 InlayHint features: ~textEdits~, ~tooltip~, ~data~, ~InlayHintLabelPart~ (per-part ~tooltip~/~location~/~command~), ~inlayHint/resolve~, interactive mouse handler, and ~lsp-inlay-hint-accept~ command (see [[https://github.com/emacs-lsp/lsp-mode/issues/4775][#4775]])

--- a/clients/lsp-oxfmt.el
+++ b/clients/lsp-oxfmt.el
@@ -1,0 +1,106 @@
+;;; lsp-oxfmt.el --- LSP client for Oxfmt -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Pradyuman Vig
+;; Copyright (C) 2026 emacs-lsp maintainers
+
+;; Author: Pradyuman Vig <me@pmn.co>
+;; Keywords: languages, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; LSP client for Oxfmt, using the `oxfmt --lsp' command.
+
+;;; Code:
+
+(require 'lsp-mode)
+
+(defgroup lsp-oxfmt nil
+  "LSP support for Oxfmt."
+  :group 'lsp-mode
+  :link '(url-link "https://oxc.rs/docs/guide/usage/formatter/editors"))
+
+(lsp-defcustom lsp-oxfmt-config-path nil
+  "Path to an Oxfmt configuration file.
+When set, Oxfmt disables automatic configuration discovery."
+  :type '(choice (const :tag "Automatic" nil)
+                 string)
+  :group 'lsp-oxfmt
+  :lsp-path "oxc.fmt.configPath")
+
+(lsp-defcustom lsp-oxfmt-disable-nested-config nil
+  "Whether to disable nested Oxfmt configuration discovery.
+When nil, use the language server default."
+  :type '(choice (const :tag "Server default" nil)
+                 (const :tag "Enabled" t)
+                 (const :tag "Disabled" :json-false))
+  :group 'lsp-oxfmt
+  :lsp-path "oxc.fmt.disableNestedConfig")
+
+(lsp-dependency 'oxfmt
+                '(:system "oxfmt")
+                '(:npm :package "oxfmt"
+                       :path "oxfmt"))
+
+(defun lsp-oxfmt--server-command ()
+  "Return the command used to start the Oxfmt language server."
+  (let* ((local-path (concat "node_modules/.bin/oxfmt"
+                             (when (eq system-type 'windows-nt) ".cmd")))
+         (root (locate-dominating-file default-directory local-path)))
+    (list (if root
+              (expand-file-name local-path root)
+            (lsp-package-path 'oxfmt))
+          "--lsp")))
+
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection #'lsp-oxfmt--server-command)
+  :activation-fn
+  (lsp-activate-on
+   "javascript"
+   "javascriptreact"
+   "typescript"
+   "typescriptreact"
+   "json"
+   "jsonc"
+   "css"
+   "scss"
+   "less"
+   "graphql"
+   "toml"
+   "html"
+   "vue"
+   "svelte"
+   "markdown"
+   "mdx"
+   "yaml")
+  :server-id 'oxfmt
+  :priority -1
+  :add-on? t
+  :multi-root t
+  :initialized-fn
+  (lambda (workspace)
+    (with-lsp-workspace workspace
+      (lsp--set-configuration
+       (lsp-configuration-section "oxc"))))
+  :synchronize-sections '("oxc")
+  :download-server-fn
+  (lambda (_client callback error-callback _update?)
+    (lsp-package-ensure 'oxfmt callback error-callback))))
+
+(lsp-consistency-check lsp-oxfmt)
+
+(provide 'lsp-oxfmt)
+;;; lsp-oxfmt.el ends here

--- a/docs/lsp-clients.json
+++ b/docs/lsp-clients.json
@@ -867,6 +867,16 @@
     "debugger": "Not available"
   },
   {
+    "name": "oxfmt",
+    "full-name": "Oxfmt",
+    "server-name": "oxfmt",
+    "server-url": "https://github.com/oxc-project/oxc",
+    "installation": "npm install -g oxfmt",
+    "installation-url": "https://oxc.rs/docs/guide/usage/formatter/editors",
+    "lsp-install-server": "oxfmt",
+    "debugger": "Not available"
+  },
+  {
     "name": "pascal",
     "full-name": "Pascal/Object Pascal",
     "server-name": "pascal-language-server",

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -186,8 +186,9 @@ As defined by the Language Server Protocol 3.16."
      lsp-ltex lsp-ltex-plus lsp-lua lsp-fennel lsp-magik lsp-markdown
      lsp-marksman lsp-matlab lsp-mdx lsp-meson lsp-metals lsp-mint lsp-mojo
      lsp-move lsp-mssql lsp-nextflow lsp-nginx lsp-nim lsp-nix lsp-nushell
-     lsp-ocaml lsp-odin lsp-openscad lsp-pascal lsp-perl lsp-perlnavigator
-      lsp-php lsp-pls lsp-postgres lsp-prisma lsp-purescript lsp-pwsh lsp-pyls lsp-pylsp
+     lsp-ocaml lsp-odin lsp-openscad lsp-oxfmt lsp-pascal lsp-perl
+     lsp-perlnavigator lsp-php lsp-pls lsp-postgres lsp-prisma lsp-purescript
+     lsp-pwsh lsp-pyls lsp-pylsp
      lsp-pyright lsp-python-ms lsp-python-ty lsp-qml lsp-r lsp-racket lsp-remark
      lsp-rf lsp-roc lsp-ron lsp-roslyn lsp-rubocop lsp-ruby-lsp
      lsp-ruby-syntax-tree lsp-ruff lsp-rust lsp-semgrep lsp-shader

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,7 @@ nav:
     - OCaml (ocaml-lsp): page/lsp-ocaml-lsp-server.md
     - Odin (ols): page/lsp-ols.md
     - OpenSCAD: page/lsp-openscad.md
+    - Oxfmt: page/lsp-oxfmt.md
     - Pascal/Object Pascal: page/lsp-pascal.md
     - Perl (PLS): page/lsp-pls.md
     - Perl (Perl::LanguageServer): page/lsp-perl.md


### PR DESCRIPTION
## Summary

This PR adds an Oxfmt client that can run alongside JavaScript and TypeScript language servers (via `oxfmt --lsp`). It supports project-local executable resolution, multi-root workspaces, native `oxc.fmt` configuration settings, and document formatting.

## Testing

- `nix shell nixpkgs#eask-cli -c make compile EASK=eask`
- targeted `package-lint` for `clients/lsp-oxfmt.el`
- targeted `checkdoc` for `clients/lsp-oxfmt.el`
- generated `docs/page/lsp-oxfmt.md` successfully
- initialized Oxfmt through lsp-mode (alongside `ts-ls`) and formatted a TypeScript buffer

(My testing sequence for this `oxfmt` client was very similar to the process I ran for `oxlint` in https://github.com/emacs-lsp/lsp-mode/pull/5104)