### PR TITLE
Omit params, inlineCompletion, and initializationOptions when they are empty instead of sending null

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -3591,7 +3591,8 @@ CANCEL-HANDLER will be called in case the request is being canceled.
 If NO-MERGE is non-nil, don't merge the results but return alist
 workspace->result.
 CANCEL-TOKEN is the token that can be used to cancel request."
-  (lsp--send-request-async `(:jsonrpc "2.0" :method ,method :params ,params)
+  (lsp--send-request-async (append `(:jsonrpc "2.0" :method ,method)
+                                   (when params `(:params ,params)))
                            callback mode error-handler cancel-handler no-merge cancel-token))
 
 (defun lsp--create-request-cancel (id workspaces hook buf method cancel-callback)
@@ -3915,7 +3916,6 @@ disappearing, unset all the variables related to it."
                       (diagnostic . ((dynamicRegistration . :json-false)
                                      (relatedDocumentSupport . :json-false)))
                       (linkedEditingRange . ((dynamicRegistration . t)))
-                      (inlineCompletion . ())
                       ,@(when lsp-inlay-hint-enable
                           '((inlayHint . ((dynamicRegistration . :json-false)
                                           (resolveSupport . ((properties . ["textEdits" "tooltip"])))))))))
@@ -8321,8 +8321,9 @@ SESSION is the active session."
                                 :version (emacs-version))
               :rootUri (lsp--path-to-uri root)
               :capabilities (lsp--client-capabilities custom-capabilities)
-              :initializationOptions initialization-options
               :workDoneToken "1")
+        (when initialization-options
+          (list :initializationOptions initialization-options))
         (when lsp-server-trace
           (list :trace lsp-server-trace))
         (->> (or workspace-folders (list root))


### PR DESCRIPTION
The language server for TypeScript 7 (`tsgo`) is written in Go which has a pretty strict JSON parser. In particular it refuses to parse `null` for things that are supposed to be omitted.

This pull request fixes three things that make the `tsgo` language server crash when trying to use it:
- `params` in a request cannot be `null`, it should be omitted when nil
- `inlineCompletion` cannot be `null`, it should be omitted when nil (and given that it is hard-coded to `nil`, I just removed it)
- `initializationOptions` cannot be `null`, it should be omitted when nil

See also #5081 which describes the same issue, and #5099 which has another workaround.