### PR TITLE
Rename lsp-magik-typing-cache-indexed-definitions-method-usages

### DIFF
--- a/clients/lsp-magik.el
+++ b/clients/lsp-magik.el
@@ -149,7 +149,7 @@ The next update resets the delay."
   :package-version '(lsp-mode . "10.0.0")
   :lsp-path "magik.typing.indexConditionUsages")
 
-(lsp-defcustom lsp-magik-typing-cache-indexed-definitions-method-usages nil
+(lsp-defcustom lsp-magik-typing-cache-indexed-definitions nil
   "Store and load the indexed definitions in the workspace folders."
   :type 'boolean
   :group 'lsp-magik


### PR DESCRIPTION
The "-method-usages" suffix was a naming mistake from when this setting was introduced in #4514: it maps to
magik.typing.cacheIndexedDefinitions and its docstring is about caching indexed definitions in general, not method usages. The nil default is kept: enabling it can write types.jsonl incorrectly if the server is shut down uncleanly, a bug fixed on magik-tools' develop branch but not yet released.

CC: @StevenLooman 