### PR TITLE
fix(ci): unbreak the Emacs snapshot jobs

### DIFF
--- a/Eask
+++ b/Eask
@@ -51,6 +51,13 @@
  (depends-on "org")
  (depends-on "elenv"))
 
+;; Emacs 32 changed the default of `current-time-list' to nil, so `current-time'
+;; returns a (TICKS . HZ) cons cell.  Eask's `eask-current-time' still expects
+;; the older list form and fails with "Wrong type argument: listp, 1000000000",
+;; which breaks `eask package'.  See emacs-eask/cli#431; remove this once a
+;; corrected Eask is released.
+(setq current-time-list t)
+
 (setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432
 
 (add-hook 'eask-before-compile-hook

--- a/test/lsp-common-test.el
+++ b/test/lsp-common-test.el
@@ -18,6 +18,11 @@
 
 ;;; Code:
 
+;; `lsp-byte-compilation-test' let-binds `byte-compile-error-on-warn', which is
+;; only declared special once bytecomp is loaded.  Without this require the
+;; binding is lexical, and bytecomp's own `defvar' then fails with
+;; "Defining as dynamic an already lexical var".
+(require 'bytecomp)
 (require 'ert)
 (require 'lsp-mode)
 (require 'elenv)


### PR DESCRIPTION
The three Unix `snapshot` CI jobs (`ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`) have been failing for months, for two unrelated reasons. Both come from changes in Emacs, not from lsp-mode. The failures were not noticed because those matrix rows are `experimental: true` / `continue-on-error: true`, so the workflow run still reports **success**. Examples: [run 31922473272](https://github.com/emacs-lsp/lsp-mode/actions/runs/31922473272) and the `master` run [30209672396](https://github.com/emacs-lsp/lsp-mode/actions/runs/30209672396).

### 1. `eask package` fails, so `make build` never completes

```
Wrong type argument: listp, 1000000000
make: *** [Makefile:16: build] Error 255
```

Emacs 32 changed the default value of `current-time-list` to `nil`. As a result, `current-time` returns a `(TICKS . HZ)` cons cell instead of the older `(HIGH LOW USEC PSEC)` list:

```elisp
(current-time)  ;; => (1787828065331724000 . 1000000000)
```

Eask's `eask-current-time` ([`lisp/_prepare.el`](https://github.com/emacs-eask/cli/blob/master/lisp/_prepare.el#L313)) still expects the list:

```elisp
(defun eask-current-time ()
  "Return current time."
  (let ((now (current-time))) (logior (ash (car now) 16) (cadr now))))
```

`(cadr now)` evaluates `(car 1000000000)`, and `1000000000` is the `HZ` value from the cons cell. That is the number in the error message.

This happens while building the package archive, before any lsp-mode file is compiled, which is why the snapshot jobs never reached the test suite at all.

This patch sets `current-time-list` back to `t` in the `Eask` file. That is a workaround, not a fix. The underlying problem is tracked in emacs-eask/cli#431, and this hunk can be removed once a corrected Eask is released.

For dating the regression: the snapshot job already ran Emacs `32.0.50` on 26 July and the build succeeded, while the same version label fails from 9 August onwards. So the `current-time-list` change landed during Emacs 32 development rather than in a released version.

### 2. `lsp-byte-compilation-test` fails

```
Test lsp-byte-compilation-test condition:
    (error "Defining as dynamic an already lexical var"
	   byte-compile-error-on-warn)
```

`test/lsp-common-test.el` uses `lexical-binding: t` and binds `byte-compile-error-on-warn` with `let`. That variable is only declared special once `bytecomp` has been loaded, so the binding is created as a lexical one. `byte-compile-file` then loads `bytecomp`, whose `defvar` for the same symbol conflicts with the lexical binding, and Emacs signals an error.

This reproduces without lsp-mode:

```elisp
;;; repro.el --- -*- lexical-binding: t -*-
(defun my-test ()
  (let ((byte-compile-warnings '(lexical))
        (byte-compile-error-on-warn t))
    (byte-compile-file "victim.el")))
;; => (error "Defining as dynamic an already lexical var" byte-compile-error-on-warn)
```

Adding `(require 'bytecomp)` declares the variable special before the `let`, and the reproduction then returns `t`.

### Verification

Tested on GNU Emacs 32.0.50 (development build, 26 August 2026) with an unmodified Eask 0.12.9:

- Without this patch, `eask package` fails with the `listp` error.
- With this patch, `eask package` and `eask install` succeed, and `lsp-byte-compilation-test` passes. Every file in `.` and `clients/` compiles with `byte-compile-error-on-warn` set to `t`.

### A separate problem, not addressed here

Once the two changes above are applied and the test suite runs again, three further tests fail on very recent Emacs 32 builds: `lsp--merge-results`, `lsp--build-workspace-configuration-response-test-3` and `-4`.

The cause is a third change in Emacs, in `json.el`. The condition inside `json-alist-p` was changed from `(atom (cdar list))` to `(atom (caar list))`. A list of plists is now treated as an alist:

```elisp
(json-encode (list (list :a 1) (list :a 2)))
;; Emacs 30: [{"a":1},{"a":2}]
;; Emacs 32: {"a":[1],"a":[2]}
```

`lsp--merge-results` converts vectors to lists (`lsp-mode.el:1513`), so `json-encode` now produces a JSON object where the test expects a JSON array.

Two notes on scope:

- This affects `json-encode`, which is only used by these tests. It does not affect `lsp--json-serialize`, which is what lsp-mode uses to send data to language servers, so normal use of lsp-mode is not affected.
- It did not appear in CI, only on a local Emacs build newer than the one CI currently installs. So it is not a current CI failure.

I left it out of this pull request because the fix could reasonably go in either of two places, and that choice belongs to the maintainers: change the tests to use `lsp--json-serialize` or compare data structures instead of JSON text, or change `lsp--merge-results` to return a vector. The second option affects a function used in many places. I am happy to prepare either as a separate pull request.
