### PR TITLE
Fix flymake mode-line stuck on :Wait after backend reruns

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,6 @@
 * Changelog
 ** Unreleased 10.0.1
+  * Fix the flymake mode-line indicator staying stuck on ~:Wait~ after ~flymake-start~ reruns the backend: re-report cached diagnostics on every backend call instead of only the first, matching ~eglot-flymake-backend~.
   * Add ~lsp-pylsp-plugins-ruff-format-enabled~ to expose python-lsp-ruff's ~formatEnabled~ setting.
   * Fix ~lsp-install-server~ download from the Visual Studio Code Marketplace.
   * Add support for LSP 3.17 InlayHint features: ~textEdits~, ~tooltip~, ~data~, ~InlayHintLabelPart~ (per-part ~tooltip~/~location~/~command~), ~inlayHint/resolve~, interactive mouse handler, and ~lsp-inlay-hint-accept~ command (see [[https://github.com/emacs-lsp/lsp-mode/issues/4775][#4775]])

--- a/lsp-diagnostics.el
+++ b/lsp-diagnostics.el
@@ -311,10 +311,13 @@ reformat the message in any other way."
 
 (defun lsp-diagnostics--flymake-backend (report-fn &rest _args)
   "Flymake backend using REPORT-FN."
-  (let ((first-run (null lsp-diagnostics--flymake-report-fn)))
-    (setq lsp-diagnostics--flymake-report-fn report-fn)
-    (when first-run
-      (lsp-diagnostics--flymake-update-diagnostics))))
+  (setq lsp-diagnostics--flymake-report-fn report-fn)
+  ;; Report the cached diagnostics on every call, not only the first
+  ;; one.  Flymake counts this backend as running from the moment it is
+  ;; called and as reported only once REPORT-FN is invoked; a backend
+  ;; that stays silent leaves the mode-line stuck on "Wait".  Eglot's
+  ;; `eglot-flymake-backend' re-reports the same way.
+  (lsp-diagnostics--flymake-update-diagnostics))
 
 (defun lsp-diagnostics--flymake-update-diagnostics ()
   "Report new diagnostics to flymake."

--- a/test/lsp-mock-server-test.el
+++ b/test/lsp-mock-server-test.el
@@ -263,6 +263,40 @@ TEST-BODY can interact with the mock server."
                                        "line 1 unique word broming + common"
                                        "                   ^^^^^^^         ")))))
 
+(ert-deftest lsp-mock-server-flymake-reports-on-every-restart ()
+  "Test that the flymake backend reports on every `flymake-start'.
+
+Flymake counts a backend as reporting only once it invokes its
+REPORT-FN for the current check.  A backend that stays silent on a
+restart re-enters the running set but never the reporting set, so the
+mode-line shows `Wait' indefinitely even though diagnostics are
+current."
+  (require 'flymake)
+  (lsp-mock-run-with-mock-server
+   ;; The mock server environment binds `lsp-diagnostics-provider' to
+   ;; :none, so rebind it here before enabling the flymake integration
+   (let ((lsp-diagnostics-provider :flymake))
+     (lsp-diagnostics-mode 1)
+     (should flymake-mode)
+     ;; First run: the backend reports the (still empty) cached diagnostics
+     (flymake-start)
+     (should (null (cl-set-difference (flymake-running-backends)
+                                      (flymake-reporting-backends))))
+     (should (eq (length (flymake-diagnostics)) 0))
+     (lsp-test-command-send-diags lsp-test-sample-file (buffer-string) "broming")
+     (lsp-test-sync-wait (progn (should (lsp-workspaces))
+                                (gethash lsp-test-sample-file (lsp-diagnostics t))))
+     ;; A restart must re-report the cached diagnostics, not stay silent
+     (flymake-start)
+     (should (null (cl-set-difference (flymake-running-backends)
+                                      (flymake-reporting-backends))))
+     (should (eq (length (flymake-diagnostics)) 1))
+     ;; And a further restart must not lose them
+     (flymake-start)
+     (should (null (cl-set-difference (flymake-running-backends)
+                                      (flymake-reporting-backends))))
+     (should (eq (length (flymake-diagnostics)) 1)))))
+
 (ert-deftest lsp-mock-server-crashes ()
   "Test that the mock server crashes when instructed so."
   (let ((initial-serv-count (lsp-test-total-folder-count)))


### PR DESCRIPTION
Fixes #5115.

With `lsp-diagnostics-provider :flymake`, the mode-line shows `Wait` ("Waiting for 1 running backend(s)") after anything calls `flymake-start` again: certain save hooks, toggling `flymake-mode`, or another backend restarting the check. It stays until the server happens to push a fresh diagnostics update.

Flymake counts a backend as running from the moment it calls it, and as reported only once the backend invokes `report-fn`. `lsp-diagnostics--flymake-backend` called `report-fn` only on its first run and stashed it on later runs. Each restart put the backend back into `flymake-running-backends` and never into `flymake-reporting-backends`. `flymake--mode-line-exception` shows `Wait` while that difference is non-empty.

The fix reports the cached diagnostics on every backend call. Eglot solved the same bug this way (joaotavora/eglot#267): its current `eglot-flymake-backend` re-reports on every invocation. #1423 proposed the same change in 2020 for a different symptom and was closed over the cost of redundant re-reports. That cost is required by flymake's protocol, because a push backend that stays silent is indistinguishable from a hung one. The re-report does not change what is on screen: the displayed diagnostics come from the same cache.

## Verification

Emacs 31.1, macOS, `lsp-diagnostics-provider :flymake`, buffer with 2 deliberate type errors. Values are `(flymake--mode-line-exception)`, the running and reporting backend counts, and `(length (flymake-diagnostics))`.

typescript-language-server 5.3.0:

| step | exception | running | reported | diags |
|---|---|---|---|---|
| old code, after `flymake-start` | `:Wait` | 1 | 0 | 2 |
| fixed, after `flymake-start` | `""` | 1 | 1 | 2 |
| fixed, 2 more restarts | `""` | 1 | 1 | 2 |
| fixed, after an edit adds a third error (fresh push) | `""` | 1 | 1 | 3 |
| fixed, restart after that push | `""` | 1 | 1 | 3 |

clangd, buffer with one error: repeated `flymake-start` keeps the exception empty and the diagnostic count unchanged.

`Wait` clears and no diagnostics are lost.

The flymake path had no test coverage. The new mock-server regression test (`lsp-mock-server-flymake-reports-on-every-restart`) asserts that after each `flymake-start` the backend re-enters `flymake-reporting-backends` and the diagnostic count is unchanged. The test fails against the previous implementation at exactly that assertion. The full suite (130 tests) passes, and `lsp-diagnostics.el` byte-compiles clean with `byte-compile-error-on-warn`.
