### PR TITLE
fix(scad): add scad-ts-mode

### DIFF
--- a/clients/lsp-openscad.el
+++ b/clients/lsp-openscad.el
@@ -88,7 +88,7 @@
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-openscad-server-connection)
-                  :major-modes '(scad-mode)
+                  :major-modes '(scad-mode scad-ts-mode)
                   :priority -1
                   :initialized-fn (lambda (workspace)
                                     ;; OpenSCAD-LSP returns an empty list of

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -907,6 +907,7 @@ Changes take effect only when a new session is started."
     (ssass-mode . "sass")
     (scss-mode . "scss")
     (scad-mode . "openscad")
+    (scad-ts-mode . "openscad")
     (xml-mode . "xml")
     (c-mode . "c")
     (c-ts-mode . "c")


### PR DESCRIPTION
lsp-openscad only supported scad-mode as :major-mode. 
Therefore it failed on scad-ts-mode
(https://github.com/yoshinari-nomura/scad-ts-mode).

This commit add supported for scad-ts-mode.