### PR TITLE
Bump the magik language server to 0.12.1

### DIFF
--- a/clients/lsp-magik.el
+++ b/clients/lsp-magik.el
@@ -40,7 +40,7 @@
   :tag "Lsp Magik"
   :package-version '(lsp-mode . "9.0.0"))
 
-(defcustom lsp-magik-version "0.12.0"
+(defcustom lsp-magik-version "0.12.1"
   "Version of LSP server."
   :type 'string
   :group 'lsp-magik


### PR DESCRIPTION
Release: https://github.com/StevenLooman/magik-tools/releases/tag/0.12.1
Changelog: https://github.com/StevenLooman/magik-tools/blob/4a8864fef9f2e57d34ce52b9a25e8f01c6dfe75e/CHANGES.md?plain=1#L1

Settings schema is unchanged from 0.12.0; the only functional change in this release is a newline-trimming fix unrelated to settings.

CC: @StevenLooman 